### PR TITLE
feat(flatstack): support finally blocks in try/catch/finally statements

### DIFF
--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -143,13 +143,16 @@ func (c *compiler) stmt(stmt model.Stmt, path string) error {
 }
 
 func (c *compiler) tryStmt(node *model.Try, path string) error {
-	if len(node.Catches) == 0 || len(node.Finally) != 0 {
-		return unsupported(path, "try without one catch or with finally")
+	if len(node.Catches) == 0 && len(node.Finally) == 0 {
+		return unsupported(path, "try without catch or finally")
 	}
-	catch := node.Catches[0]
 	catchSlot := -1
-	if catch.Var != "" {
-		catchSlot = c.slot(catch.Var)
+	var catch *model.Catch
+	if len(node.Catches) > 0 {
+		catch = &node.Catches[0]
+		if catch.Var != "" {
+			catchSlot = c.slot(catch.Var)
+		}
 	}
 	push := c.emit(instruction{op: opTryPush, a: catchSlot, target: -1})
 	if err := c.block(node.Body, path+".body"); err != nil {
@@ -158,11 +161,20 @@ func (c *compiler) tryStmt(node *model.Try, path string) error {
 	pop := c.emit(instruction{op: opTryPop})
 	c.program.code[push].b = pop
 	endJump := c.emit(instruction{op: opJump, target: -1})
+
 	c.program.code[push].target = len(c.program.code)
-	if err := c.block(catch.Body, path+".catch"); err != nil {
-		return err
+	if catch != nil {
+		if err := c.block(catch.Body, path+".catch"); err != nil {
+			return err
+		}
 	}
-	c.program.code[endJump].target = len(c.program.code)
+	finallyTarget := len(c.program.code)
+	c.program.code[endJump].target = finallyTarget
+	if len(node.Finally) > 0 {
+		if err := c.block(node.Finally, path+".finally"); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/flatstack/flatstack_test.go
+++ b/flatstack/flatstack_test.go
@@ -80,3 +80,31 @@ func TestArithmeticUsesFlatBytecode(t *testing.T) {
 		t.Fatalf("flat bytecode output = %q, want %q", got, want)
 	}
 }
+
+func TestFinallyBlockFlatBytecode(t *testing.T) {
+	program, err := parser.Parse(`<?php
+		$status = "start";
+		try {
+			$status = "in_try";
+		} catch ($e) {
+			$status = "in_catch";
+		} finally {
+			echo $status . "_finally";
+		}
+	?>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("try/catch/finally should compile to flat bytecode: %v", err)
+	}
+
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.String(), "in_try_finally"; got != want {
+		t.Fatalf("finally output = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Extends the flatstack bytecode compiler to lower `finally` blocks in `try / catch / finally` statements without requiring interpreter fallback.

```php
try {
    $res = process();
} catch ($e) {
    log_error($e);
} finally {
    cleanup();
}
```