### PR TITLE
feat(status): durable trace storage — disk driver, sampling, streamed permalinks

### DIFF
--- a/stdlib/status/driver_disk.go
+++ b/stdlib/status/driver_disk.go
@@ -1,0 +1,107 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// Storage persists completed request traces beyond process restarts and
+// returns them for permalinks. Put stores one completed Request under its
+// ULID; Get returns the stored record as a stream so a handler can carry
+// it straight into the HTTP response body without decoding.
+type Storage interface {
+	Put(ctx context.Context, record *Request) error
+	Get(ctx context.Context, id string) (io.ReadCloser, error)
+}
+
+// ulidRe matches the Crockford base32 ULIDs issued by newULID. Validation
+// happens before any path is built, so no request id can escape the
+// storage directory.
+var ulidRe = regexp.MustCompile(`^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$`)
+
+// DiskStorage stores one <ULID>.json per record under a directory. The
+// directory may live on tmpfs (e.g. /dev/shm/phpscript-trace-detail) so
+// records survive restarts without disk I/O; cleanup is left to an
+// external job over plain files, as ULID filenames sort by time.
+type DiskStorage struct {
+	dir string
+}
+
+// NewDiskStorage creates the directory (0700) if needed and returns the
+// driver.
+func NewDiskStorage(dir string) (*DiskStorage, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("status: disk storage requires a path")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("status: disk storage: %w", err)
+	}
+	return &DiskStorage{dir: dir}, nil
+}
+
+func (d *DiskStorage) path(id string) (string, error) {
+	if !ulidRe.MatchString(id) {
+		return "", fmt.Errorf("status: invalid record id %q", id)
+	}
+	return filepath.Join(d.dir, id+".json"), nil
+}
+
+// Put writes the record atomically (temp file + rename): a permalink
+// either sees the whole record or a 404, never a torn file.
+func (d *DiskStorage) Put(ctx context.Context, record *Request) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dst, err := d.path(record.ID)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(d.dir, record.ID+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if err := json.NewEncoder(tmp).Encode(record); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, dst)
+}
+
+// Get returns the stored record file as an io.ReadCloser. The caller may
+// copy it directly into the response body (the ideal state for JSON
+// permalinks) or decode it for HTML rendering.
+func (d *DiskStorage) Get(ctx context.Context, id string) (io.ReadCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	p, err := d.path(id)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(p)
+}
+
+// sampled reports whether one trace should be written out, for a sampling
+// percentage between 0 and 100. The trace is always collected in memory;
+// sampling only gates the storage write.
+func sampled(percent float64) bool {
+	if percent >= 100 {
+		return true
+	}
+	if percent <= 0 {
+		return false
+	}
+	return rand.Float64()*100 < percent
+}

--- a/stdlib/status/driver_disk_test.go
+++ b/stdlib/status/driver_disk_test.go
@@ -1,0 +1,140 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testULID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+func TestDiskStoragePutGetRoundtrip(t *testing.T) {
+	d, err := NewDiskStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := &Request{ID: testULID, Request: "GET /x", Duration: 3 * time.Millisecond}
+	if err := d.Put(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := d.Get(context.Background(), testULID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	var got Request
+	if err := json.NewDecoder(rc).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != rec.ID || got.Request != rec.Request {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestDiskStorageRejectsInvalidIDs(t *testing.T) {
+	dir := t.TempDir()
+	d, err := NewDiskStorage(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"", "../../etc/passwd", "short", strings.Repeat("A", 27), "01arz3ndektsv4rrffq69g5fav"} {
+		if err := d.Put(context.Background(), &Request{ID: id}); err == nil {
+			t.Errorf("Put(%q) accepted", id)
+		}
+		if _, err := d.Get(context.Background(), id); err == nil {
+			t.Errorf("Get(%q) accepted", id)
+		}
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("directory not empty after rejected ids: %v", entries)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "..", "etc")); !os.IsNotExist(err) {
+		t.Fatalf("traversal artifact: %v", err)
+	}
+}
+
+func TestSampledBounds(t *testing.T) {
+	if !sampled(100) || !sampled(150) {
+		t.Fatal("sampling >= 100 must always write")
+	}
+	if sampled(0) || sampled(-1) {
+		t.Fatal("sampling <= 0 must never write")
+	}
+	hits := 0
+	for i := 0; i < 10000; i++ {
+		if sampled(0.5) {
+			hits++
+		}
+	}
+	// 0.5% of 10000 = ~50; accept a generous band.
+	if hits == 0 || hits > 300 {
+		t.Fatalf("sampled(0.5) hit %d/10000, outside plausible band", hits)
+	}
+}
+
+func TestFinishWritesSampledTrace(t *testing.T) {
+	dir := t.TempDir()
+	s := NewModule(Options{RingBufferSize: 4, TopRequests: 5, Driver: "disk", Path: dir, Sampling: 100})
+	handler := s.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hello", nil))
+	id := rec.Header().Get("Request-Id")
+	if id == "" {
+		t.Fatal("no Request-Id issued")
+	}
+	if _, err := os.Stat(filepath.Join(dir, id+".json")); err != nil {
+		t.Fatalf("trace not written: %v", err)
+	}
+}
+
+func TestFinishSamplingZeroWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	s := NewModule(Options{RingBufferSize: 4, TopRequests: 5, Driver: "disk", Path: dir, Sampling: 0})
+	handler := s.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/hello", nil))
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("sampling=0 wrote %d files", len(entries))
+	}
+}
+
+// TestDetailPermalinkFromStorage proves the permalink case of the issue:
+// the record is gone from the in-memory ring but survives on disk; JSON
+// requests get the stored file streamed straight into the body.
+func TestDetailPermalinkFromStorage(t *testing.T) {
+	dir := t.TempDir()
+	s := NewModule(Options{RingBufferSize: 4, TopRequests: 5, Driver: "disk", Path: dir, Sampling: 100})
+	rec := &Request{ID: testULID, Request: "GET /old", ResponseStatus: 200}
+	if err := s.storage.Put(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+	// Not in history (fresh module) — must come from storage.
+	req := httptest.NewRequest(http.MethodGet, ServerStatusDetailPath+testULID, nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	var got Request
+	if err := json.Unmarshal(body, &got); err != nil || got.ID != testULID {
+		t.Fatalf("streamed permalink wrong: %v %s", err, body)
+	}
+	// Unknown id still 404s.
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, ServerStatusDetailPath+"01ARZ3NDEKTSV4RRFFQ69G5FAX", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing id code = %d", w.Code)
+	}
+}

--- a/stdlib/status/middleware.go
+++ b/stdlib/status/middleware.go
@@ -143,21 +143,37 @@ type ServerStatus struct {
 	allocated uint64
 	stateTime map[model.Status]time.Duration
 	options   Options
+	storage   Storage
 }
 
 var _ platform.Module = (*ServerStatus)(nil)
 
 var _ model.Tracer = (*ServerStatus)(nil)
 
-// NewModule creates an empty status module.
+// NewModule creates an empty status module. An unknown Driver or a failing
+// storage path is surfaced on stderr and telemetry continues memory-only:
+// the status page must never take the server down.
 func NewModule(options Options) *ServerStatus {
-	return &ServerStatus{
+	s := &ServerStatus{
 		UnimplementedModule: *platform.NewUnimplementedModule("status"),
 		started:             time.Now(),
 		active:              make(map[string]*Request),
 		stateTime:           make(map[model.Status]time.Duration),
 		options:             options,
 	}
+	switch options.Driver {
+	case "":
+	case "disk":
+		storage, err := NewDiskStorage(options.Path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "status: %v — trace detail storage disabled\n", err)
+		} else {
+			s.storage = storage
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "status: unknown driver %q — trace detail storage disabled\n", options.Driver)
+	}
+	return s
 }
 
 // NewServerStatus creates an empty status module.
@@ -319,6 +335,15 @@ func (s *ServerStatus) finish(ctx context.Context, entry *Request, rw *responseW
 	s.history = append(s.history, *entry)
 	if len(s.history) > s.options.RingBufferSize {
 		s.history = append(s.history[:0], s.history[len(s.history)-s.options.RingBufferSize:]...)
+	}
+	// Flush the completed trace to durable storage, sampling-gated. The
+	// write happens outside the request path (finish already runs after the
+	// response); a storage error only costs the permalink, never the page.
+	if s.storage != nil && sampled(s.options.Sampling) {
+		record := *entry
+		if err := s.storage.Put(ctx, &record); err != nil {
+			fmt.Fprintf(os.Stderr, "status: trace storage put %s: %v\n", record.ID, err)
+		}
 	}
 }
 
@@ -665,6 +690,23 @@ func (s *ServerStatus) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *ServerStatus) serveDetail(w http.ResponseWriter, r *http.Request, id string) {
 	request, ok := s.completedRequest(id)
+	if !ok && s.storage != nil {
+		rc, err := s.storage.Get(r.Context(), id)
+		if err == nil {
+			defer rc.Close()
+			accept := strings.ToLower(r.Header.Get("Accept"))
+			if strings.Contains(accept, "text/json") || strings.Contains(accept, "application/json") {
+				// Ideal state: carry the stored file straight into the
+				// response body, no decode round trip.
+				w.Header().Set("Content-Type", "text/json; charset=utf-8")
+				_, _ = io.Copy(w, rc)
+				return
+			}
+			if decodeErr := json.NewDecoder(rc).Decode(&request); decodeErr == nil {
+				ok = true
+			}
+		}
+	}
 	if !ok {
 		http.NotFound(w, r)
 		return

--- a/stdlib/status/options.go
+++ b/stdlib/status/options.go
@@ -12,6 +12,19 @@ type Options struct {
 
 	// TrackMemoryUse records process-wide allocation changes for each request.
 	TrackMemoryUse bool `yaml:"track_memory_use"`
+
+	// Driver selects a durable storage for trace detail ("" = none,
+	// "disk" = one <ULID>.json per record under Path).
+	Driver string `yaml:"driver"`
+
+	// Path is the storage directory for Driver, e.g.
+	// /dev/shm/phpscript-trace-detail (tmpfs: survives restarts, no disk IO).
+	Path string `yaml:"path"`
+
+	// Sampling is the percentage (0-100) of completed traces written out to
+	// the storage driver. The trace is always collected in memory; sampling
+	// only gates the write. Values like 0.5 are valid.
+	Sampling float64 `yaml:"sampling"`
 }
 
 // NewOptions returns the default status page options.
@@ -20,5 +33,6 @@ func NewOptions() Options {
 		RingBufferSize: 100,
 		TopRequests:    20,
 		TrackMemoryUse: true,
+		Sampling:       100,
 	}
 }


### PR DESCRIPTION
Implements #23 — scoped to `stdlib/status` only.

## What's in

- `Storage` interface (`Put`/`Get` taking `context.Context`) and a `DiskStorage` driver: one `<ULID>.json` per record under a configurable path. A tmpfs path like `/dev/shm/phpscript-trace-detail` works as suggested — records survive restarts with no disk IO. Puts are atomic (temp file + rename), and ids are validated against the ULID alphabet before any path is built.
- Options extended: `driver` (`""` | `disk`), `path`, and `sampling` (float 0–100, `0.5` valid). The trace is always collected in memory; sampling only gates the storage write.
- Permalinks: `/debug/server-status/detail/<id>` falls back to storage when the id has rotated out of the in-memory ring. JSON requests get the stored file carried straight into the response body (`io.Copy`, no decode round trip) — the "ideal state" from the issue. HTML/text decode and render as before.
- Failure containment: unknown driver or failing path degrades to memory-only telemetry with a stderr notice — the status page never takes the server down.
- Cleanup stays external as suggested (plain files, ULID names sort by time — a cron one-liner).

## Shape

Kept dependency-free/inlined per the direction in #19. The `Storage` interface makes swapping in an external backend (e.g. the `recordlog` package discussed in the issue) a one-file change if you ever want it.

## Testing

- Unit tests: put/get roundtrip, id rejection with traversal proof, sampling bounds, middleware write-through, permalink served from storage after ring rotation, 404 on unknown id.
- `go test -race ./stdlib/status` green; full repo suite green (15 packages); `phpscript lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
