### PR TITLE
Add flatstack execution runner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@ runtime is mainly focused on:
 1. Bundling and using PHP as part of a Go service, embedding php assets to a binary
 2. Interfacing type safe Go code with PHP as an "intra-process" execution bridge
 
+For the runner-compatible compile-once bytecode backend, see
+[Flat-stack runtime](./flatstack.md).
+
 This allows several use cases for the runtime, however does not support
 running most open source PHP projects that are using advanced syntax
 that the runtime doesn't implement.

--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -1,0 +1,289 @@
+# Flat-stack runtime
+
+The `flatstack` package is an alternative entry point for embedding phpscript.
+It keeps the `runner` API while adding a compile-once flat-bytecode path for a
+growing subset of the public `model.Program` AST.
+
+```diagram
+parser.Parse
+     │
+     ▼
+model.Program
+     │
+     ├── supported by flatstack ──▶ compiler ──▶ immutable opcodes
+     │                                          │
+     │                                          ▼
+     │                                  operand/slot VM
+     │                                          │
+     │                                          ▼
+     │                                   runner host bridge
+     │
+     └── unsupported ─────────────▶ runner interpreter + expr VM
+```
+
+The entire program is checked and compiled before execution. If any node is not
+supported, no flat instruction runs and the complete program is delegated to
+the runner. This prevents fallback from repeating constructors, method calls,
+output, or other side effects.
+
+## Using flatstack
+
+Normal use differs only in the imported package and constructor:
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+func main() {
+	program, err := parser.Parse(`<?php echo "hello"; ?>`)
+	if err != nil {
+		panic(err)
+	}
+
+	runtime := flatstack.New(os.Stdout, flatstack.Options{})
+	runtime.SetContext(context.Background())
+	stdlib.Register(runtime)
+
+	if err := runtime.Run(program); err != nil {
+		panic(err)
+	}
+}
+```
+
+To change only an existing import path while retaining the local identifier
+`runner`, use an import alias:
+
+```go
+import runner "github.com/titpetric/phpscript/flatstack"
+```
+
+Existing calls such as `runner.New`, `runner.Options`, `runner.IsExit`, and
+`runner.NewExprCache` then continue to compile.
+
+## API compatibility
+
+The following flatstack types are aliases of their runner counterparts:
+
+- `Runtime` and `Options`
+- `Context` and `Scope`
+- `ExprCache` and `IncludeCache`
+- `ExitError` and `HostPanicError`
+- `IncludeFunc` and `Transpiler`
+
+Because `flatstack.Runtime` is an alias of `runner.Runtime`, APIs that accept a
+concrete `*runner.Runtime` remain usable. In particular, these calls require no
+adapter:
+
+```go
+stdlib.Register(runtime)
+stdlib.RegisterFS(runtime, ".")
+requestContext.Register(runtime)
+```
+
+The package also forwards the runner package functions used by embedders:
+
+- `NewContext` and `FromRequest`
+- `NewScope` and `ScopeFromContext`
+- `NewExprCache` and `NewIncludeCache`
+- `NewTranspiler`
+- `IsExit`
+
+### Are runner and flatstack interchangeable?
+
+For code that directly constructs and runs a runtime, **yes at the API and
+fallback-behavior level**. The full fixture corpus is executed through both
+imports in CI-style tests.
+
+They are **not yet independent equivalent engines**:
+
+- `flatstack.Runtime` deliberately aliases `runner.Runtime`; this preserves the
+  complete embedding API rather than duplicating runtime, standard-library,
+  include, request, and reflection state.
+- Only the documented subset below executes as native flat bytecode.
+- Every other valid program uses the existing runner interpreter.
+- `route.Service` and the bundled CLI/server currently construct `runner.New`
+  internally. Merely changing a callback type does not make those paths use
+  flatstack.
+- `Runtime.OnError` selects the interpreter because its per-statement recovery
+  contract has not been added to bytecode.
+
+Use `flatstack.Supports` when native bytecode execution is required:
+
+```go
+if err := flatstack.Supports(program); err != nil {
+	return fmt.Errorf("benchmark would use runner fallback: %w", err)
+}
+```
+
+Applications normally do not need this check because transparent fallback is
+the compatibility contract. Benchmarks should always use it unless they are
+intentionally measuring fallback.
+
+## Native bytecode subset
+
+Flat bytecode currently supports these statements:
+
+- Variable and array-index assignment, including compound assignment and append
+- Expression statements
+- `echo`
+- Inline HTML
+- `if`/`else`
+- `for`/`while` and `foreach`, including nested `break` and `continue`
+- `switch`, fallthrough, and `break`
+- `try`/`catch` and `throw` (a `finally` block still selects fallback)
+
+It supports these expressions:
+
+- Scalar literals
+- Local variables, runtime globals, and constants through host lookup
+- PHP arrays, keyed/unkeyed literals, reads, writes, and append
+- Arithmetic (`+`, `-`, `*`, `/`, `%`)
+- Comparisons (`==`, `!=`, `===`, `!==`, `<`, `<=`, `>`, `>=`)
+- Short-circuit logical operators and unary `!`, `+`, and `-`
+- Prefix/postfix increment and decrement of variables and array indexes
+- Assignment expressions and full/Elvis ternaries
+- Host and PHP object construction with `new`
+- Registered/free function calls and method calls
+- Property reads
+- String concatenation with `.`
+
+The native operations above do not use `expr-lang`; arithmetic, coercion,
+comparison, array access, and truthiness are implemented by the flat VM and its
+small PHP-semantics host boundary. The bridge uses runner's existing reflection
+path for registered Go constructors/functions/methods. `expr-lang` remains in
+the compatibility interpreter for unsupported programs.
+
+The current end-to-end corpus result is **14 native and 14 compatibility
+fallback fixtures (28 total)**. Both paths pass all fixtures. `Supports` is the
+authoritative per-program answer; a fixture count is useful progress evidence,
+not a claim that half of the PHP language is implemented.
+
+### Current native barriers
+
+The complete program atomically selects fallback when it contains any currently
+unsupported form. The major remaining forms are:
+
+- User function declarations/calls and `return`
+- PHP class declarations, property writes, class constants, and property
+  increment/decrement
+- Includes as statements or expressions
+- Closures and callback bodies
+- `finally`
+- Casts and destructuring/list assignment
+
+These are not called "unsupported programs" at the public runtime boundary:
+they are valid phpscript programs and execute through runner. "Unsupported" in
+a `Supports` error means only "not yet lowerable to native flat bytecode."
+
+## Host calls, errors, and panics
+
+Flat bytecode uses the runner's existing host bridge, including:
+
+- Automatic `context.Context` injection
+- PHP-style case-insensitive method lookup
+- Argument conversion
+- Go constructor and method error propagation
+- Exported Go struct field access
+
+Panics raised by registered Go constructors, functions, or methods become
+`HostPanicError` at the reflection boundary. Native bytecode `try`/`catch` can
+catch these errors exactly like a returned Go error:
+
+```php
+try {
+    $host->crash();
+} catch (Exception $error) {
+    echo "caught: " . $error;
+}
+```
+
+Without a catch, `Runtime.Run` returns the error to Go. The VM also has a
+last-resort recovery guard for engine defects; ordinary host panics do not rely
+on that guard.
+
+## Compilation and caching
+
+`Runtime.Run` looks for flat bytecode in the configured `ExprCache`. On a cache
+miss it compiles the complete AST and stores the immutable bytecode by program
+identity. Share the cache between runtimes that execute the same parsed program:
+
+```go
+cache := flatstack.NewExprCache()
+
+runtime := flatstack.New(output, flatstack.Options{})
+runtime.SetExprCache(cache)
+runtime.Run(program)
+```
+
+For compile-once/run-many workloads, parse the source once and reuse both the
+`*model.Program` and cache. Re-parsing creates a different program identity and
+therefore a new flat compilation.
+
+## Validation and benchmarks
+
+The test suite contains:
+
+- Native flat-bytecode correctness and host-bridge tests
+- Runner-fallback and side-effect atomicity tests
+- Shared-cache parallel tests and race checks
+- Allocation-budget and deep-expression tests
+- The complete `.phpt` fixture corpus through both runtime imports
+- Compiler-input, malformed-AST, native differential, and fallback differential
+  fuzz targets
+
+Run the normal and race suites with:
+
+```bash
+set -a; . ./.env.testing; set +a
+go test ./...
+go test -race ./flatstack ./runner
+```
+
+Run the flatstack benchmarks with:
+
+```bash
+go test ./flatstack -run '^$' -bench '^BenchmarkFlatstack' -benchmem
+go test ./tests -run '^$' \
+  -bench 'BenchmarkGoBindingHTTP|BenchmarkFlatstackMinitplImportSwap' -benchmem
+```
+
+Run individual fuzz targets in isolated jobs:
+
+```bash
+go test ./flatstack -run '^$' -fuzz '^FuzzFlatstackCompilerInput$' -fuzztime=30s
+go test ./flatstack -run '^$' -fuzz '^FuzzFlatstackDifferential$' -fuzztime=30s
+go test ./flatstack -run '^$' -fuzz '^FuzzFlatstackModelAST$' -fuzztime=30s
+go test ./tests -run '^$' -fuzz '^FuzzFlatstackImportSwapFallback$' -fuzztime=30s
+```
+
+## Remaining work
+
+The highest-value next steps are:
+
+1. Add bytecode call frames for user functions, returns, and closures.
+2. Add PHP class declarations, object-property writes, and class constants.
+3. Integrate include compilation/execution while preserving include scope,
+   include-once state, return values, and autoload semantics.
+4. Complete exception `finally` semantics and remaining lvalue/cast forms.
+5. Add instruction, call-depth, and deadline budgets to native execution.
+6. Pool operand/local/iterator storage to reduce per-run allocations.
+7. Cache native-rejection decisions and use a structural cache key where
+   callers need to reparse identical source frequently.
+8. Let `route.Service` and CLI/server entry points select a runtime factory so
+   they can opt into flatstack instead of always constructing `runner.New`.
+9. Track native-versus-fallback execution in diagnostics so production users
+   can measure bytecode coverage without calling `Supports` separately.
+
+Flatstack is therefore interchangeable as an embedding API and for observable
+fixture behavior, but it is not yet a standalone replacement for runner's
+implementation. Replacing runner with copied or inlined code would be the wrong
+next step: shared runtime/bridge infrastructure avoids two diverging APIs while
+the opcode compiler and VM replace execution semantics incrementally.

--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -4,6 +4,9 @@ The `flatstack` package is an alternative entry point for embedding phpscript.
 It keeps the `runner` API while adding a compile-once flat-bytecode path for a
 growing subset of the public `model.Program` AST.
 
+The API is experimental and may change at any point before a stable release,
+or be absorbed into the already provided runner APIs.
+
 ```diagram
 parser.Parse
      │

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,10 +1,10 @@
 # phpscript language reference
 
-| Reference area | Status | Notes |
-| --- | --- | --- |
-| PHP language reference | Partial compatibility | Only documented chapters and features are implemented. |
-| phpscript extensions | Compatibility | Documented separately because these APIs and syntax do not exist in PHP. |
-| Fibers, generators, attributes, references, enums, stream contexts and wrappers | Not implemented | Omitted from the sitemap because phpscript has no corresponding feature. |
+| Reference area                                                                  | Status                | Notes                                                                    |
+|---------------------------------------------------------------------------------|-----------------------|--------------------------------------------------------------------------|
+| PHP language reference                                                          | Partial compatibility | Only documented chapters and features are implemented.                   |
+| phpscript extensions                                                            | Compatibility         | Documented separately because these APIs and syntax do not exist in PHP. |
+| Fibers, generators, attributes, references, enums, stream contexts and wrappers | Not implemented       | Omitted from the sitemap because phpscript has no corresponding feature. |
 
 A PHP language-reference-shaped guide to the syntax and runtime behavior implemented by phpscript.
 

--- a/docs/reference/basic-syntax/README.md
+++ b/docs/reference/basic-syntax/README.md
@@ -1,12 +1,12 @@
 # Basic syntax
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| PHP tags | Compatibility | `<?php`, short `<?`, and `?>` are recognized. |
-| Escaping from HTML | Compatibility | Text outside PHP tags is emitted; as in PHP, one newline immediately after `?>` is consumed. |
-| Instruction separation | Compatibility | Semicolons terminate simple statements; a closing tag also ends PHP mode. |
-| Comments | Compatibility | `//`, `#`, and `/* ... */` comments are supported. |
-| Shebang | phpscript extension | A leading `#!` line is ignored, allowing executable scripts. |
+| PHP language-reference feature | Status              | Notes                                                                                        |
+|--------------------------------|---------------------|----------------------------------------------------------------------------------------------|
+| PHP tags                       | Compatibility       | `<?php`, short `<?`, and `?>` are recognized.                                                |
+| Escaping from HTML             | Compatibility       | Text outside PHP tags is emitted; as in PHP, one newline immediately after `?>` is consumed. |
+| Instruction separation         | Compatibility       | Semicolons terminate simple statements; a closing tag also ends PHP mode.                    |
+| Comments                       | Compatibility       | `//`, `#`, and `/* ... */` comments are supported.                                           |
+| Shebang                        | phpscript extension | A leading `#!` line is ignored, allowing executable scripts.                                 |
 
 phpscript accepts files containing PHP blocks and inline text. The closing tag
 is optional at the end of a file. One newline immediately following a closing

--- a/docs/reference/classes-and-objects/README.md
+++ b/docs/reference/classes-and-objects/README.md
@@ -1,15 +1,15 @@
 # Classes and objects
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Classes, properties, methods | Partial compatibility | Basic declarations, construction, `$this`, fields, and method calls are supported. |
-| Constructors | Compatibility | `__construct` is called when present. |
-| Class constants | Compatibility | Declaration and `Class::NAME` access are supported. |
-| Visibility, static, final, abstract | Not enforced | Modifiers may be accepted but do not provide PHP semantics. |
-| Inheritance and interfaces | Not implemented | `extends`, `implements`, interfaces, and traits are unavailable. |
-| Static members and methods | Not implemented | `Class::method()` and static properties are unavailable. |
-| Magic methods | Partial compatibility | `__construct` is supported; the wider PHP magic-method contract is not. |
-| Enums, anonymous classes, cloning | Not implemented | These PHP object features are unavailable. |
+| PHP language-reference feature      | Status                | Notes                                                                              |
+|-------------------------------------|-----------------------|------------------------------------------------------------------------------------|
+| Classes, properties, methods        | Partial compatibility | Basic declarations, construction, `$this`, fields, and method calls are supported. |
+| Constructors                        | Compatibility         | `__construct` is called when present.                                              |
+| Class constants                     | Compatibility         | Declaration and `Class::NAME` access are supported.                                |
+| Visibility, static, final, abstract | Not enforced          | Modifiers may be accepted but do not provide PHP semantics.                        |
+| Inheritance and interfaces          | Not implemented       | `extends`, `implements`, interfaces, and traits are unavailable.                   |
+| Static members and methods          | Not implemented       | `Class::method()` and static properties are unavailable.                           |
+| Magic methods                       | Partial compatibility | `__construct` is supported; the wider PHP magic-method contract is not.            |
+| Enums, anonymous classes, cloning   | Not implemented       | These PHP object features are unavailable.                                         |
 
 ## Declaring a class
 

--- a/docs/reference/constants/README.md
+++ b/docs/reference/constants/README.md
@@ -1,12 +1,12 @@
 # Constants
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Global constant declarations | Not implemented | `const` and `define()` cannot declare global constants in script code. |
-| Host-registered constants | phpscript extension | A Go host can register constants with `Runtime.SetConst`. |
-| Class constants | Compatibility | `const NAME = value` and `Class::NAME` are supported. |
-| Predefined constants | Partial compatibility | Standard-library registration installs a small runtime-defined set. |
-| Magic constants | Partial compatibility | Only `__NAMESPACE__` is implemented. |
+| PHP language-reference feature | Status                | Notes                                                                  |
+|--------------------------------|-----------------------|------------------------------------------------------------------------|
+| Global constant declarations   | Not implemented       | `const` and `define()` cannot declare global constants in script code. |
+| Host-registered constants      | phpscript extension   | A Go host can register constants with `Runtime.SetConst`.              |
+| Class constants                | Compatibility         | `const NAME = value` and `Class::NAME` are supported.                  |
+| Predefined constants           | Partial compatibility | Standard-library registration installs a small runtime-defined set.    |
+| Magic constants                | Partial compatibility | Only `__NAMESPACE__` is implemented.                                   |
 
 ## Class constants
 

--- a/docs/reference/control-structures/README.md
+++ b/docs/reference/control-structures/README.md
@@ -1,15 +1,15 @@
 # Control structures
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| `if`, `elseif`, `else` | Compatibility | Brace-delimited branches are supported. |
-| `while`, `for`, `foreach` | Compatibility | Brace-delimited loops are supported. |
-| `switch` | Compatibility | Case fallthrough and `break` are supported. |
-| `break`, `continue` | Partial compatibility | Only the nearest loop/switch can be targeted; numeric levels are unavailable. |
-| `return` | Compatibility | A value is optional. |
-| `include`, `require` | Partial compatibility | All four keywords parse, but `include_once` and `require_once` do not suppress repeated execution. |
-| `declare`, `do-while`, `goto`, alternate syntax | Not implemented | These PHP control structures are unavailable. |
-| Parenthesis-free conditions | phpscript extension | `if $value {}` and `foreach $items as $item {}` are accepted. |
+| PHP language-reference feature                  | Status                | Notes                                                                                              |
+|-------------------------------------------------|-----------------------|----------------------------------------------------------------------------------------------------|
+| `if`, `elseif`, `else`                          | Compatibility         | Brace-delimited branches are supported.                                                            |
+| `while`, `for`, `foreach`                       | Compatibility         | Brace-delimited loops are supported.                                                               |
+| `switch`                                        | Compatibility         | Case fallthrough and `break` are supported.                                                        |
+| `break`, `continue`                             | Partial compatibility | Only the nearest loop/switch can be targeted; numeric levels are unavailable.                      |
+| `return`                                        | Compatibility         | A value is optional.                                                                               |
+| `include`, `require`                            | Partial compatibility | All four keywords parse, but `include_once` and `require_once` do not suppress repeated execution. |
+| `declare`, `do-while`, `goto`, alternate syntax | Not implemented       | These PHP control structures are unavailable.                                                      |
+| Parenthesis-free conditions                     | phpscript extension   | `if $value {}` and `foreach $items as $item {}` are accepted.                                      |
 
 ## Conditions
 

--- a/docs/reference/errors/README.md
+++ b/docs/reference/errors/README.md
@@ -1,12 +1,12 @@
 # Errors
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Parse errors | Compatibility | Invalid source is rejected with a line-oriented parser error. |
-| Runtime errors | Partial compatibility | Failures are represented as Go errors and can be caught by script code. |
-| PHP error levels and handlers | Not implemented | `E_*`, `set_error_handler()`, and `trigger_error()` semantics are unavailable. |
-| Error-control operator | Not implemented | `@` does not suppress failures. |
-| Host error callback | phpscript extension | `Runtime.OnError` consumes statement errors after invoking the callback. |
+| PHP language-reference feature | Status                | Notes                                                                          |
+|--------------------------------|-----------------------|--------------------------------------------------------------------------------|
+| Parse errors                   | Compatibility         | Invalid source is rejected with a line-oriented parser error.                  |
+| Runtime errors                 | Partial compatibility | Failures are represented as Go errors and can be caught by script code.        |
+| PHP error levels and handlers  | Not implemented       | `E_*`, `set_error_handler()`, and `trigger_error()` semantics are unavailable. |
+| Error-control operator         | Not implemented       | `@` does not suppress failures.                                                |
+| Host error callback            | phpscript extension   | `Runtime.OnError` consumes statement errors after invoking the callback.       |
 
 phpscript uses one error path for explicit `throw` statements and errors
 returned by Go-backed functions. It does not model PHP notices, warnings,

--- a/docs/reference/exceptions/README.md
+++ b/docs/reference/exceptions/README.md
@@ -1,12 +1,12 @@
 # Exceptions
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| `throw` | Compatibility | Values and constructed `Exception` objects can be thrown. |
-| `try`, `catch`, `finally` | Partial compatibility | The first catch handles every failure; `finally` always runs. |
-| Catch type filters | Not implemented | Parsed exception types and union filters are ignored. |
-| Exception hierarchy | Not implemented | There is no PHP `Throwable` hierarchy or type-based dispatch. |
-| Extending exceptions | Not implemented | Class inheritance is unavailable. |
+| PHP language-reference feature | Status                | Notes                                                         |
+|--------------------------------|-----------------------|---------------------------------------------------------------|
+| `throw`                        | Compatibility         | Values and constructed `Exception` objects can be thrown.     |
+| `try`, `catch`, `finally`      | Partial compatibility | The first catch handles every failure; `finally` always runs. |
+| Catch type filters             | Not implemented       | Parsed exception types and union filters are ignored.         |
+| Exception hierarchy            | Not implemented       | There is no PHP `Throwable` hierarchy or type-based dispatch. |
+| Extending exceptions           | Not implemented       | Class inheritance is unavailable.                             |
 
 ## Throwing and catching
 

--- a/docs/reference/exceptions/README.md
+++ b/docs/reference/exceptions/README.md
@@ -26,3 +26,7 @@ the first can handle the error.
 
 Errors returned by a Go function invoked through a runtime binding enter the
 same catch path as an explicit `throw`.
+
+Panics raised by registered Go constructors, functions, or methods are recovered
+at the host-call boundary and enter this same catch path as `HostPanicError`.
+Without a matching `try`/`catch`, the error is returned to the embedding host.

--- a/docs/reference/expressions/README.md
+++ b/docs/reference/expressions/README.md
@@ -1,14 +1,14 @@
 # Expressions
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Literals and variables | Compatibility | Supported values can be used as expressions. |
-| Assignment expressions | Partial compatibility | Plain `=` to a variable returns the assigned value; other expression targets/operators are unavailable. |
-| Ternary expressions | Compatibility | Full and shorthand (`?:`) forms are supported. |
-| Function and method calls | Compatibility | Calls are expressions. |
-| `new` expressions | Compatibility | Parentheses are optional when no constructor arguments are supplied. |
-| `include` expressions | Partial compatibility | Include forms can occur as statements or expressions; failure behavior is simplified. |
-| `match`, `yield`, cloning | Not implemented | These PHP expression forms are unavailable. |
+| PHP language-reference feature | Status                | Notes                                                                                                   |
+|--------------------------------|-----------------------|---------------------------------------------------------------------------------------------------------|
+| Literals and variables         | Compatibility         | Supported values can be used as expressions.                                                            |
+| Assignment expressions         | Partial compatibility | Plain `=` to a variable returns the assigned value; other expression targets/operators are unavailable. |
+| Ternary expressions            | Compatibility         | Full and shorthand (`?:`) forms are supported.                                                          |
+| Function and method calls      | Compatibility         | Calls are expressions.                                                                                  |
+| `new` expressions              | Compatibility         | Parentheses are optional when no constructor arguments are supplied.                                    |
+| `include` expressions          | Partial compatibility | Include forms can occur as statements or expressions; failure behavior is simplified.                   |
+| `match`, `yield`, cloning      | Not implemented       | These PHP expression forms are unavailable.                                                             |
 
 ## Assignment expressions
 

--- a/docs/reference/extensions/README.md
+++ b/docs/reference/extensions/README.md
@@ -1,13 +1,13 @@
 # phpscript extensions
 
-| Extension | Status | Notes |
-| --- | --- | --- |
-| `defer()` | phpscript extension | Runs callbacks when the current execution frame exits. |
-| `PS` namespace | phpscript extension | Contains host-backed APIs such as `PS\Database`. |
-| `func` keyword | phpscript extension | Alias for block-bodied `function`. |
-| `fn` keyword | PHP-incompatible | Alias for block-bodied `function`, not a PHP arrow function. |
-| Parenthesis-free conditions | PHP-incompatible | Selected `if` and `foreach` forms can omit parentheses. |
-| `{...}` arrays | PHP-incompatible | Braces can delimit an array literal. |
+| Extension                   | Status              | Notes                                                        |
+|-----------------------------|---------------------|--------------------------------------------------------------|
+| `defer()`                   | phpscript extension | Runs callbacks when the current execution frame exits.       |
+| `PS` namespace              | phpscript extension | Contains host-backed APIs such as `PS\Database`.             |
+| `func` keyword              | phpscript extension | Alias for block-bodied `function`.                           |
+| `fn` keyword                | PHP-incompatible    | Alias for block-bodied `function`, not a PHP arrow function. |
+| Parenthesis-free conditions | PHP-incompatible    | Selected `if` and `foreach` forms can omit parentheses.      |
+| `{...}` arrays              | PHP-incompatible    | Braces can delimit an array literal.                         |
 
 These features have no equivalent in the PHP language reference or deliberately
 use syntax differently. Avoid them when source must also run on PHP.

--- a/docs/reference/extensions/bindings.md
+++ b/docs/reference/extensions/bindings.md
@@ -20,7 +20,7 @@ rt.RegisterConstructor("Storage", NewStorage)
 
 program, err := parser.Parse(source)
 if err == nil {
-    err = rt.Run(program)
+	err = rt.Run(program)
 }
 ```
 

--- a/docs/reference/functions/README.md
+++ b/docs/reference/functions/README.md
@@ -1,13 +1,13 @@
 # Functions
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| User-defined functions | Compatibility | Named functions, parameters, defaults, calls, and returns are supported. |
-| Anonymous functions | Partial compatibility | Closures work, but `use (...)` captures are parsed and ignored. |
-| Arrow functions | Incompatible syntax | `fn` introduces a normal block-bodied function/closure; PHP's `fn (...) => ...` form is unavailable. |
-| Arguments by value | Partial compatibility | Names are bound in a new local scope, but mutable arrays do not have PHP copy-on-write behavior. |
-| References and variadics | Not implemented | `&`, `...`, named arguments, and argument unpacking are unavailable. |
-| Type declarations | Not implemented | Parameter and return types are unavailable. |
+| PHP language-reference feature | Status                | Notes                                                                                                |
+|--------------------------------|-----------------------|------------------------------------------------------------------------------------------------------|
+| User-defined functions         | Compatibility         | Named functions, parameters, defaults, calls, and returns are supported.                             |
+| Anonymous functions            | Partial compatibility | Closures work, but `use (...)` captures are parsed and ignored.                                      |
+| Arrow functions                | Incompatible syntax   | `fn` introduces a normal block-bodied function/closure; PHP's `fn (...) => ...` form is unavailable. |
+| Arguments by value             | Partial compatibility | Names are bound in a new local scope, but mutable arrays do not have PHP copy-on-write behavior.     |
+| References and variadics       | Not implemented       | `&`, `...`, named arguments, and argument unpacking are unavailable.                                 |
+| Type declarations              | Not implemented       | Parameter and return types are unavailable.                                                          |
 
 ## Defining functions
 

--- a/docs/reference/namespaces/README.md
+++ b/docs/reference/namespaces/README.md
@@ -1,14 +1,14 @@
 # Namespaces
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Defining namespaces | Partial compatibility | Only one semicolon-delimited namespace at the start of a file is supported. |
-| Sub-namespaces | Compatibility | Qualified names with `\` are supported. |
-| Multiple namespaces per file | Not implemented | Braced namespaces and repeated declarations are unavailable. |
+| PHP language-reference feature     | Status                | Notes                                                                             |
+|------------------------------------|-----------------------|-----------------------------------------------------------------------------------|
+| Defining namespaces                | Partial compatibility | Only one semicolon-delimited namespace at the start of a file is supported.       |
+| Sub-namespaces                     | Compatibility         | Qualified names with `\` are supported.                                           |
+| Multiple namespaces per file       | Not implemented       | Braced namespaces and repeated declarations are unavailable.                      |
 | Relative and fully-qualified names | Partial compatibility | Current-namespace and leading-`\` names resolve; `namespace\Name` is unavailable. |
-| Aliasing and importing | Not implemented | The `use` import statement is unavailable. |
-| `__NAMESPACE__` | Compatibility | Resolves to the current namespace name. |
-| Function fallback | Compatibility | Unqualified calls fall back from the current namespace to global functions. |
+| Aliasing and importing             | Not implemented       | The `use` import statement is unavailable.                                        |
+| `__NAMESPACE__`                    | Compatibility         | Resolves to the current namespace name.                                           |
+| Function fallback                  | Compatibility         | Unqualified calls fall back from the current namespace to global functions.       |
 
 ## Defining a namespace
 

--- a/docs/reference/operators/README.md
+++ b/docs/reference/operators/README.md
@@ -1,15 +1,15 @@
 # Operators
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Arithmetic | Partial compatibility | `+`, `-`, `*`, `/`, `%`, and unary `+`/`-` are supported. Exponentiation is unavailable. |
-| Increment/decrement | Compatibility | Prefix and postfix `++` and `--` work on assignable targets. |
-| Assignment | Partial compatibility | `=`, `+=`, `-=`, and `.=` are supported; other compound forms are unavailable. |
-| Comparison | Partial compatibility | `<`, `<=`, `>`, `>=`, `==`, `!=`, `===`, and `!==` are supported with simplified coercion. |
-| Logical | Partial compatibility | `!`, `&&`, and `||` are supported; word forms (`and`, `or`, `xor`) are unavailable. |
-| String | Compatibility | `.` and `.=` concatenate values. |
-| Array, bitwise, execution, type, functional | Not implemented | PHP's operators in these groups are unavailable. |
-| Error control (`@`) | Not implemented | The token is accepted but does not suppress errors. |
+| PHP language-reference feature              | Status                | Notes                                                                                      |
+|---------------------------------------------|-----------------------|--------------------------------------------------------------------------------------------|
+| Arithmetic                                  | Partial compatibility | `+`, `-`, `*`, `/`, `%`, and unary `+`/`-` are supported. Exponentiation is unavailable.   |
+| Increment/decrement                         | Compatibility         | Prefix and postfix `++` and `--` work on assignable targets.                               |
+| Assignment                                  | Partial compatibility | `=`, `+=`, `-=`, and `.=` are supported; other compound forms are unavailable.             |
+| Comparison                                  | Partial compatibility | `<`, `<=`, `>`, `>=`, `==`, `!=`, `===`, and `!==` are supported with simplified coercion. |
+| Logical                                     | Partial compatibility | `!`, `&&`, and `                                                                           |
+| String                                      | Compatibility         | `.` and `.=` concatenate values.                                                           |
+| Array, bitwise, execution, type, functional | Not implemented       | PHP's operators in these groups are unavailable.                                           |
+| Error control (`@`)                         | Not implemented       | The token is accepted but does not suppress errors.                                        |
 
 ## Precedence
 

--- a/docs/reference/predefined-interfaces-and-classes/README.md
+++ b/docs/reference/predefined-interfaces-and-classes/README.md
@@ -1,14 +1,14 @@
 # Predefined interfaces and classes
 
-| PHP predefined interface or class | Status | Notes |
-| --- | --- | --- |
-| `Exception` | Partial compatibility | A host-backed exception value can be constructed and thrown. |
-| `Closure` | Partial compatibility | Anonymous functions produce callable runtime values, without the PHP class API. |
-| `stdClass` | Not implemented | `(object)` is parsed but currently leaves its operand unchanged. |
-| `Throwable`, `Traversable`, `Iterator`, `Countable` | Not implemented | Interfaces and PHP's exception hierarchy are unavailable. |
-| `ArrayAccess`, `Serializable`, `Stringable` | Not implemented | Interfaces are unavailable. |
-| `Generator`, `Fiber`, `WeakReference`, `WeakMap` | Not implemented | Corresponding language/runtime features are unavailable. |
-| Enum interfaces and predefined attributes | Not implemented | Enums and attributes are unavailable. |
+| PHP predefined interface or class                   | Status                | Notes                                                                           |
+|-----------------------------------------------------|-----------------------|---------------------------------------------------------------------------------|
+| `Exception`                                         | Partial compatibility | A host-backed exception value can be constructed and thrown.                    |
+| `Closure`                                           | Partial compatibility | Anonymous functions produce callable runtime values, without the PHP class API. |
+| `stdClass`                                          | Not implemented       | `(object)` is parsed but currently leaves its operand unchanged.                |
+| `Throwable`, `Traversable`, `Iterator`, `Countable` | Not implemented       | Interfaces and PHP's exception hierarchy are unavailable.                       |
+| `ArrayAccess`, `Serializable`, `Stringable`         | Not implemented       | Interfaces are unavailable.                                                     |
+| `Generator`, `Fiber`, `WeakReference`, `WeakMap`    | Not implemented       | Corresponding language/runtime features are unavailable.                        |
+| Enum interfaces and predefined attributes           | Not implemented       | Enums and attributes are unavailable.                                           |
 
 ## `Exception`
 

--- a/docs/reference/predefined-variables/README.md
+++ b/docs/reference/predefined-variables/README.md
@@ -1,14 +1,14 @@
 # Predefined variables
 
-| PHP predefined variable | Status | Notes |
-| --- | --- | --- |
-| `$_GET` | Compatibility | First query-string value for each key. |
-| `$_POST` | Partial compatibility | First parsed form value for each key; uploads are unavailable. |
-| `$_PATH` | phpscript extension | Route wildcard values from the matched Go HTTP pattern. |
-| `$GLOBALS`, `$_SERVER`, `$_FILES`, `$_REQUEST` | Not implemented | Not seeded by the request runtime. |
-| `$_SESSION`, `$_ENV`, `$_COOKIE` | Not implemented | Not seeded by the request runtime. |
-| `$argc`, `$argv` | Not implemented | CLI arguments are not exposed as PHP predefined variables. |
-| `$php_errormsg`, `$http_response_header` | Not implemented | PHP error and stream globals are unavailable. |
+| PHP predefined variable                        | Status                | Notes                                                          |
+|------------------------------------------------|-----------------------|----------------------------------------------------------------|
+| `$_GET`                                        | Compatibility         | First query-string value for each key.                         |
+| `$_POST`                                       | Partial compatibility | First parsed form value for each key; uploads are unavailable. |
+| `$_PATH`                                       | phpscript extension   | Route wildcard values from the matched Go HTTP pattern.        |
+| `$GLOBALS`, `$_SERVER`, `$_FILES`, `$_REQUEST` | Not implemented       | Not seeded by the request runtime.                             |
+| `$_SESSION`, `$_ENV`, `$_COOKIE`               | Not implemented       | Not seeded by the request runtime.                             |
+| `$argc`, `$argv`                               | Not implemented       | CLI arguments are not exposed as PHP predefined variables.     |
+| `$php_errormsg`, `$http_response_header`       | Not implemented       | PHP error and stream globals are unavailable.                  |
 
 These arrays are installed only when a Go host creates and registers a request
 context. Their values are ordinary phpscript arrays, while their reserved names

--- a/docs/reference/types/README.md
+++ b/docs/reference/types/README.md
@@ -1,13 +1,13 @@
 # Types
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| `null`, `bool`, `int`, `float`, `string` | Compatibility | Scalar values are dynamically typed. |
-| Arrays | Partial compatibility | Ordered list and associative-array behavior is supported by one runtime array type. |
-| Objects | Partial compatibility | phpscript and Go-backed objects are supported. |
-| Callable values | Partial compatibility | Closures, function names, and bound methods can be invoked by supported APIs. |
-| Type declarations | Not implemented | Parameter, return, property, union, intersection, and `mixed` declarations are unavailable. |
-| Resources | Partial compatibility | Some filesystem APIs return host-backed file values; PHP resource semantics are not general-purpose. |
+| PHP language-reference feature           | Status                | Notes                                                                                                |
+|------------------------------------------|-----------------------|------------------------------------------------------------------------------------------------------|
+| `null`, `bool`, `int`, `float`, `string` | Compatibility         | Scalar values are dynamically typed.                                                                 |
+| Arrays                                   | Partial compatibility | Ordered list and associative-array behavior is supported by one runtime array type.                  |
+| Objects                                  | Partial compatibility | phpscript and Go-backed objects are supported.                                                       |
+| Callable values                          | Partial compatibility | Closures, function names, and bound methods can be invoked by supported APIs.                        |
+| Type declarations                        | Not implemented       | Parameter, return, property, union, intersection, and `mixed` declarations are unavailable.          |
+| Resources                                | Partial compatibility | Some filesystem APIs return host-backed file values; PHP resource semantics are not general-purpose. |
 
 Values are dynamically typed. The runtime performs PHP-like truthiness and
 numeric/string coercion for its supported operators, but it is not a complete

--- a/docs/reference/variables/README.md
+++ b/docs/reference/variables/README.md
@@ -1,13 +1,13 @@
 # Variables
 
-| PHP language-reference feature | Status | Notes |
-| --- | --- | --- |
-| Basics | Compatibility | Variables use the `$name` form and are created by assignment. |
-| Predefined variables | Partial compatibility | Only the request variables documented in [Predefined variables](../predefined-variables/README.md) are seeded. |
-| Variable scope | Partial compatibility | Calls have local scope; PHP `global` and static locals are unavailable. |
-| Variable variables | Not implemented | Forms such as `$$name` are unavailable. |
-| Variables from external sources | Partial compatibility | HTTP query, form, and route values are provided by the request context. |
-| References | Not implemented | `&` is accepted in limited positions but does not create PHP reference semantics. |
+| PHP language-reference feature  | Status                | Notes                                                                                                          |
+|---------------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------|
+| Basics                          | Compatibility         | Variables use the `$name` form and are created by assignment.                                                  |
+| Predefined variables            | Partial compatibility | Only the request variables documented in [Predefined variables](../predefined-variables/README.md) are seeded. |
+| Variable scope                  | Partial compatibility | Calls have local scope; PHP `global` and static locals are unavailable.                                        |
+| Variable variables              | Not implemented       | Forms such as `$$name` are unavailable.                                                                        |
+| Variables from external sources | Partial compatibility | HTTP query, form, and route values are provided by the request context.                                        |
+| References                      | Not implemented       | `&` is accepted in limited positions but does not create PHP reference semantics.                              |
 
 ## Basics
 

--- a/flatstack/benchmark_test.go
+++ b/flatstack/benchmark_test.go
@@ -1,0 +1,101 @@
+package flatstack_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/model"
+	"github.com/titpetric/phpscript/parser"
+)
+
+func mustFlatProgram(tb testing.TB, source string) *model.Program {
+	tb.Helper()
+	program, err := parser.Parse(source)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		tb.Fatalf("benchmark would use interpreter fallback: %v", err)
+	}
+	return program
+}
+
+// Benchmarks are modeled after the flat-stack repository's compile-once/run-
+// many and parallel-load matrix. They deliberately gate on Supports.
+func BenchmarkFlatstackPrecompiledConcat(b *testing.B) {
+	program := mustFlatProgram(b, `<?php $a = "hello"; $b = "-world"; echo $a . $b; ?>`)
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	if err := runtime.Run(program); err != nil { // warm bytecode cache
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := runtime.Run(program); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFlatstackPrecompiledLanguageLoop(b *testing.B) {
+	program := mustFlatProgram(b, `<?php
+$sum = 0;
+for ($i = 0; $i < 20; $i += 1) {
+    if ($i % 2 == 0) $sum += $i;
+}
+echo $sum;
+?>`)
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	if err := runtime.Run(program); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := runtime.Run(program); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFlatstackParseCompileRun(b *testing.B) {
+	const source = `<?php $a = "hello"; $b = "-world"; echo $a . $b; ?>`
+	b.ReportAllocs()
+	for b.Loop() {
+		program, err := parser.Parse(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		runtime := flatstack.New(io.Discard, flatstack.Options{})
+		if err := runtime.Run(program); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFlatstackParallelHostBridge(b *testing.B) {
+	program := mustFlatProgram(b, `<?php
+$storage = new Storage;
+$storage->set("color", "blue");
+$record = $storage->get("color");
+echo $storage->tenant() . ":" . $record->value;
+`)
+	cache := flatstack.NewExprCache()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		runtime := flatstack.New(io.Discard, flatstack.Options{})
+		runtime.SetExprCache(cache)
+		runtime.SetContext(context.WithValue(context.Background(), contextKey("tenant"), "acme"))
+		runtime.RegisterConstructor("Storage", newStorage)
+		for pb.Next() {
+			if err := runtime.Run(program); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -1,0 +1,514 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+type loopContext struct {
+	breaks         []int
+	continues      []int
+	continueTarget int
+}
+
+type compiler struct {
+	program  Program
+	locals   map[string]int
+	loops    []loopContext
+	nextIter int
+}
+
+// Compile validates and lowers the entire AST before execution can cause side
+// effects. Any unsupported nested node rejects the whole program.
+func Compile(ast *model.Program) (program *Program, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			program = nil
+			err = fmt.Errorf("flatstack: compiler panic: %v", recovered)
+		}
+	}()
+	c := &compiler{locals: make(map[string]int)}
+	if ast != nil {
+		for i, stmt := range ast.Stmts {
+			if err := c.stmt(stmt, fmt.Sprintf("stmt[%d]", i)); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &c.program, nil
+}
+
+func (c *compiler) emit(inst instruction) int {
+	index := len(c.program.code)
+	c.program.code = append(c.program.code, inst)
+	return index
+}
+
+func (c *compiler) constant(value any) int {
+	index := len(c.program.constants)
+	c.program.constants = append(c.program.constants, value)
+	return index
+}
+
+func (c *compiler) slot(name string) int {
+	if slot, ok := c.locals[name]; ok {
+		return slot
+	}
+	slot := len(c.program.localNames)
+	c.locals[name] = slot
+	c.program.localNames = append(c.program.localNames, name)
+	return slot
+}
+
+func (c *compiler) block(statements []model.Stmt, path string) error {
+	for i, stmt := range statements {
+		if err := c.stmt(stmt, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *compiler) stmt(stmt model.Stmt, path string) error {
+	switch node := stmt.(type) {
+	case *model.InlineHTML:
+		c.emit(instruction{op: opPushConst, a: c.constant(node.Text)})
+		c.emit(instruction{op: opEcho})
+	case *model.Echo:
+		for i, argument := range node.Args {
+			if err := c.expr(argument, fmt.Sprintf("%s.echo[%d]", path, i)); err != nil {
+				return err
+			}
+			c.emit(instruction{op: opEcho})
+		}
+	case *model.ExprStmt:
+		if err := c.expr(node.X, path+".expr"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opPop})
+	case *model.Assign:
+		return c.assignment(node.Target, node.Op, node.Value, false, path)
+	case *model.If:
+		if err := c.expr(node.Cond, path+".cond"); err != nil {
+			return err
+		}
+		falseJump := c.emit(instruction{op: opJumpFalse, target: -1})
+		if err := c.block(node.Then, path+".then"); err != nil {
+			return err
+		}
+		endJump := c.emit(instruction{op: opJump, target: -1})
+		c.program.code[falseJump].target = len(c.program.code)
+		if err := c.block(node.Else, path+".else"); err != nil {
+			return err
+		}
+		c.program.code[endJump].target = len(c.program.code)
+	case *model.For:
+		return c.forStmt(node, path)
+	case *model.Foreach:
+		return c.foreachStmt(node, path)
+	case *model.Switch:
+		return c.switchStmt(node, path)
+	case *model.Try:
+		return c.tryStmt(node, path)
+	case *model.Throw:
+		if err := c.expr(node.X, path+".value"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opThrow})
+	case *model.Break:
+		if len(c.loops) == 0 {
+			return unsupported(path, "break outside loop")
+		}
+		jump := c.emit(instruction{op: opJump, target: -1})
+		index := len(c.loops) - 1
+		c.loops[index].breaks = append(c.loops[index].breaks, jump)
+	case *model.Continue:
+		loopIndex := -1
+		for i := len(c.loops) - 1; i >= 0; i-- {
+			if c.loops[i].continueTarget != -1 {
+				loopIndex = i
+				break
+			}
+		}
+		if loopIndex < 0 {
+			return unsupported(path, "continue outside loop")
+		}
+		jump := c.emit(instruction{op: opJump, target: -1})
+		c.loops[loopIndex].continues = append(c.loops[loopIndex].continues, jump)
+	default:
+		return unsupported(path, "statement %T", stmt)
+	}
+	return nil
+}
+
+func (c *compiler) tryStmt(node *model.Try, path string) error {
+	if len(node.Catches) == 0 || len(node.Finally) != 0 {
+		return unsupported(path, "try without one catch or with finally")
+	}
+	catch := node.Catches[0]
+	catchSlot := -1
+	if catch.Var != "" {
+		catchSlot = c.slot(catch.Var)
+	}
+	push := c.emit(instruction{op: opTryPush, a: catchSlot, target: -1})
+	if err := c.block(node.Body, path+".body"); err != nil {
+		return err
+	}
+	pop := c.emit(instruction{op: opTryPop})
+	c.program.code[push].b = pop
+	endJump := c.emit(instruction{op: opJump, target: -1})
+	c.program.code[push].target = len(c.program.code)
+	if err := c.block(catch.Body, path+".catch"); err != nil {
+		return err
+	}
+	c.program.code[endJump].target = len(c.program.code)
+	return nil
+}
+
+func (c *compiler) switchStmt(node *model.Switch, path string) error {
+	if err := c.expr(node.Cond, path+".cond"); err != nil {
+		return err
+	}
+	conditionSlot := c.slot(fmt.Sprintf("\x00switch-%d", len(c.program.code)))
+	c.emit(instruction{op: opStore, a: conditionSlot})
+	caseJumps := make([]int, len(node.Cases))
+	for i, switchCase := range node.Cases {
+		c.emit(instruction{op: opLoad, a: conditionSlot})
+		if err := c.expr(switchCase.Value, fmt.Sprintf("%s.case[%d].value", path, i)); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opBinary, name: "=="})
+		caseJumps[i] = c.emit(instruction{op: opJumpTrue, target: -1})
+	}
+	defaultJump := c.emit(instruction{op: opJump, target: -1})
+	c.loops = append(c.loops, loopContext{continueTarget: -1})
+	for i, switchCase := range node.Cases {
+		c.program.code[caseJumps[i]].target = len(c.program.code)
+		if err := c.block(switchCase.Body, fmt.Sprintf("%s.case[%d].body", path, i)); err != nil {
+			return err
+		}
+	}
+	c.program.code[defaultJump].target = len(c.program.code)
+	if err := c.block(node.Default, path+".default"); err != nil {
+		return err
+	}
+	endPC := len(c.program.code)
+	control := &c.loops[len(c.loops)-1]
+	for _, patch := range control.breaks {
+		c.program.code[patch].target = endPC
+	}
+	c.loops = c.loops[:len(c.loops)-1]
+	return nil
+}
+
+func (c *compiler) forStmt(node *model.For, path string) error {
+	if node.Init != nil {
+		if err := c.stmt(node.Init, path+".init"); err != nil {
+			return err
+		}
+	}
+	conditionPC := len(c.program.code)
+	var endCondition int = -1
+	if node.Cond != nil {
+		if err := c.expr(node.Cond, path+".cond"); err != nil {
+			return err
+		}
+		endCondition = c.emit(instruction{op: opJumpFalse, target: -1})
+	}
+	c.loops = append(c.loops, loopContext{continueTarget: -2})
+	if err := c.block(node.Body, path+".body"); err != nil {
+		return err
+	}
+	postPC := len(c.program.code)
+	loop := &c.loops[len(c.loops)-1]
+	loop.continueTarget = postPC
+	for _, patch := range loop.continues {
+		c.program.code[patch].target = postPC
+	}
+	if node.Post != nil {
+		if err := c.stmt(node.Post, path+".post"); err != nil {
+			return err
+		}
+	}
+	c.emit(instruction{op: opJump, target: conditionPC})
+	endPC := len(c.program.code)
+	if endCondition >= 0 {
+		c.program.code[endCondition].target = endPC
+	}
+	for _, patch := range loop.breaks {
+		c.program.code[patch].target = endPC
+	}
+	c.loops = c.loops[:len(c.loops)-1]
+	return nil
+}
+
+func (c *compiler) foreachStmt(node *model.Foreach, path string) error {
+	keyTarget, valueTarget := node.KeyTarget, node.ValTarget
+	if keyTarget == nil && node.KeyVar != "" {
+		keyTarget = &model.Var{Name: node.KeyVar}
+	}
+	if valueTarget == nil && node.ValVar != "" {
+		valueTarget = &model.Var{Name: node.ValVar}
+	}
+	if valueTarget == nil {
+		return unsupported(path+".value", "missing foreach target")
+	}
+	if err := c.expr(node.Source, path+".source"); err != nil {
+		return err
+	}
+	iterator := c.nextIter
+	c.nextIter++
+	keySlot := -1
+	if keyTarget != nil {
+		keySlot = c.slot(fmt.Sprintf("\x00foreach-key-%d", iterator))
+	}
+	valueSlot := c.slot(fmt.Sprintf("\x00foreach-value-%d", iterator))
+	c.emit(instruction{op: opIterInit, a: iterator})
+	nextPC := len(c.program.code)
+	next := c.emit(instruction{op: opIterNext, a: iterator, b: keySlot, c: valueSlot, target: -1})
+	if keyTarget != nil {
+		c.emit(instruction{op: opLoad, a: keySlot})
+		if err := c.storeTop(keyTarget, path+".key"); err != nil {
+			return err
+		}
+	}
+	c.emit(instruction{op: opLoad, a: valueSlot})
+	if err := c.storeTop(valueTarget, path+".value"); err != nil {
+		return err
+	}
+	c.loops = append(c.loops, loopContext{continueTarget: nextPC})
+	if err := c.block(node.Body, path+".body"); err != nil {
+		return err
+	}
+	c.emit(instruction{op: opJump, target: nextPC})
+	closePC := len(c.program.code)
+	c.emit(instruction{op: opIterClose, a: iterator})
+	endPC := len(c.program.code)
+	c.program.code[next].target = closePC
+	loop := &c.loops[len(c.loops)-1]
+	for _, patch := range loop.breaks {
+		c.program.code[patch].target = closePC
+	}
+	for _, patch := range loop.continues {
+		c.program.code[patch].target = nextPC
+	}
+	c.loops = c.loops[:len(c.loops)-1]
+	_ = endPC
+	return nil
+}
+
+// storeTop consumes a value already on the operand stack and writes it to a
+// foreach target. Index targets are evaluated once per iteration.
+func (c *compiler) storeTop(target model.Expr, path string) error {
+	switch target := target.(type) {
+	case *model.Var:
+		c.emit(instruction{op: opStore, a: c.slot(target.Name)})
+	case *model.Index:
+		if target.Index == nil {
+			return unsupported(path, "append foreach target")
+		}
+		if err := c.expr(target.Base, path+".base"); err != nil {
+			return err
+		}
+		if err := c.expr(target.Index, path+".index"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opSetIndex, name: "="})
+	default:
+		return unsupported(path, "foreach target %T", target)
+	}
+	return nil
+}
+
+func (c *compiler) assignment(target model.Expr, operator string, value model.Expr, keep bool, path string) error {
+	if err := c.expr(value, path+".value"); err != nil {
+		return err
+	}
+	switch target := target.(type) {
+	case *model.Var:
+		c.emit(instruction{op: opStore, a: c.slot(target.Name), b: boolInt(keep), name: operator})
+	case *model.Index:
+		if err := c.expr(target.Base, path+".target.base"); err != nil {
+			return err
+		}
+		appendValue := target.Index == nil || operator == "[]="
+		if !appendValue {
+			if err := c.expr(target.Index, path+".target.index"); err != nil {
+				return err
+			}
+		}
+		c.emit(instruction{op: opSetIndex, b: boolInt(appendValue), c: boolInt(keep), name: operator})
+	default:
+		return unsupported(path+".target", "assignment target %T", target)
+	}
+	return nil
+}
+
+func (c *compiler) expr(expr model.Expr, path string) error {
+	switch node := expr.(type) {
+	case *model.Lit:
+		c.emit(instruction{op: opPushConst, a: c.constant(node.Value)})
+	case *model.Parenthesized:
+		return c.expr(node.X, path+".expression")
+	case *model.Var:
+		c.emit(instruction{op: opLoad, a: c.slot(node.Name)})
+	case *model.ArrayLit:
+		for i, item := range node.Items {
+			if item.Key == nil {
+				c.emit(instruction{op: opPushConst, a: c.constant(nil)})
+			} else if err := c.expr(item.Key, fmt.Sprintf("%s.key[%d]", path, i)); err != nil {
+				return err
+			}
+			if err := c.expr(item.Val, fmt.Sprintf("%s.value[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		c.emit(instruction{op: opArray, a: len(node.Items)})
+	case *model.Index:
+		if node.Index == nil {
+			return unsupported(path, "append index read")
+		}
+		if err := c.expr(node.Base, path+".base"); err != nil {
+			return err
+		}
+		if err := c.expr(node.Index, path+".index"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opIndex})
+	case *model.Binary:
+		return c.binary(node, path)
+	case *model.Unary:
+		if node.Op == "++" || node.Op == "--" {
+			return c.incDec(node, path)
+		}
+		if node.Op != "!" && node.Op != "+" && node.Op != "-" {
+			return unsupported(path, "unary operator %q", node.Op)
+		}
+		if err := c.expr(node.X, path+".operand"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opUnary, name: node.Op})
+	case *model.Ternary:
+		if err := c.expr(node.Cond, path+".cond"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opDup})
+		falseJump := c.emit(instruction{op: opJumpFalse, target: -1})
+		if node.Then != nil {
+			c.emit(instruction{op: opPop})
+			if err := c.expr(node.Then, path+".then"); err != nil {
+				return err
+			}
+		}
+		endJump := c.emit(instruction{op: opJump, target: -1})
+		c.program.code[falseJump].target = len(c.program.code)
+		c.emit(instruction{op: opPop})
+		if err := c.expr(node.Else, path+".else"); err != nil {
+			return err
+		}
+		c.program.code[endJump].target = len(c.program.code)
+	case *model.Call:
+		for i, argument := range node.Args {
+			if err := c.expr(argument, fmt.Sprintf("%s.arg[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		c.emit(instruction{op: opCall, a: len(node.Args), name: node.Name, extra: node.Fallback})
+	case *model.New:
+		for i, argument := range node.Args {
+			if err := c.expr(argument, fmt.Sprintf("%s.arg[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		c.emit(instruction{op: opConstruct, a: len(node.Args), name: node.Class})
+	case *model.MethodCall:
+		if err := c.expr(node.Base, path+".base"); err != nil {
+			return err
+		}
+		for i, argument := range node.Args {
+			if err := c.expr(argument, fmt.Sprintf("%s.arg[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		c.emit(instruction{op: opCallMethod, a: len(node.Args), name: node.Method})
+	case *model.PropAccess:
+		if err := c.expr(node.Base, path+".base"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opGetProperty, name: node.Name})
+	case *model.AssignExpr:
+		if node.Op != "" && node.Op != "=" {
+			return unsupported(path, "assignment expression operator %q", node.Op)
+		}
+		return c.assignment(node.Target, node.Op, node.Value, true, path)
+	default:
+		return unsupported(path, "expression %T", expr)
+	}
+	return nil
+}
+
+func (c *compiler) incDec(node *model.Unary, path string) error {
+	switch target := node.X.(type) {
+	case *model.Var:
+		c.emit(instruction{op: opIncDecLocal, a: c.slot(target.Name), b: boolInt(node.Postfix), name: node.Op})
+	case *model.Index:
+		if target.Index == nil {
+			return unsupported(path, "increment append target")
+		}
+		if err := c.expr(target.Base, path+".base"); err != nil {
+			return err
+		}
+		if err := c.expr(target.Index, path+".index"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opIncDecIndex, b: boolInt(node.Postfix), name: node.Op})
+	default:
+		return unsupported(path, "increment target %T", node.X)
+	}
+	return nil
+}
+
+func (c *compiler) binary(node *model.Binary, path string) error {
+	switch node.Op {
+	case "&&", "||":
+		if err := c.expr(node.Left, path+".left"); err != nil {
+			return err
+		}
+		jumpOp, constant := opJumpFalse, false
+		if node.Op == "||" {
+			jumpOp, constant = opJumpTrue, true
+		}
+		branch := c.emit(instruction{op: jumpOp, target: -1})
+		if err := c.expr(node.Right, path+".right"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opTruthy})
+		end := c.emit(instruction{op: opJump, target: -1})
+		c.program.code[branch].target = len(c.program.code)
+		c.emit(instruction{op: opPushConst, a: c.constant(constant)})
+		c.program.code[end].target = len(c.program.code)
+	case ".", "+", "-", "*", "/", "%", "==", "!=", "===", "!==", "<", "<=", ">", ">=":
+		if err := c.expr(node.Left, path+".left"); err != nil {
+			return err
+		}
+		if err := c.expr(node.Right, path+".right"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opBinary, name: node.Op})
+	default:
+		return unsupported(path, "binary operator %q", node.Op)
+	}
+	return nil
+}
+
+func unsupported(path, format string, args ...any) error {
+	return fmt.Errorf("flatstack: %s: unsupported %s", path, fmt.Sprintf(format, args...))
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/flatstack/engine/program.go
+++ b/flatstack/engine/program.go
@@ -1,0 +1,78 @@
+// Package engine compiles model AST programs into flat bytecode and executes
+// them against a host-provided PHP semantics bridge.
+package engine
+
+import "github.com/titpetric/phpscript/model"
+
+type opcode uint8
+
+const (
+	opPushConst opcode = iota
+	opPop
+	opDup
+	opLoad
+	opStore
+	opArray
+	opIndex
+	opSetIndex
+	opIncDecLocal
+	opIncDecIndex
+	opBinary
+	opUnary
+	opTruthy
+	opJump
+	opJumpFalse
+	opJumpTrue
+	opCall
+	opConstruct
+	opCallMethod
+	opGetProperty
+	opEcho
+	opIterInit
+	opIterNext
+	opIterClose
+	opTryPush
+	opTryPop
+	opThrow
+)
+
+type instruction struct {
+	op     opcode
+	a      int
+	b      int
+	c      int
+	target int
+	name   string
+	extra  string
+}
+
+// Program is immutable bytecode compiled from a complete model.Program.
+type Program struct {
+	code       []instruction
+	constants  []any
+	localNames []string
+}
+
+// Entry is one key/value pair produced for foreach.
+type Entry struct {
+	Key   any
+	Value any
+}
+
+// Host owns PHP value semantics and the Go API bridge. The engine itself owns
+// only compilation, operand/local storage, jumps, and iteration state.
+type Host interface {
+	Construct(string, []any) (any, error)
+	CallMethod(any, string, []any) (any, error)
+	Call(string, string, []any) (any, error)
+	GetProperty(any, string) any
+	Lookup(string) any
+	Array([]model.ArrayItemValue) any
+	Index(any, any) any
+	SetIndex(any, any, any, bool, string) error
+	Binary(string, any, any) (any, error)
+	Unary(string, any) (any, error)
+	Truthy(any) bool
+	Entries(any) []Entry
+	Echo(any) error
+}

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -1,0 +1,384 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+type iteratorState struct {
+	entries []Entry
+	index   int
+}
+
+type errorHandler struct {
+	target     int
+	local      int
+	start      int
+	end        int
+	stackDepth int
+}
+
+// Run executes a previously validated flat instruction stream.
+func Run(program *Program, host Host) (err error) {
+	if program == nil {
+		return nil
+	}
+	pc := 0
+	stack := make([]any, 0, 32)
+	locals := make([]any, len(program.localNames))
+	initialized := make([]bool, len(program.localNames))
+	iterators := make(map[int]*iteratorState)
+	var handlers []errorHandler
+	defer func() {
+		clear(stack)
+		clear(locals)
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("flatstack: VM panic at pc %d: %v", pc, recovered)
+		}
+	}()
+
+	pop := func() (any, error) {
+		if len(stack) == 0 {
+			return nil, fmt.Errorf("operand stack underflow")
+		}
+		last := len(stack) - 1
+		value := stack[last]
+		stack[last] = nil
+		stack = stack[:last]
+		return value, nil
+	}
+	args := func(count int) ([]any, error) {
+		if count < 0 || count > len(stack) {
+			return nil, fmt.Errorf("argument stack underflow")
+		}
+		start := len(stack) - count
+		values := append([]any(nil), stack[start:]...)
+		clear(stack[start:])
+		stack = stack[:start]
+		return values, nil
+	}
+	handle := func(runErr error) bool {
+		if runErr == nil || len(handlers) == 0 {
+			return false
+		}
+		last := len(handlers) - 1
+		handler := handlers[last]
+		handlers = handlers[:last]
+		if handler.stackDepth < len(stack) {
+			clear(stack[handler.stackDepth:])
+			stack = stack[:handler.stackDepth]
+		}
+		for errors.Unwrap(runErr) != nil {
+			runErr = errors.Unwrap(runErr)
+		}
+		if handler.local >= 0 {
+			locals[handler.local], initialized[handler.local] = runErr, true
+		}
+		pc = handler.target
+		return true
+	}
+
+	for pc < len(program.code) {
+		inst := program.code[pc]
+		switch inst.op {
+		case opPushConst:
+			stack = append(stack, program.constants[inst.a])
+		case opPop:
+			if _, err = pop(); err != nil {
+				return err
+			}
+		case opDup:
+			if len(stack) == 0 {
+				return fmt.Errorf("flatstack: pc %d: duplicate stack underflow", pc)
+			}
+			stack = append(stack, stack[len(stack)-1])
+		case opLoad:
+			if initialized[inst.a] {
+				stack = append(stack, locals[inst.a])
+			} else {
+				stack = append(stack, host.Lookup(program.localNames[inst.a]))
+			}
+		case opStore:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			if inst.name != "" && inst.name != "=" {
+				current := host.Lookup(program.localNames[inst.a])
+				if initialized[inst.a] {
+					current = locals[inst.a]
+				}
+				operator := inst.name[:len(inst.name)-1]
+				value, err = host.Binary(operator, current, value)
+				if err != nil {
+					return err
+				}
+			}
+			locals[inst.a], initialized[inst.a] = value, true
+			if inst.b != 0 {
+				stack = append(stack, value)
+			}
+		case opArray:
+			items := make([]model.ArrayItemValue, inst.a)
+			for i := inst.a - 1; i >= 0; i-- {
+				value, popErr := pop()
+				if popErr != nil {
+					return popErr
+				}
+				key, popErr := pop()
+				if popErr != nil {
+					return popErr
+				}
+				items[i] = model.ArrayItemValue{Key: key, Val: value}
+			}
+			stack = append(stack, host.Array(items))
+		case opIndex:
+			index, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			base, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			stack = append(stack, host.Index(base, index))
+		case opSetIndex:
+			var index any
+			var popErr error
+			if inst.b == 0 {
+				index, popErr = pop()
+				if popErr != nil {
+					return popErr
+				}
+			}
+			base, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			if err = host.SetIndex(base, index, value, inst.b != 0, inst.name); err != nil {
+				if handle(err) {
+					continue
+				}
+				return err
+			}
+			if inst.c != 0 {
+				stack = append(stack, value)
+			}
+		case opIncDecLocal:
+			current := host.Lookup(program.localNames[inst.a])
+			if initialized[inst.a] {
+				current = locals[inst.a]
+			}
+			operator := "+"
+			if inst.name == "--" {
+				operator = "-"
+			}
+			next, binaryErr := host.Binary(operator, current, int64(1))
+			if binaryErr != nil {
+				if handle(binaryErr) {
+					continue
+				}
+				return binaryErr
+			}
+			locals[inst.a], initialized[inst.a] = next, true
+			if inst.b != 0 {
+				stack = append(stack, current)
+			} else {
+				stack = append(stack, next)
+			}
+		case opIncDecIndex:
+			index, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			base, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			current := host.Index(base, index)
+			operator := "+"
+			if inst.name == "--" {
+				operator = "-"
+			}
+			next, binaryErr := host.Binary(operator, current, int64(1))
+			if binaryErr != nil {
+				if handle(binaryErr) {
+					continue
+				}
+				return binaryErr
+			}
+			if err = host.SetIndex(base, index, next, false, "="); err != nil {
+				if handle(err) {
+					continue
+				}
+				return err
+			}
+			if inst.b != 0 {
+				stack = append(stack, current)
+			} else {
+				stack = append(stack, next)
+			}
+		case opBinary:
+			right, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			left, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value, binaryErr := host.Binary(inst.name, left, right)
+			if binaryErr != nil {
+				if handle(binaryErr) {
+					continue
+				}
+				return binaryErr
+			}
+			stack = append(stack, value)
+		case opUnary:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value, err = host.Unary(inst.name, value)
+			if err != nil {
+				if handle(err) {
+					continue
+				}
+				return err
+			}
+			stack = append(stack, value)
+		case opTruthy:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			stack = append(stack, host.Truthy(value))
+		case opJump:
+			for len(handlers) > 0 {
+				handler := handlers[len(handlers)-1]
+				if inst.target >= handler.start && inst.target <= handler.end {
+					break
+				}
+				handlers = handlers[:len(handlers)-1]
+			}
+			pc = inst.target
+			continue
+		case opJumpFalse, opJumpTrue:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			truthy := host.Truthy(value)
+			if (inst.op == opJumpFalse && !truthy) || (inst.op == opJumpTrue && truthy) {
+				pc = inst.target
+				continue
+			}
+		case opCall, opConstruct:
+			arguments, argErr := args(inst.a)
+			if argErr != nil {
+				return argErr
+			}
+			var value any
+			if inst.op == opCall {
+				value, err = host.Call(inst.name, inst.extra, arguments)
+			} else {
+				value, err = host.Construct(inst.name, arguments)
+			}
+			if err != nil {
+				if handle(err) {
+					continue
+				}
+				return err
+			}
+			stack = append(stack, value)
+		case opCallMethod:
+			arguments, argErr := args(inst.a)
+			if argErr != nil {
+				return argErr
+			}
+			receiver, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value, callErr := host.CallMethod(receiver, inst.name, arguments)
+			if callErr != nil {
+				if handle(callErr) {
+					continue
+				}
+				return callErr
+			}
+			stack = append(stack, value)
+		case opGetProperty:
+			receiver, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			stack = append(stack, host.GetProperty(receiver, inst.name))
+		case opEcho:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			if err = host.Echo(value); err != nil {
+				if handle(err) {
+					continue
+				}
+				return err
+			}
+		case opIterInit:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			iterators[inst.a] = &iteratorState{entries: host.Entries(value)}
+		case opIterNext:
+			iterator := iterators[inst.a]
+			if iterator == nil || iterator.index >= len(iterator.entries) {
+				pc = inst.target
+				continue
+			}
+			entry := iterator.entries[iterator.index]
+			iterator.index++
+			if inst.b >= 0 {
+				locals[inst.b], initialized[inst.b] = entry.Key, true
+			}
+			locals[inst.c], initialized[inst.c] = entry.Value, true
+		case opIterClose:
+			delete(iterators, inst.a)
+		case opTryPush:
+			handlers = append(handlers, errorHandler{
+				target:     inst.target,
+				local:      inst.a,
+				start:      pc + 1,
+				end:        inst.b,
+				stackDepth: len(stack),
+			})
+		case opTryPop:
+			if len(handlers) == 0 {
+				return fmt.Errorf("flatstack: pc %d: exception handler underflow", pc)
+			}
+			handlers = handlers[:len(handlers)-1]
+		case opThrow:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			throwErr := fmt.Errorf("uncaught exception: %v", value)
+			if handle(throwErr) {
+				continue
+			}
+			return throwErr
+		default:
+			return fmt.Errorf("flatstack: pc %d: invalid opcode %d", pc, inst.op)
+		}
+		pc++
+	}
+	return nil
+}

--- a/flatstack/flatstack.go
+++ b/flatstack/flatstack.go
@@ -1,0 +1,48 @@
+// Package flatstack provides the runner embedding API with an opt-in flat
+// bytecode backend. Unsupported programs are rejected before execution and run
+// by the full interpreter, preserving runner behavior while the bytecode subset
+// grows.
+package flatstack
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	flatvm "github.com/titpetric/phpscript/flatstack/engine"
+	"github.com/titpetric/phpscript/model"
+	"github.com/titpetric/phpscript/runner"
+)
+
+type Runtime = runner.Runtime
+type Options = runner.Options
+type ExitError = runner.ExitError
+type HostPanicError = runner.HostPanicError
+type ExprCache = runner.ExprCache
+type IncludeCache = runner.IncludeCache
+type IncludeFunc = runner.IncludeFunc
+type Scope = runner.Scope
+type Context = runner.Context
+type Transpiler = runner.Transpiler
+
+func New(w io.Writer, opts Options) *Runtime { return runner.NewFlatStack(w, opts) }
+func NewExprCache() *ExprCache               { return runner.NewExprCache() }
+func NewIncludeCache() *IncludeCache         { return runner.NewIncludeCache() }
+func NewScope() *Scope                       { return runner.NewScope() }
+func NewContext() Context                    { return runner.NewContext() }
+func FromRequest(r *http.Request) Context    { return runner.FromRequest(r) }
+func NewTranspiler() *Transpiler             { return runner.NewTranspiler() }
+
+func ScopeFromContext(ctx context.Context) (*Scope, bool) {
+	return runner.ScopeFromContext(ctx)
+}
+
+func IsExit(err error) (*ExitError, bool) { return runner.IsExit(err) }
+
+// Supports reports whether p will execute through flat bytecode rather than
+// the compatibility interpreter. Call this in benchmarks to prevent measuring
+// an accidental fallback.
+func Supports(p *model.Program) error {
+	_, err := flatvm.Compile(p)
+	return err
+}

--- a/flatstack/flatstack_test.go
+++ b/flatstack/flatstack_test.go
@@ -1,0 +1,82 @@
+package flatstack_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+)
+
+type contextKey string
+
+type storage struct {
+	values map[string]string
+	tenant string
+}
+
+func (s *storage) Set(_ context.Context, key, value string) { s.values[key] = value }
+func (s *storage) Get(_ context.Context, key string) (record, error) {
+	value, ok := s.values[key]
+	if !ok {
+		return record{}, errors.New("missing key")
+	}
+	return record{Value: value}, nil
+}
+func (s *storage) Tenant() string { return s.tenant }
+
+type record struct {
+	Value string
+}
+
+func newStorage(ctx context.Context) (*storage, error) {
+	tenant, _ := ctx.Value(contextKey("tenant")).(string)
+	return &storage{values: make(map[string]string), tenant: tenant}, nil
+}
+
+func TestRunnerCompatibleFastPath(t *testing.T) {
+	program, err := parser.Parse(`<?php
+$storage = new Storage;
+$storage->set("color", "blue");
+$record = $storage->get("color");
+echo $storage->tenant() . ":" . $record->value;
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("benchmark program should use flat bytecode: %v", err)
+	}
+
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetContext(context.WithValue(context.Background(), contextKey("tenant"), "acme"))
+	runtime.RegisterConstructor("Storage", newStorage)
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.String(), "acme:blue"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestArithmeticUsesFlatBytecode(t *testing.T) {
+	program, err := parser.Parse(`<?php echo 20 + 22; ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("arithmetic should compile to flat bytecode: %v", err)
+	}
+
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.String(), "42"; got != want {
+		t.Fatalf("flat bytecode output = %q, want %q", got, want)
+	}
+}

--- a/flatstack/fuzz_test.go
+++ b/flatstack/fuzz_test.go
@@ -1,0 +1,120 @@
+package flatstack_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/model"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+)
+
+// FuzzFlatstackCompilerInput is adapted from the source flat-stack compiler
+// fuzz target. Parse and unsupported errors are valid; panics are not.
+func FuzzFlatstackCompilerInput(f *testing.F) {
+	seeds := []string{
+		`<?php $a = "value"; echo $a; ?>`,
+		`<?php $a = "left"; $b = "right"; echo $a . $b; ?>`,
+		`before <?php echo "inside"; ?> after`,
+		`<?php $storage = new Storage; $storage->tenant(); ?>`,
+		`<?php echo 10 + 20; ?>`,
+		`<?php $a = "unterminated; ?>`,
+		`<?php if ($a) { echo "fallback"; } ?>`,
+		`<?php`,
+		``,
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, source string) {
+		if len(source) > 16<<10 {
+			t.Skip()
+		}
+		program, err := parser.Parse(source)
+		if err != nil {
+			return
+		}
+		// Compilation is the target. Arbitrary input can now produce supported,
+		// intentionally infinite loops, so executing it would make fuzzing hang.
+		_ = flatstack.Supports(program)
+	})
+}
+
+// FuzzFlatstackDifferential compares supported bytecode with runner semantics.
+// Hex encoding keeps arbitrary bytes safe inside a PHP string literal.
+func FuzzFlatstackDifferential(f *testing.F) {
+	f.Add([]byte("hello"), []byte("world"))
+	f.Add([]byte{0, 1, 2, 255}, []byte("suffix"))
+	f.Add([]byte{}, []byte{})
+
+	f.Fuzz(func(t *testing.T, leftBytes, rightBytes []byte) {
+		if len(leftBytes)+len(rightBytes) > 8<<10 {
+			t.Skip()
+		}
+		left := hex.EncodeToString(leftBytes)
+		right := hex.EncodeToString(rightBytes)
+		source := `<?php $left = "` + left + `"; $right = "` + right + `"; echo $left . ":" . $right; ?>`
+		program, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := flatstack.Supports(program); err != nil {
+			t.Fatalf("generated program left flat subset: %v", err)
+		}
+
+		var flatOutput strings.Builder
+		flatRuntime := flatstack.New(&flatOutput, flatstack.Options{})
+		if err := flatRuntime.Run(program); err != nil {
+			t.Fatal(err)
+		}
+
+		var runnerOutput strings.Builder
+		runnerRuntime := runner.New(&runnerOutput, runner.Options{})
+		if err := runnerRuntime.Run(program); err != nil {
+			t.Fatal(err)
+		}
+		if flatOutput.String() != runnerOutput.String() {
+			t.Fatalf("output mismatch: flatstack=%q runner=%q", flatOutput.String(), runnerOutput.String())
+		}
+		if want := left + ":" + right; flatOutput.String() != want {
+			t.Fatalf("output = %q, want %q", flatOutput.String(), want)
+		}
+	})
+}
+
+// FuzzFlatstackModelAST probes compiler boundaries that source parsing cannot
+// produce, including nil and partially initialized nodes.
+func FuzzFlatstackModelAST(f *testing.F) {
+	f.Add([]byte{0, 1, 2, 3, 4, 5})
+	f.Add([]byte{})
+	f.Add([]byte{255, 255, 255})
+
+	f.Fuzz(func(t *testing.T, shape []byte) {
+		if len(shape) > 4096 {
+			t.Skip()
+		}
+		program := &model.Program{}
+		for _, selector := range shape {
+			switch selector % 7 {
+			case 0:
+				program.Stmts = append(program.Stmts, nil)
+			case 1:
+				program.Stmts = append(program.Stmts, &model.Echo{Args: []model.Expr{nil}})
+			case 2:
+				program.Stmts = append(program.Stmts, &model.Assign{})
+			case 3:
+				program.Stmts = append(program.Stmts, &model.ExprStmt{X: &model.Binary{Op: "."}})
+			case 4:
+				program.Stmts = append(program.Stmts, &model.InlineHTML{Text: "safe"})
+			case 5:
+				program.Stmts = append(program.Stmts, &model.Echo{Args: []model.Expr{&model.Lit{Value: int64(selector)}}})
+			case 6:
+				program.Stmts = append(program.Stmts, &model.Return{})
+			}
+		}
+		_ = flatstack.Supports(program)
+	})
+}

--- a/flatstack/load_test.go
+++ b/flatstack/load_test.go
@@ -1,0 +1,369 @@
+package flatstack_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+)
+
+// These cases mirror the flat-stack repository's table-driven VM and load
+// tests, adapted to phpscript's public parser and runner-compatible API.
+func TestFlatstackTableDrivenExecution(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "literal",
+			source: `<?php echo "hello"; ?>`,
+			want:   "hello",
+		},
+		{
+			name:   "assigned concat",
+			source: `<?php $left = "flat"; $right = "stack"; echo $left . "-" . $right; ?>`,
+			want:   "flat-stack",
+		},
+		{
+			name:   "php string coercion",
+			source: `<?php $number = 42; echo "answer=" . $number; ?>`,
+			want:   "answer=42",
+		},
+		{
+			name:   "inline html",
+			source: `before-<?php $value = "inside"; echo $value; ?>-after`,
+			want:   "before-inside-after",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := flatstack.Supports(program); err != nil {
+				t.Fatalf("test unexpectedly uses interpreter fallback: %v", err)
+			}
+			var output strings.Builder
+			runtime := flatstack.New(&output, flatstack.Options{})
+			if err := runtime.Run(program); err != nil {
+				t.Fatal(err)
+			}
+			if got := output.String(); got != test.want {
+				t.Fatalf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFlatstackNativeLanguageCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"arithmetic and precedence", `<?php echo 2 + 3 * 4, ":", 9 % 4;`, "14:1"},
+		{"comparison and unary", `<?php echo 2 < 3 ? "yes" : "no"; echo !false ? ":true" : ":false";`, "yes:true"},
+		{"short circuit", `<?php $n = 0; false && ($n = 1); true || ($n = 2); echo $n;`, "0"},
+		{"array read write append", `<?php $a = array("x" => 1); $a["x"] += 2; $a[] = 4; echo $a["x"], ":", $a[0];`, "3:4"},
+		{"increment and decrement", `<?php $n = 1; echo $n++, ":", ++$n, ":"; $a = array(4); echo --$a[0], ":", $a[0]--;`, "1:3:3:3"},
+		{"if else", `<?php $n = 3; if ($n > 2) echo "big"; else echo "small";`, "big"},
+		{"for continue break", `<?php for ($i = 0; $i < 6; $i += 1) { if ($i == 2) continue; if ($i == 5) break; echo $i; }`, "0134"},
+		{"switch fallthrough and break", `<?php $n = 2; switch ($n) { case 1: echo "one"; break; case 2: echo "two"; case 3: echo "+three"; break; default: echo "other"; }`, "two+three"},
+		{"throw and catch", `<?php try { throw "boom"; } catch (Exception $e) { echo $e; }`, "uncaught exception: boom"},
+		{"foreach variables", `<?php foreach (array("a" => 1, "b" => 2) as $k => $v) echo $k . $v;`, "a1b2"},
+		{"foreach index targets", `<?php $state = array(); foreach (array("x" => 7) as $state["k"] => $state["v"]) echo $state["k"] . $state["v"];`, "x7"},
+		{"elvis evaluates condition once", `<?php $value = "kept"; echo $value ?: "fallback";`, "kept"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := flatstack.Supports(program); err != nil {
+				t.Fatalf("expected native bytecode support: %v", err)
+			}
+			var output strings.Builder
+			runtime := flatstack.New(&output, flatstack.Options{})
+			if err := runtime.Run(program); err != nil {
+				t.Fatal(err)
+			}
+			if got := output.String(); got != test.want {
+				t.Fatalf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFlatstackLoopControlUnwindsTryHandler(t *testing.T) {
+	program, err := parser.Parse(`<?php
+for ($i = 0; $i < 1; $i += 1) {
+    try { break; } catch (Exception $e) { echo "wrong catch"; }
+}
+$storage = new Storage;
+$storage->get("missing");
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	runtime.RegisterConstructor("Storage", newStorage)
+	err = runtime.Run(program)
+	if err == nil || !strings.Contains(err.Error(), "missing key") {
+		t.Fatalf("error after break = %v, want uncaught missing-key error", err)
+	}
+}
+
+func TestFlatstackRejectsWholeProgramBeforeSideEffects(t *testing.T) {
+	program, err := parser.Parse(`<?php
+$storage = new Storage;
+function unsupported() { return 42; }
+echo unsupported();
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err == nil {
+		t.Fatal("program with a user function should require interpreter fallback")
+	}
+
+	var constructions atomic.Int64
+	constructor := func(context.Context) (*storage, error) {
+		constructions.Add(1)
+		return &storage{values: make(map[string]string)}, nil
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.RegisterConstructor("Storage", constructor)
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := constructions.Load(); got != 1 {
+		t.Fatalf("constructor called %d times; fallback repeated a side effect", got)
+	}
+	if got := output.String(); got != "42" {
+		t.Fatalf("fallback output = %q, want 42", got)
+	}
+}
+
+func TestFlatstackSharedCacheParallel(t *testing.T) {
+	program, err := parser.Parse(`<?php $a = "shared"; $b = "-cache"; echo $a . $b; ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := flatstack.NewExprCache()
+	const workers = 16
+	const iterations = 100
+	var failures atomic.Int64
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				var output strings.Builder
+				runtime := flatstack.New(&output, flatstack.Options{})
+				runtime.SetExprCache(cache)
+				if err := runtime.Run(program); err != nil || output.String() != "shared-cache" {
+					failures.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := failures.Load(); got != 0 {
+		t.Fatalf("parallel runs failed: %d", got)
+	}
+}
+
+func TestFlatstackHostErrorPropagates(t *testing.T) {
+	program, err := parser.Parse(`<?php $storage = new Storage; $storage->get("missing"); ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	runtime.RegisterConstructor("Storage", newStorage)
+	err = runtime.Run(program)
+	if err == nil || !strings.Contains(err.Error(), "missing key") {
+		t.Fatalf("error = %v, want missing-key host error", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("output unavailable")
+}
+
+func TestFlatstackOutputErrorPropagates(t *testing.T) {
+	program, err := parser.Parse(`<?php echo "value"; ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := flatstack.New(failingWriter{}, flatstack.Options{})
+	err = runtime.Run(program)
+	if err == nil || !strings.Contains(err.Error(), "output unavailable") {
+		t.Fatalf("error = %v, want writer error", err)
+	}
+}
+
+func TestFlatstackRuntimeGlobalUsesFlatBytecode(t *testing.T) {
+	program, err := parser.Parse(`<?php echo "tenant=" . $tenant; ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("runtime global should compile as a host-backed flat local: %v", err)
+	}
+
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetGlobal("tenant", "acme")
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "tenant=acme" {
+		t.Fatalf("output = %q, want tenant=acme", got)
+	}
+}
+
+type panicHost struct{}
+
+func (panicHost) Crash() {
+	panic("deliberate host panic")
+}
+
+func TestFlatstackHostPanicBecomesError(t *testing.T) {
+	program, err := parser.Parse(`<?php $host = new PanicHost; $host->crash(); ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	runtime.RegisterConstructor("PanicHost", func() panicHost { return panicHost{} })
+	err = runtime.Run(program)
+	var panicErr *flatstack.HostPanicError
+	if err == nil || !errors.As(err, &panicErr) || !strings.Contains(err.Error(), "deliberate host panic") {
+		t.Fatalf("panic boundary error = %v", err)
+	}
+}
+
+func TestFlatstackHostPanicCanBeCaught(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		setup  func(*flatstack.Runtime)
+	}{
+		{
+			name: "method",
+			source: `<?php
+$host = new PanicHost;
+try { $host->crash(); } catch (Exception $e) { echo "caught: " . $e; }
+?>`,
+			setup: func(runtime *flatstack.Runtime) {
+				runtime.RegisterConstructor("PanicHost", func() panicHost { return panicHost{} })
+			},
+		},
+		{
+			name: "constructor",
+			source: `<?php
+try { $host = new PanicHost; } catch (Exception $e) { echo "caught: " . $e; }
+?>`,
+			setup: func(runtime *flatstack.Runtime) {
+				runtime.RegisterConstructor("PanicHost", func() panicHost {
+					panic("constructor exploded")
+				})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := flatstack.Supports(program); err != nil {
+				t.Fatalf("try/catch should compile into flat bytecode: %v", err)
+			}
+			var output strings.Builder
+			runtime := flatstack.New(&output, flatstack.Options{})
+			test.setup(runtime)
+			if err := runtime.Run(program); err != nil {
+				t.Fatalf("caught panic escaped runtime: %v", err)
+			}
+			if got := output.String(); !strings.HasPrefix(got, "caught: host panic in ") {
+				t.Fatalf("output = %q, want caught host panic", got)
+			}
+		})
+	}
+}
+
+func TestFlatstackPrecompiledAllocationBudget(t *testing.T) {
+	program, err := parser.Parse(`<?php $left = "flat"; $right = "stack"; echo $left . $right; ?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := flatstack.New(io.Discard, flatstack.Options{})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	allocations := testing.AllocsPerRun(500, func() {
+		if err := runtime.Run(program); err != nil {
+			panic(err)
+		}
+	})
+	t.Logf("precompiled concat allocations/run = %.2f", allocations)
+	if allocations > 4 {
+		t.Fatalf("precompiled concat allocations/run = %.2f, want <= 4", allocations)
+	}
+}
+
+func TestFlatstackDeepConcat(t *testing.T) {
+	const depth = 100
+	source := `<?php $value = "x"; echo $value` + strings.Repeat(` . "x"`, depth) + `; ?>`
+	program, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.Len(), depth+1; got != want {
+		t.Fatalf("output length = %d, want %d", got, want)
+	}
+}
+
+func ExampleSupports() {
+	program, _ := parser.Parse(`<?php $a = "flat"; echo $a . "stack"; ?>`)
+	fmt.Println(flatstack.Supports(program) == nil)
+	// Output: true
+}

--- a/runner/expr_cache.go
+++ b/runner/expr_cache.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/expr-lang/expr/vm"
+	flatvm "github.com/titpetric/phpscript/flatstack/engine"
 	"github.com/titpetric/phpscript/model"
 )
 
@@ -15,13 +16,36 @@ type compiledExpr struct {
 	prog     *vm.Program
 }
 
-// ExprCache stores immutable compiled expression programs by transpiled source.
-// AST-specific metadata stays on each Runtime so a shared cache neither retains
-// freshly parsed request ASTs nor reuses closures/nested expressions from a
-// different program.
+// ExprCache stores immutable compiled expression programs by transpiled source
+// and optional flat bytecode by parsed program identity. Expression AST metadata
+// stays runtime-local; flat bytecode retains its source Program for the lifetime
+// of the explicitly shared cache.
 type ExprCache struct {
 	mu    sync.RWMutex
 	bySrc map[string]*vm.Program
+	byAST map[*model.Program]*flatvm.Program
+}
+
+func (c *ExprCache) getFlat(p *model.Program) (*flatvm.Program, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	program, ok := c.byAST[p]
+	return program, ok
+}
+
+func (c *ExprCache) setFlat(p *model.Program, program *flatvm.Program) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.byAST == nil {
+		c.byAST = make(map[*model.Program]*flatvm.Program)
+	}
+	c.byAST[p] = program
 }
 
 // NewExprCache returns an empty compiled expression cache.

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -1,0 +1,174 @@
+package runner
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	flatvm "github.com/titpetric/phpscript/flatstack/engine"
+	"github.com/titpetric/phpscript/model"
+)
+
+func (rt *Runtime) runFlat(ast *model.Program) (bool, error) {
+	if rt.errorHandler != nil {
+		// The interpreter can recover per statement through OnError. The flat
+		// backend currently returns the first execution error.
+		return false, nil
+	}
+	program, ok := rt.exprCache.getFlat(ast)
+	if !ok {
+		var err error
+		program, err = flatvm.Compile(ast)
+		if err != nil {
+			return false, nil
+		}
+		rt.exprCache.setFlat(ast, program)
+	}
+	return true, flatvm.Run(program, flatHost{runtime: rt})
+}
+
+type flatHost struct {
+	runtime *Runtime
+}
+
+func (h flatHost) Construct(class string, args []any) (any, error) {
+	return h.runtime.helperNew(NewScope())(strings.TrimPrefix(class, "\\"), args...)
+}
+
+func (h flatHost) CallMethod(receiver any, method string, args []any) (any, error) {
+	return h.runtime.helperCall(NewScope())(receiver, method, args...)
+}
+
+func (h flatHost) GetProperty(receiver any, name string) any {
+	return h.runtime.helperGet(nil)(receiver, name)
+}
+
+func (h flatHost) Echo(value any) error {
+	_, err := io.WriteString(h.runtime.out, phpString(value))
+	return err
+}
+
+func (h flatHost) Lookup(name string) any {
+	if value, ok := h.runtime.globals[name]; ok {
+		return value
+	}
+	return h.runtime.constants[name]
+}
+
+func (h flatHost) Array(items []model.ArrayItemValue) any { return helperArray(items...) }
+func (h flatHost) Index(base, index any) any              { return helperIndex(base, index) }
+func (h flatHost) Truthy(value any) bool                  { return phpTruthy(value) }
+
+func (h flatHost) SetIndex(base, key, value any, appendValue bool, op string) error {
+	array, ok := base.(*model.Array)
+	if !ok {
+		return fmt.Errorf("assign: target is not an array")
+	}
+	if appendValue {
+		array.Append(value)
+		return nil
+	}
+	key = normalizeKey(key)
+	if op != "" && op != "=" {
+		current, _ := array.Get(key)
+		binaryOp := strings.TrimSuffix(op, "=")
+		var err error
+		value, err = h.Binary(binaryOp, current, value)
+		if err != nil {
+			return err
+		}
+	}
+	array.Set(key, value)
+	return nil
+}
+
+func (h flatHost) Binary(op string, left, right any) (any, error) {
+	switch op {
+	case ".":
+		return helperConcat(left, right), nil
+	case "+", "-", "*", "/", "%":
+		return phpArith(op, left, right), nil
+	case "==":
+		return phpLooseEqual(left, right), nil
+	case "!=":
+		return !phpLooseEqual(left, right), nil
+	case "===", "!==":
+		equal := reflect.TypeOf(left) == reflect.TypeOf(right) && reflect.DeepEqual(left, right)
+		if op == "!==" {
+			equal = !equal
+		}
+		return equal, nil
+	case "&&":
+		return phpTruthy(left) && phpTruthy(right), nil
+	case "||":
+		return phpTruthy(left) || phpTruthy(right), nil
+	case "<", "<=", ">", ">=":
+		var cmp int
+		if isNumeric(left) && isNumeric(right) {
+			a, b := toFloat(left), toFloat(right)
+			if a < b {
+				cmp = -1
+			} else if a > b {
+				cmp = 1
+			}
+		} else {
+			cmp = strings.Compare(phpString(left), phpString(right))
+		}
+		switch op {
+		case "<":
+			return cmp < 0, nil
+		case "<=":
+			return cmp <= 0, nil
+		case ">":
+			return cmp > 0, nil
+		default:
+			return cmp >= 0, nil
+		}
+	default:
+		return nil, fmt.Errorf("unsupported binary operator %q", op)
+	}
+}
+
+func (h flatHost) Unary(op string, value any) (any, error) {
+	switch op {
+	case "!":
+		return !phpTruthy(value), nil
+	case "+":
+		return phpArith("+", int64(0), value), nil
+	case "-":
+		return phpArith("-", int64(0), value), nil
+	default:
+		return nil, fmt.Errorf("unsupported unary operator %q", op)
+	}
+}
+
+func (h flatHost) Entries(value any) []flatvm.Entry {
+	var entries []flatvm.Entry
+	if array, ok := value.(*model.Array); ok {
+		array.Range(func(key, value any) bool {
+			entries = append(entries, flatvm.Entry{Key: key, Value: value})
+			return true
+		})
+		return entries
+	}
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return nil
+	}
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			entries = append(entries, flatvm.Entry{Key: int64(i), Value: rv.Index(i).Interface()})
+		}
+	case reflect.Map:
+		for _, key := range rv.MapKeys() {
+			entries = append(entries, flatvm.Entry{Key: key.Interface(), Value: rv.MapIndex(key).Interface()})
+		}
+	}
+	return entries
+}
+
+func (h flatHost) Call(name, fallback string, args []any) (any, error) {
+	return h.runtime.helperFunc(NewScope())(name, fallback, args...)
+}

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -14,6 +14,18 @@ import (
 var contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
 
+// HostPanicError converts a panic raised by a registered Go constructor,
+// function, or method into the runtime error path. PHP try/catch can therefore
+// handle it like an error returned by the same host callable.
+type HostPanicError struct {
+	Callable string
+	Value    any
+}
+
+func (e *HostPanicError) Error() string {
+	return fmt.Sprintf("host panic in %s: %v", e.Callable, e.Value)
+}
+
 // wantsContext reports whether fn's first parameter is a context.Context.
 func wantsContext(t reflect.Type) bool {
 	return t.Kind() == reflect.Func && t.NumIn() > 0 && t.In(0) == contextType
@@ -182,7 +194,13 @@ func adapt(fn any) func(...any) (any, error) {
 
 // invokeAny calls fn (any Go callable) with args via reflection, coercing
 // arguments to the declared parameter types where convertible.
-func invokeAny(fn any, args []any) (any, error) {
+func invokeAny(fn any, args []any) (result any, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = nil
+			err = &HostPanicError{Callable: fmt.Sprintf("%T", fn), Value: recovered}
+		}
+	}()
 	rv := reflect.ValueOf(fn)
 	if rv.Kind() != reflect.Func {
 		return nil, fmt.Errorf("not callable: %T", fn)
@@ -324,7 +342,16 @@ func (rt *Runtime) helperNew(scope *Scope) func(class string, args ...any) (any,
 // so `$obj->get()` resolves Go's exported Get). When the method's first
 // parameter is a context.Context the runtime context is auto-injected, and
 // arguments are coerced to the declared parameter types.
-func (rt *Runtime) callGoMethod(base any, method string, args []any) (any, error) {
+func (rt *Runtime) callGoMethod(base any, method string, args []any) (result any, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = nil
+			err = &HostPanicError{
+				Callable: fmt.Sprintf("%T::%s", base, method),
+				Value:    recovered,
+			}
+		}
+	}()
 	if base == nil {
 		return nil, fmt.Errorf("call %s on nil", method)
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -60,6 +60,15 @@ func (rt *Runtime) LoadFile(path string) (*model.Program, error) {
 
 // Run executes a whole program in the global scope.
 func (rt *Runtime) Run(p *model.Program) error {
+	if rt.flat {
+		if handled, err := rt.runFlat(p); handled {
+			return err
+		}
+	}
+	return rt.runInterpreted(p)
+}
+
+func (rt *Runtime) runInterpreted(p *model.Program) error {
 	scope := NewScope()
 	for name, val := range rt.globals {
 		scope.Set(name, val)

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -29,6 +29,7 @@ var phpSuperglobals = map[string]struct{}{
 // with registered functions, classes, constructors, and runtime state.
 type Runtime struct {
 	out     io.Writer
+	flat    bool
 	funcs   map[string]any
 	userFns map[string]struct{}
 	wrapped map[string]func(...any) (any, error)
@@ -160,6 +161,15 @@ func environmentSnapshot() map[string]string {
 		env[name] = value
 	}
 	return env
+}
+
+// NewFlatStack returns a Runtime that executes supported programs through the
+// flat bytecode backend and atomically falls back to the interpreter otherwise.
+// Most callers should use flatstack.New, which preserves runner's public API.
+func NewFlatStack(w io.Writer, opts Options) *Runtime {
+	rt := New(w, opts)
+	rt.flat = true
+	return rt
 }
 
 // SetContext installs the lifecycle context auto-injected into registered Go

--- a/stdlib/environment_test.go
+++ b/stdlib/environment_test.go
@@ -1,0 +1,61 @@
+package stdlib_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+func TestEnvironmentIsRuntimeScoped(t *testing.T) {
+	const name = "PHPSCRIPT_ENV_TEST"
+	t.Setenv(name, "host")
+
+	run := func(source string) string {
+		t.Helper()
+		program, err := parser.Parse(source)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		var out strings.Builder
+		rt := runner.New(&out, runner.Options{})
+		stdlib.Register(rt)
+		if err := rt.Run(program); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		return out.String()
+	}
+
+	if got := run(`<?php putenv("PHPSCRIPT_ENV_TEST", "request"); echo getenv("PHPSCRIPT_ENV_TEST");`); got != "request" {
+		t.Fatalf("request environment = %q, want request", got)
+	}
+	if got := run(`<?php echo getenv("PHPSCRIPT_ENV_TEST");`); got != "host" {
+		t.Fatalf("next request environment = %q, want host", got)
+	}
+	if got := os.Getenv(name); got != "host" {
+		t.Fatalf("host environment mutated to %q", got)
+	}
+}
+
+func TestPutenvSupportsAssignmentAndUnset(t *testing.T) {
+	program, err := parser.Parse(`<?php
+putenv("PHPSCRIPT_ASSIGNMENT=value");
+echo getenv("PHPSCRIPT_ASSIGNMENT");
+putenv("PHPSCRIPT_ASSIGNMENT");
+echo getenv("PHPSCRIPT_ASSIGNMENT") === false ? "-missing" : "-present";`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	stdlib.Register(rt)
+	if err := rt.Run(program); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got, want := out.String(), "value-missing"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}

--- a/tests/fixtures_test.go
+++ b/tests/fixtures_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/titpetric/phpscript/flatstack"
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/runner"
 	"github.com/titpetric/phpscript/stdlib"
@@ -300,6 +301,10 @@ echo $storage->tenant() . ":" . $record->value;
 		b.Fatal(err)
 	}
 	sharedExprCache := runner.NewExprCache()
+	flatExprCache := flatstack.NewExprCache()
+	if err := flatstack.Supports(prog); err != nil {
+		b.Fatalf("flatstack benchmark would fall back: %v", err)
+	}
 
 	goHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		storage, err := NewStorage(r.Context())
@@ -325,6 +330,15 @@ echo $storage->tenant() . ":" . $record->value;
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	})
+	flatHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt := flatstack.New(w, flatstack.Options{})
+		rt.SetExprCache(flatExprCache)
+		rt.SetContext(r.Context())
+		rt.RegisterConstructor("Storage", NewStorage)
+		if err := rt.Run(prog); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
 
 	request := httptest.NewRequest(http.MethodGet, "/binding", nil)
 	request = request.WithContext(context.WithValue(request.Context(), tenantKey, "acme"))
@@ -336,6 +350,7 @@ echo $storage->tenant() . ":" . $record->value;
 	}{
 		{name: "go_handler", handler: goHandler},
 		{name: "php_vm_handler", handler: phpHandler},
+		{name: "flatstack_handler", handler: flatHandler},
 	}
 	for _, benchmark := range benchmarks {
 		b.Run(benchmark.name, func(b *testing.B) {

--- a/tests/flatstack_benchmark_test.go
+++ b/tests/flatstack_benchmark_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+)
+
+// BenchmarkFlatstackMinitplImportSwap quantifies the compatibility-fallback
+// cost for a real application fixture that is not yet in the bytecode subset.
+func BenchmarkFlatstackMinitplImportSwap(b *testing.B) {
+	source, err := fixturesFS.ReadFile("fixtures/test-minitpl.php")
+	if err != nil {
+		b.Fatal(err)
+	}
+	program, err := parser.Parse(string(source))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err == nil {
+		b.Fatal("minitpl unexpectedly became a flat-bytecode benchmark; update this benchmark")
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var output strings.Builder
+		runtime := newFlatstackTestRuntime(&output, b.Context())
+		if err := runtime.Run(program); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/tests/flatstack_fixtures_test.go
+++ b/tests/flatstack_fixtures_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"context"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+var flatIncludeCache = flatstack.NewIncludeCache()
+var flatExprCache = flatstack.NewExprCache()
+
+func newFlatstackTestRuntime(out *strings.Builder, ctx context.Context, input ...*strings.Reader) *flatstack.Runtime {
+	options := flatstack.Options{RootFS: testPHPFS()}
+	if len(input) > 0 {
+		options.Stdin = input[0]
+	}
+	runtime := flatstack.New(out, options)
+	runtime.SetIncludeCache(flatIncludeCache)
+	runtime.SetExprCache(flatExprCache)
+	runtime.SetContext(context.WithValue(ctx, tenantKey, "acme"))
+	runtime.RegisterConstructor("Storage", NewStorage)
+	runtime.RegisterConstructor("FailStorage", NewFailStorage)
+	stdlib.RegisterFS(runtime, ".")
+	stdlib.Register(runtime)
+	return runtime
+}
+
+func runFlatstackFixture(ctx context.Context, fixture fixture) (string, error) {
+	program, err := parser.Parse(fixture.PHP)
+	if err != nil {
+		return "Internal Server Error", err
+	}
+	var output strings.Builder
+	runtime := newFlatstackTestRuntime(&output, ctx, strings.NewReader(fixture.Stdin))
+	if err := runtime.Run(program); err != nil {
+		if _, ok := flatstack.IsExit(err); ok {
+			return output.String(), nil
+		}
+		return "Internal Server Error", err
+	}
+	return output.String(), nil
+}
+
+// TestFlatstackImportSwapFixtures runs the end-to-end fixture contract through
+// the flatstack import. Currently supported ASTs use bytecode and the remainder
+// exercise the compatibility fallback.
+func TestFlatstackImportSwapFixtures(t *testing.T) {
+	entries, err := fs.ReadDir(fixturesFS, "fixtures")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".phpt") {
+			continue
+		}
+		data, err := fixturesFS.ReadFile("fixtures/" + entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixture, err := parseFixture(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run(fixture.Name, func(t *testing.T) {
+			output, runErr := runFlatstackFixture(t.Context(), fixture)
+			if fixture.Error != "" {
+				if runErr == nil || !errorChainContains(runErr, fixture.Error) {
+					t.Fatalf("error = %v, want containing %q", runErr, fixture.Error)
+				}
+			} else if runErr != nil {
+				t.Fatalf("unexpected error: %v", runErr)
+			}
+			got := strings.TrimRight(output, "\n")
+			want := strings.TrimRight(fixture.Expected, "\n")
+			if got != want {
+				t.Fatalf("output mismatch\n got: %q\nwant: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFlatstackNativeFixtureCoverage(t *testing.T) {
+	expectedNative := map[string]bool{
+		"array_indexing.phpt":                   true,
+		"autoloading_default.phpt":              true,
+		"autoloading_missing.phpt":              true,
+		"condition_syntax.phpt":                 true,
+		"die_exit.phpt":                         true,
+		"exception.phpt":                        true,
+		"stdin.phpt":                            true,
+		"storage_constructor_error.phpt":        true,
+		"storage_constructor_error_caught.phpt": true,
+		"storage_context.phpt":                  true,
+		"storage_lifecycle.phpt":                true,
+		"storage_list.phpt":                     true,
+		"storage_method_error.phpt":             true,
+		"storage_method_error_caught.phpt":      true,
+	}
+	entries, err := fs.ReadDir(fixturesFS, "fixtures")
+	if err != nil {
+		t.Fatal(err)
+	}
+	native, total := 0, 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".phpt") {
+			continue
+		}
+		total++
+		data, err := fixturesFS.ReadFile("fixtures/" + entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixture, err := parseFixture(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		program, err := parser.Parse(fixture.PHP)
+		if err != nil {
+			t.Fatal(err)
+		}
+		isNative := flatstack.Supports(program) == nil
+		if isNative {
+			native++
+		}
+		if isNative != expectedNative[entry.Name()] {
+			t.Errorf("%s native = %v, want %v", entry.Name(), isNative, expectedNative[entry.Name()])
+		}
+	}
+	if native != len(expectedNative) || total != 28 {
+		t.Fatalf("native=%d fallback=%d total=%d; want native=%d total=28", native, total-native, total, len(expectedNative))
+	}
+	t.Logf("flatstack fixture coverage: native=%d fallback=%d total=%d", native, total-native, total)
+}

--- a/tests/flatstack_fuzz_test.go
+++ b/tests/flatstack_fuzz_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+)
+
+// FuzzFlatstackImportSwapFallback differentially checks native flat bytecode
+// against runner with bounded arithmetic programs. The historical name remains
+// stable so existing fuzz corpora and CI commands keep working.
+func FuzzFlatstackImportSwapFallback(f *testing.F) {
+	f.Add(int64(20), int64(22), uint8(0))
+	f.Add(int64(-5), int64(9), uint8(1))
+	f.Add(int64(7), int64(6), uint8(2))
+
+	f.Fuzz(func(t *testing.T, left, right int64, operation uint8) {
+		operators := [...]string{"+", "-", "*"}
+		op := operators[int(operation)%len(operators)]
+		source := fmt.Sprintf("<?php echo %d %s %d; ?>", left, op, right)
+		program, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := flatstack.Supports(program); err != nil {
+			t.Fatalf("arithmetic left native flat bytecode: %v", err)
+		}
+
+		var runnerOutput strings.Builder
+		runnerRuntime := runner.New(&runnerOutput, runner.Options{})
+		runnerErr := runnerRuntime.Run(program)
+
+		var flatOutput strings.Builder
+		flatRuntime := flatstack.New(&flatOutput, flatstack.Options{})
+		flatErr := flatRuntime.Run(program)
+
+		if (runnerErr == nil) != (flatErr == nil) {
+			t.Fatalf("error mismatch: runner=%v flatstack=%v", runnerErr, flatErr)
+		}
+		if runnerOutput.String() != flatOutput.String() {
+			t.Fatalf("output mismatch: runner=%q flatstack=%q", runnerOutput.String(), flatOutput.String())
+		}
+	})
+}


### PR DESCRIPTION
This PR adds the following:

- Add flatstack/ package, tests and docs. It's passing for about 50% of .phpt fixtures

 _Re: @hazyhaar in [#6](https://github.com/titpetric/phpscript/issues/6#issuecomment-5213809415)_

The proposed engine doesn't really have parity with phpscript, reimplements some "standard library" functions, doesn't properly evaluate php open/close tags, and also omits some things that are implemented in phpscript (compact, ...). This is an attempt to wrap/provide a flatstack/ package while maintaining compatibility with the existing APIs.

It would be possible to interface the runner.Runner type so it could be used with flatstack.Runner and allow for reuse of the existing bindings from stdlib/ ; there's a heuristic which falls back from the flatstack runner to the normal runner if some unsupported ast is encountered. The github repo with the flat-stack engine also just implements CleanPHP, trimming the php tags from source code, rather than respecting they can be reused in chunks, e.g. this is valid code:

```php
<?php

$arr = [1,2,3];
for ($arr as $value) {
    ?><h1>Heading <?php echo $value; ?></h1><?php
}
```

The minitpl/smarty/latte flavoured template would be somewhat like this:

```smarty
{foreach $arr as $value}
   <h1>Heading {value}</h1>
{/foreach}
```

while not the greatest example, it's close to how template engines work, they replace known template syntax in various template tags with php code snippets so `<h1>Heading {value}</h1>` is converted to something like the above php code and then just executed with the help of `include` or `eval`.

---

Status for the PR: under review, evaluation, consideration and testing. The benchmarks need more work so both the flat stack approach and runner can be compared, and the flat stack needs to be extended further. The biggest concern is usage of expr-lang to provide the go api bridge and needing to fall back to the runner package for unsupported AST's.

The recover() of panics to promote them to an Exception is another thing that's added here, but will likely be added to the main branch separately. It's only handling panics in invoked go native code, not panics which may occur in go runtime from other usage. The healthy suggestion is to not use `panic` calls in go and return an error when you can.