### PR TITLE
perf: cut fixture allocations by 80%

### DIFF
--- a/cmd/phpscript/ast/run.go
+++ b/cmd/phpscript/ast/run.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/titpetric/cli"
 
-	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 )
 
@@ -39,16 +38,12 @@ func Run(args []string) error {
 	return nil
 }
 
-func printTokens(tokens *model.Array) {
-	tokens.Range(func(_, val any) bool {
-		if tok, ok := val.(*model.Array); ok {
-			id, _ := tok.Get(int64(0))
-			text, _ := tok.Get(int64(1))
-			line, _ := tok.Get(int64(2))
-			fmt.Printf("%4d  %-28s  %q\n", line, parser.TokenName(int(id.(int64))), text)
-			return true
+func printTokens(tokens []any) {
+	for _, val := range tokens {
+		if tok, ok := val.([]any); ok {
+			fmt.Printf("%4d  %-28s  %q\n", tok[2], parser.TokenName(int(tok[0].(int64))), tok[1])
+			continue
 		}
 		fmt.Printf("      %-28s  %q\n", "CHAR", val)
-		return true
-	})
+	}
 }

--- a/docs/allocation-performance.md
+++ b/docs/allocation-performance.md
@@ -24,26 +24,32 @@ Same five-element list, five representations:
 
 | Return shape                 | B/op | allocs/op | ns/op |
 |------------------------------|-----:|----------:|------:|
-| `[]string`, no copy          |   48 |         2 |   218 |
-| `[]string`                   |  128 |         3 |   313 |
-| `any` holding `[]string`     |  144 |         4 |   325 |
-| `[]any`                      |  208 |         8 |   443 |
-| `*model.Array`               |  728 |        13 |  1121 |
-| `any` holding `*model.Array` |  744 |        14 |  1268 |
+| `[]string`, no copy          |   48 |         2 |   254 |
+| `[]string`                   |  128 |         3 |   328 |
+| `any` holding `[]string`     |  144 |         4 |   313 |
+| `[]any`                      |  208 |         8 |   469 |
+| `*model.Array`               |  408 |        11 |   724 |
+| `any` holding `*model.Array` |  424 |        12 |   814 |
 
 Five rows of two columns — the database shape:
 
 | Return shape                     | B/op | allocs/op | ns/op |
 |----------------------------------|-----:|----------:|------:|
-| `[]map[string]any`               | 1856 |        18 |  1793 |
-| `*model.Array` of `*model.Array` | 2888 |        38 |  4788 |
+| `[]map[string]any`               | 1856 |        18 |  1635 |
+| `*model.Array` of `*model.Array` | 2648 |        36 |  2750 |
 
 `explode(",", "a,b,c,d,e")`, before and after this guideline was applied:
 
 | Implementation       | B/op | allocs/op | ns/op |
 |----------------------|-----:|----------:|------:|
-| `[]string` (now)     |  128 |         3 |   457 |
-| `*model.Array` (was) |  808 |        14 |  1347 |
+| `[]string` (now)     |  128 |         3 |   412 |
+| `*model.Array` (was) |  488 |        12 |   765 |
+
+The `*model.Array` rows are cheaper than they used to be — 728 B/13 allocs and
+2888 B/38 in an earlier revision of this document — because `model.Array` now
+has a list mode (see the audit at the bottom). The ordering of the table is
+unchanged: a slice still beats it, and the gap on the nested database shape is
+still an order of magnitude in time.
 
 ## The rules
 
@@ -157,21 +163,65 @@ Sources: [Stack Allocations and Escape Analysis](https://goperf.dev/01-common-pa
 [Memory Preallocation](https://goperf.dev/01-common-patterns/mem-prealloc/),
 [Escape Analysis in Go](https://blog.jetbrains.com/go/2026/07/20/escape-analysis/).
 
-## The bigger lever
+## The bigger lever (fixed)
 
-Before optimising a return shape, know what it is competing with.
-`runner.baseEnv` rebuilds the expression environment on **every** `Eval`,
-allocating one closure per registered function. The same script, run against a
-runtime with the full stdlib versus one with a single binding registered:
+This section used to say that the size of the function table was the dominant
+cost: `runner.baseEnv` rebuilt the expression environment on **every** `Eval`,
+allocating one closure per registered function, and roughly 78% of a script's
+allocations were that rebuild. The same script against a runtime with the full
+stdlib versus one with a single binding registered measured 649 vs 145
+allocs/op.
+
+It no longer does. `runner` now:
+
+- pools evaluation environments per `Runtime` (`acquireEnv` / `releaseEnv`) and
+  reaches the registered function's scope through a `scopeRef` indirection
+  instead of capturing it, so an environment is built once rather than per
+  `Eval`;
+- populates an environment with the functions an expression actually calls, on
+  demand (`Runtime.installFunc`, fed by `Transpiler.Calls`), instead of the
+  whole table;
+- caches the expr compile configuration per function-table generation
+  (`Runtime.exprConfig`) and builds its type-env nature directly
+  (`typeEnvNature`) rather than letting expr walk the table reflectively.
 
 | Runtime                    | B/op  | allocs/op | ns/op |
 |----------------------------|------:|----------:|------:|
-| full stdlib (80 functions) | 28031 |       649 | 55986 |
-| one binding                |  3822 |       145 | 14627 |
+| full stdlib (was)          | 28031 |       649 | 55986 |
+| one binding (was)          |  3822 |       145 | 14627 |
+| full stdlib (now)          |   929 |        24 |  5562 |
+| one binding (now)          |   929 |        24 |  4936 |
 
-Roughly 78% of a script's allocations are the size of the function table,
-re-paid per expression. That dwarfs every return shape in this document.
+The two are now identical: a script pays for the functions it calls, not for
+the size of the table it could call from.
 `BenchmarkScriptEnvFullStdlib` / `BenchmarkScriptEnvMinimal` measure it.
+
+### The compile-time type env, and why it is still there
+
+The third bullet was the single largest item in the tree once the runtime env
+was fixed: `expr.Compile(src, expr.Env(typeEnv), ...)` makes expr walk the
+whole ~95-entry type-env map through `reflect.Value.MapKeys` + `MapIndex` +
+`copyVal` on **every compile**. That was 64% of all allocations.
+
+The obvious fix — drop `expr.Env` entirely, since PHP is dynamically typed and
+the comment above `Runtime.compile` claimed we compiled without type
+information anyway — is **wrong, and silently so**. `expr/parser.parseCall`
+checks its own `predicates` table *before* the disabled-builtins list, and the
+only thing that stops a name being parsed as expr's predicate syntax is
+`conf.Config.IsOverridden(name)`, which consults `Config.Env`. PHP's `count`,
+`map`, `filter`, `find`, `sum`, `reduce` and `sortBy` all collide.
+`expr.DisableAllBuiltins()` does not cover this. With no env, `count($x)`
+compiles to expr's `count` predicate instead of the registered PHP function.
+
+So the env stays; what was removed is the per-compile cost of deriving it. The
+config is built once per function-table generation, and because every entry is
+the same shared stub, one `nature.Nature` is derived and reused for all keys
+(`typeEnvNature`) instead of one reflective walk per key.
+
+If you change any of this, `runner/compile_test.go::TestCompileMatchesExprEnv`
+is the guard: it compiles a corpus both ways and diffs
+`vm.Program.Disassemble()`, so a config change that alters emitted bytecode
+fails loudly rather than becoming a subtle interpreter bug.
 
 ## How to measure
 
@@ -206,7 +256,7 @@ available.
 |----------------|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `array_keys`   | `[]any`, presized                                   | OK                                                                                                                                        |
 | `array_map`    | `([]any, error)`, presized                          | OK                                                                                                                                        |
-| `array_merge`  | `*model.Array`, presized                            | OK (by design) — merges string keys. **TODO:** return `[]any` when every input is a list, which is the common `call_user_func_array` case |
+| `array_merge`  | `*model.Array`, presized                            | OK (by design) — merges string keys. Returning `[]any` for the all-lists case was tried and reverted: once `model.Array` gained list mode it measured 8 allocs either way, and the slice cannot serve `$x = array_merge($a, $b); $x[] = "z"` (rule 4) |
 | `array_slice`  | `[]any`, exact size                                 | OK                                                                                                                                        |
 | `array_splice` | `([]any, error)`                                    | OK (by design) — resizes its argument, so it requires `*model.Array` and now errors instead of panicking on a slice                       |
 | `array_unique` | `*model.Array`, presized                            | OK (by design) — preserves keys                                                                                                           |
@@ -222,8 +272,8 @@ available.
 |------------------------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `explode`                                                                    | `[]string` from `strings.Split`       | OK                                                                                                                                                                                     |
 | `implode`                                                                    | `string`, `[]string` fast path        | OK                                                                                                                                                                                     |
-| `htmlspecialchars`                                                           | `string`                              | **TODO:** builds a `strings.NewReplacer` on every call. Hoist to a package-level `var`. Called once per template variable, so this is the hottest fixable allocation in the string set |
-| `crc32`                                                                      | `int64`                               | **TODO (verify):** `[]byte(s)` conversion per call. Escape analysis may already stack-allocate it; confirm with `go build -gcflags=-m ./stdlib` before changing anything               |
+| `htmlspecialchars`                                                           | `string`                              | OK — the `strings.Replacer` is now a package-level `var` (was rebuilt per call: 11 allocs → 2)                                                                                        |
+| `crc32`                                                                      | `int64`                               | OK — the `[]byte(s)` conversion *did* escape (`crc32.ChecksumIEEE` leaks its argument). Now a package-level table plus a byte-wise loop for inputs ≤ 256 B: 1 alloc → 0               |
 | `sprintf`                                                                    | `string`                              | OK — `fmt` boxes its arguments, but the VM already handed them over as `any`                                                                                                           |
 | `str_replace`                                                                | `string`                              | OK — reads any collection shape                                                                                                                                                        |
 | `strlen`, `str_repeat`, `strtoupper`, `strtolower`, `trim`, `ltrim`, `rtrim` | `int64` / `string`                    | OK                                                                                                                                                                                     |
@@ -275,9 +325,9 @@ available.
 | `get_include_path`, `php_sapi_name`                          | `string`                               | OK                                                                                                                                                                                                                              |
 | `get_defined_constants`                                      | `*model.Array`, presized               | OK (by design) — sorted listing                                                                                                                                                                                                 |
 | `get_defined_vars`                                           | `*model.Array`, presized               | OK (by design) — sorted listing                                                                                                                                                                                                 |
-| `getallheaders`, `get_all_headers`, `apache_request_headers` | `*model.Array` via `runner.mapToArray` | OK (by design) — sorted for determinism. **TODO:** presize with `model.NewArraySize`; once per request, so low value                                                                                                            |
+| `getallheaders`, `get_all_headers`, `apache_request_headers` | `*model.Array` via `runner.mapToArray` | OK (by design) — sorted for determinism; `mapToArray` presizes with `model.NewArraySize`                                                                                                                                       |
 | `phpinfo`                                                    | `(bool, error)`                        | OK                                                                                                                                                                                                                              |
-| `token_get_all`                                              | `*model.Array` of `*model.Array`       | **TODO:** the worst remaining shape. One nested array per token, and the minitpl compiler tokenises every template. `[]any` of `[]any` (or a `[]Token` struct slice) would cut it by roughly 4x. Lives in `parser/tokenizer.go` |
+| `token_get_all`                                              | `[]any` of `[]any`                     | OK — was `*model.Array` of `*model.Array`. Triples are carved out of chunked backing arrays and ids/lines come from a pre-boxed table: 6003 → 1828 allocs on a 5.6 KB template          |
 | `token_name`                                                 | `string`                               | OK                                                                                                                                                                                                                              |
 
 ### Language and control
@@ -308,12 +358,15 @@ available.
 | `Session\Manager`                                | `(*SessionManager, error)`; `Get` `(string, error)`, `Valid` `(bool, error)`, `Start` `error`  | OK                                                                                                                                                                                          |
 | `Session\Storage\Disk`, `Session\Storage\Memory` | pointers                                                                                       | OK                                                                                                                                                                                          |
 | `SharedMemory`                                   | `*SharedMemory`; `Get`/`Count` `string`, `Incr` `int64`, `Has`/`Delete` `bool`                 | OK                                                                                                                                                                                          |
-| `Exception`                                      | `(Exception, error)` — a struct **value**                                                      | **TODO:** returning a value boxes a copy of the struct, and PHP cannot write to its fields. `*Exception` costs the same one allocation and keeps reference semantics                        |
+| `Exception`                                      | `(*Exception, error)`                                                                          | OK — was a struct **value**, which boxed a copy and left `$e->message = "x"` failing with "not a writable object property". The pointer costs the same one allocation                       |
 
 ### Outside the binding layer
 
 | Item                    | Status                                                                                                                                                                                                                                                                                                       |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `runner.baseEnv`        | **TODO, highest value.** One closure allocated per registered function per `Eval` — around 78% of a script's allocations. Candidates: build the closure set once per `Run` and rebind the scope, or key the env off a shared immutable table with the scope passed through a field rather than a capture     |
-| `parser.TokenGetAll`    | **TODO:** see `token_get_all` above                                                                                                                                                                                                                                                                          |
-| `model.Array` internals | **TODO, broad:** a list-mode `Array` that keeps values in a `[]any` and allocates the `map[any]any` only when a non-sequential key appears would cut every remaining `*model.Array` from ~11 allocations to ~7, including PHP array literals built by `helperArray` — the hottest array path in any template |
+| `runner.baseEnv`        | **Done.** Replaced by pooled environments with on-demand function installation and a cached compile config — see "The bigger lever (fixed)" above                                                                                                                                                             |
+| `parser.TokenGetAll`    | **Done.** See `token_get_all` above                                                                                                                                                                                                                                                                          |
+| `model.Array` internals | **Done.** `Array` has a list mode: while every key is the dense sequence `0..n-1` the values live in a `[]any` and neither the `map[any]any` nor the key slice is allocated. The first key that breaks the invariant promotes it, permanently. A 5-element build went 11 → 9 allocs, 50 elements 66 → 57, and `Range` over a list is ~17x faster with zero allocations |
+| `parser` lexer / AST    | **Done.** Operator tokens come from a package-level table of substrings instead of `string(c)` per token, the token slice is presized, and AST nodes are carved out of chunked backing arrays. Parsing a 10.8 KB file went 3197 → 564 allocs                                                                   |
+| expr compile pipeline   | **Remaining, external.** `runner.compile` is now the largest single block (~48% cum): expr's own parser and compiler turning the transpiled source into a `vm.Program`. It is a *cold-start* cost — `ExprCache` means a long-lived runtime pays it once per distinct expression — so it dominates one-shot CLI runs and not servers. Reducing it means emitting fewer or shorter expressions, not micro-optimising expr |
+| `reflect.Value.Call`    | **Remaining, by design.** ~43% cum. This is the reflection boundary the project trades throughput for; see "Where the guidance stops"                                                                                                                                                                         |

--- a/docs/changelog/2026-08-16-performance-sprint.md
+++ b/docs/changelog/2026-08-16-performance-sprint.md
@@ -1,0 +1,188 @@
+# Performance sprint — allocation reduction
+
+**2026-08-16.** Total allocations across the `.phpt` fixture suite fell by
+**80.6%** (223,063 → 43,356 allocs/op), bytes allocated by **77.4%**, and GC
+runs from 10 to 2. No fixture regressed; the smallest improvements were 56% on
+allocation count and 27% on bytes.
+
+Interpreter throughput rose **4.9x** on the heavy fixtures; the `phpscript
+test` CLI over the whole suite is **1.44x** faster end to end, because fixed
+startup costs now dominate a run. See [Throughput](#throughput).
+
+## The process
+
+The work was driven by [allocation-performance.md](../allocation-performance.md),
+which had a TODO-annotated audit of every binding plus a short list of
+larger structural items. It ran in three rounds, each one measure → change →
+rebuild → re-measure:
+
+```sh
+phpscript test --profile ./tests/...   # per-fixture allocs/op, B/op, GC runs
+go install .                           # rebuild the binary being measured
+```
+
+**Round 1 — work the document's TODO list.** Four parallel efforts, each
+scoped to one package so they could not conflict: `runner` (the `baseEnv`
+rebuild), `model` (list-mode `Array`), `parser` (`TokenGetAll`'s nested array
+shape), `stdlib` (the binding audit's TODO rows). Result: −18.6%.
+
+**Rounds 2 and 3 — follow the profiler instead.** With the document's list
+exhausted, the remaining targets came from
+`go test ./tests/ -bench ... -memprofile` over the six heaviest fixtures and
+`go tool pprof -sample_index=alloc_objects`. This is where the largest single
+win came from, and it was not in the document at all. Result: −62% and −16%
+on top of what was already there.
+
+The lesson worth keeping: the audit was a good starting point and a poor
+finishing point. It correctly identified that `runner.baseEnv` dominated, but
+it attributed ~78% of allocations to the *runtime* environment when a
+comparable cost sat in the *compile-time* type environment, unmentioned. Two
+of its TODOs were also worth less than advertised by the time they were
+reached — see "Changes not made" below.
+
+## Where the wins came from
+
+| Change | Effect |
+|---|---|
+| `runner`: pooled evaluation environments (`acquireEnv`/`releaseEnv`) reached through a `scopeRef` indirection, plus on-demand installation of only the functions an expression actually calls | `baseEnv` rebuilt the whole env per `Eval`, one closure per registered function. `BenchmarkScriptEnvFullStdlib` and `...Minimal` are now identical at 24 allocs/op (were 649 and 145): a script pays for the functions it calls, not the size of the table |
+| `runner`: cache expr's compile config per function-table generation; derive the type-env nature once instead of per key | `expr.Compile(src, expr.Env(typeEnv), ...)` made expr walk a ~95-entry map via `MapKeys`/`MapIndex`/`copyVal` on **every compile** — 64% of all allocations |
+| `parser`: operator tokens from a package-level substring table, presized token slice, chunked AST node allocation | Parsing a 10.8 KB file: 3197 → 564 allocs (−82%) |
+| `parser`: `TokenGetAll` returns `[]any` of `[]any` instead of `*model.Array` of `*model.Array`, with pre-boxed id/line tables and chunked triples | 6003 → 1828 allocs on a 5.6 KB template |
+| `model`: `Array` list mode — while every key is the dense sequence `0..n-1`, values live in a `[]any` and neither the `map[any]any` nor the key slice is allocated | 5-element build 11 → 9 allocs, 50-element 66 → 57, `Range` ~17x faster at zero allocations |
+| `stdlib`: hoisted `htmlspecialchars`' `strings.Replacer` to package scope; `crc32` via a package-level table; `Exception` returns a pointer; `toString`/`toInt` off `fmt` | 11 → 2 allocs, 1 → 0 allocs, and `$e->message = "x"` now works |
+
+## Fixture data
+
+`phpscript test --profile ./tests/...`, Intel N150, Go 1.27. Bytes are KiB.
+GC columns are collections observed during the run.
+
+| Fixture | Allocs before | after | Δ | KiB before | after | Δ | GC before | after |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `include_minitpl` | 30427 | 4208 | -86% | 3093.1 | 310.7 | -90% | 2 | 0 |
+| `operators_and_mutation` | 20791 | 2039 | -90% | 1880.3 | 200.0 | -89% | 1 | 0 |
+| `ternary_conditions` | 20373 | 2973 | -85% | 1993.9 | 289.7 | -85% | 1 | 0 |
+| `array_indexing` | 13895 | 3172 | -77% | 1356.3 | 294.5 | -78% | 0 | 0 |
+| `object_nesting` | 11612 | 1775 | -85% | 1146.2 | 144.7 | -87% | 0 | 0 |
+| `runtime_introspection` | 10631 | 2011 | -81% | 1122.3 | 166.1 | -85% | 0 | 0 |
+| `session_manager` | 9109 | 1778 | -80% | 944.3 | 156.7 | -83% | 1 | 0 |
+| `request_and_response_handling` | 8196 | 1351 | -84% | 902.7 | 135.3 | -85% | 1 | 0 |
+| `compact` | 7911 | 1270 | -84% | 852.0 | 118.3 | -86% | 0 | 0 |
+| `autoloading` | 7620 | 1203 | -84% | 843.7 | 127.7 | -85% | 0 | 0 |
+| `get_included_files` | 7055 | 1318 | -81% | 946.3 | 434.2 | -54% | 0 | 1 |
+| `php_array_splice` | 6995 | 2007 | -71% | 654.6 | 233.0 | -64% | 0 | 0 |
+| `database_test` | 6428 | 1563 | -76% | 617.9 | 135.7 | -78% | 0 | 0 |
+| `storage_lifecycle` | 6347 | 1354 | -79% | 675.7 | 154.5 | -77% | 1 | 0 |
+| `storage_list` | 5696 | 1265 | -78% | 534.3 | 147.0 | -72% | 0 | 0 |
+| `exception_response_code` | 4817 | 1187 | -75% | 498.9 | 138.6 | -72% | 0 | 0 |
+| `database_migrate` | 4235 | 1368 | -68% | 509.9 | 135.9 | -73% | 1 | 0 |
+| `condition_syntax` | 4113 | 781 | -81% | 470.5 | 119.4 | -75% | 0 | 0 |
+| `php_foreach_syntax` | 4042 | 940 | -77% | 399.1 | 131.6 | -67% | 0 | 0 |
+| `flatstack_destructuring_assignment` | 4041 | 774 | -81% | 446.4 | 132.9 | -70% | 1 | 0 |
+| `flatstack_runner_compatible_fast_path` | 3523 | 1023 | -71% | 379.2 | 128.5 | -66% | 0 | 0 |
+| `autoloading_default` | 3396 | 877 | -74% | 385.6 | 154.5 | -60% | 1 | 0 |
+| `platform_database` | 2857 | 934 | -67% | 153.3 | 69.0 | -55% | 0 | 0 |
+| `user_function_declaration_and_call` | 2048 | 596 | -71% | 238.2 | 104.3 | -56% | 0 | 0 |
+| `include-return` | 1785 | 328 | -82% | 199.3 | 65.3 | -67% | 0 | 0 |
+| `defer-usage` | 1716 | 372 | -78% | 196.8 | 66.2 | -66% | 0 | 0 |
+| `storage_constructor_error_caught` | 1640 | 517 | -68% | 185.0 | 96.5 | -48% | 0 | 1 |
+| `exception` | 1602 | 564 | -65% | 177.8 | 88.9 | -50% | 0 | 0 |
+| `die_exit` | 1514 | 492 | -68% | 176.3 | 90.2 | -49% | 0 | 0 |
+| `autoloading_missing` | 1496 | 475 | -68% | 183.7 | 86.8 | -53% | 0 | 0 |
+| `stdin` | 1459 | 457 | -69% | 175.0 | 96.5 | -45% | 0 | 0 |
+| `storage_context` | 1274 | 468 | -63% | 131.6 | 90.5 | -31% | 0 | 0 |
+| `storage_method_error` | 1254 | 548 | -56% | 133.1 | 94.2 | -29% | 0 | 0 |
+| `storage_method_error_caught` | 1141 | 495 | -57% | 94.9 | 69.0 | -27% | 0 | 0 |
+| `storage_constructor_error` | 1034 | 455 | -56% | 120.4 | 87.1 | -28% | 0 | 0 |
+| `flatstack_arithmetic` | 990 | 418 | -58% | 118.2 | 82.7 | -30% | 0 | 0 |
+| `token_get_all` | — | 2930 | — | — | 186.7 | — | — | 0 |
+| **Total (36 common)** | **223063** | **43356** | **-80.6%** | **22936.8** | **5176.6** | **-77.4%** | **10** | **2** |
+
+`token_get_all.phpt` is new — added during the sprint to pin the PHP-visible
+shape of `token_get_all` after it stopped returning `*model.Array`. It is
+excluded from the total so the comparison is like-for-like.
+
+## Throughput
+
+The harness's own duration column is whole milliseconds and most fixtures now
+finish under 1 ms, so it is no longer a usable measure. The numbers below come
+from building the pre-sprint commit (`eba815c`) and running both binaries
+against the same 36 fixtures.
+
+Fixture execution excluding process startup, `ResetCaches()` per iteration so
+every run pays a cold parse and compile — the one-shot CLI case:
+
+| Fixture                  | before | after  | speedup |
+|--------------------------|-------:|-------:|--------:|
+| `include_minitpl`        |  159/s |  671/s |    4.2x |
+| `ternary_conditions`     |  276/s | 1334/s |    4.8x |
+| `operators_and_mutation` |  316/s | 2319/s |    7.3x |
+| `array_indexing`         |  328/s | 1656/s |    5.1x |
+| `object_nesting`         |  422/s | 2384/s |    5.6x |
+| `runtime_introspection`  |  542/s | 2259/s |    4.2x |
+| **combined**             | **49/s** | **242/s** | **4.9x** |
+
+End to end, `phpscript test ./tests/...` over the whole suite — including
+process startup, driver connections and fixture I/O — went **91 ms → 63 ms,
+1.44x** (five alternating runs, 89-93 ms versus 61-64 ms).
+
+The gap between 4.9x and 1.44x is the useful part: the interpreter is roughly
+five times faster, but a CLI invocation now spends most of its 63 ms on fixed
+costs this sprint did not touch. Those are what to attack next if the CLI's
+wall-clock is the target.
+
+## Changes not made, and why
+
+- **`array_merge` returning `[]any` for all-list inputs.** This was a TODO in
+  the audit, implemented, measured, and reverted. Its premise — that
+  `*model.Array` cost ~5 allocations more — stopped being true when list mode
+  landed in the same round; measured 8 allocs either way. The slice cannot
+  serve `$x = array_merge($a, $b); $x[] = "z"`, so the appendability was worth
+  more than 40 bytes.
+- **Dropping `expr.Env` entirely.** Tempting, and much faster still, but
+  wrong: `expr/parser.parseCall` consults its own `predicates` table before
+  the disabled-builtins list, and only `conf.Config.IsOverridden` — which
+  reads `Config.Env` — stops a name being parsed as expr predicate syntax.
+  PHP's `count`, `map`, `filter`, `find`, `sum`, `reduce` and `sortBy` all
+  collide. `expr.DisableAllBuiltins()` does not cover it. Caching the derived
+  config was taken instead, and `runner/compile_test.go::TestCompileMatchesExprEnv`
+  now guards it by diffing `vm.Program.Disassemble()` against a stock
+  `expr.Compile(expr.Env(...))` over a corpus.
+- **Sharing one closure set across a `Runtime`'s pooled environments via a
+  scope stack.** Cannot be made safe for concurrent use of one `Runtime` from
+  multiple goroutines without per-goroutine state. Lazy installation gets most
+  of the win without touching the scope model.
+- **Caching the expr config across `Runtime`s.** `conf.Config` is mutated
+  during compile (`NtCache` writes unsynchronised maps); a package-level cache
+  would need a global lock around every compile, trading a per-`Runtime`
+  one-time cost for cross-`Runtime` contention.
+
+One assumption that did not survive contact: the audit called `token_get_all`
+"the worst remaining shape" partly because "the minitpl compiler tokenises
+every template". Instrumenting the tokenizer showed `include_minitpl.phpt`
+never calls it — the fixture's template only uses `{name}`, which takes a
+different path. The change is still worth having (it is 3.3x on the tokenizer
+and `phpscript fmt`/`list`/`ast` use it), but it is not what made that fixture
+heavy.
+
+## What is left
+
+The two largest remaining blocks are both out of reach of this kind of work:
+
+- **expr's own parse and compile pipeline**, ~48% cumulative. This is a
+  *cold-start* cost — `ExprCache` means a long-lived runtime pays it once per
+  distinct expression — so it dominates one-shot CLI runs and not servers.
+  Reducing it means emitting fewer or shorter expressions, not micro-optimising
+  a dependency.
+- **`reflect.Value.Call`**, ~43% cumulative. This is the reflection boundary
+  the project deliberately trades throughput for; see "Where the guidance
+  stops" in [allocation-performance.md](../allocation-performance.md).
+
+## Verification
+
+`go build ./...`, `go vet ./...`, `gofmt -l` clean. `go test ./... -count=1`
+and `go test ./... -race -count=1` pass. All 37 fixtures pass. Tests were added
+for every semantic change: `model/array_test.go` (differential test against a
+replica of the old map-backed implementation), `runner/compile_test.go`
+(bytecode equivalence), `runner/transpile_test.go`, `parser/lexer_test.go`,
+`parser/parser_test.go`, `stdlib/stdlib_internal_test.go`,
+`stdlib/stdlib_script_test.go`, and `tests/fixtures/token_get_all.phpt`.

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -788,34 +788,30 @@ func collapseBlankLines(src string) string {
 func leadingComments(src string, attached map[int]bool) []string {
 	var comments []string
 	seenOpen := false
-	parser.TokenGetAll(src).Range(func(_, val any) bool {
-		a, ok := val.(*model.Array)
+	for _, val := range parser.TokenGetAll(src) {
+		a, ok := val.([]any)
 		if !ok {
 			// CHAR token — end of preamble.
 			if seenOpen {
-				return false
+				break
 			}
-			return true
+			continue
 		}
-		id, _ := a.Get(int64(0))
-		text, _ := a.Get(int64(1))
-		switch int(id.(int64)) {
+		switch int(a[0].(int64)) {
 		case parser.T_OPEN_TAG:
 			seenOpen = true
 		case parser.T_WHITESPACE, parser.T_INLINE_HTML:
 			// keep scanning
 		case parser.T_COMMENT:
-			line, _ := a.Get(int64(2))
-			if seenOpen && !attached[int(line.(int64))] {
-				comments = append(comments, strings.TrimRight(text.(string), "\r\n"))
+			if seenOpen && !attached[int(a[2].(int64))] {
+				comments = append(comments, strings.TrimRight(a[1].(string), "\r\n"))
 			}
 		default:
 			if seenOpen {
-				return false
+				return comments
 			}
 		}
-		return true
-	})
+	}
 	return comments
 }
 
@@ -829,31 +825,28 @@ func commentsBeforeDeclarations(src string) (map[int][][]string, map[int]bool) {
 		line        int
 		commentOnly bool
 	}
-	var tokens []token
+	raw := parser.TokenGetAll(src)
+	tokens := make([]token, 0, len(raw))
 	offset := 0
-	parser.TokenGetAll(src).Range(func(_, val any) bool {
-		a, ok := val.(*model.Array)
+	for _, val := range raw {
+		a, ok := val.([]any)
 		if !ok {
 			text := val.(string)
 			tokens = append(tokens, token{text: text})
 			offset += len(text)
-			return true
+			continue
 		}
-		id, _ := a.Get(int64(0))
-		text, _ := a.Get(int64(1))
-		line, _ := a.Get(int64(2))
-		tokenText := text.(string)
+		tokenText := a[1].(string)
 		lineStart := strings.LastIndex(src[:offset], "\n") + 1
 		prefix := strings.TrimSpace(src[lineStart:offset])
 		tokens = append(tokens, token{
-			id:          int(id.(int64)),
+			id:          int(a[0].(int64)),
 			text:        tokenText,
-			line:        int(line.(int64)),
+			line:        int(a[2].(int64)),
 			commentOnly: prefix == "" || prefix == "<?php" || prefix == "<?",
 		})
 		offset += len(tokenText)
-		return true
-	})
+	}
 
 	comments := make(map[int][][]string)
 	attached := make(map[int]bool)

--- a/list/list.go
+++ b/list/list.go
@@ -113,19 +113,16 @@ type scanTok struct {
 }
 
 func tokenize(src string) []scanTok {
-	var out []scanTok
-	parser.TokenGetAll(src).Range(func(_, val any) bool {
-		if a, ok := val.(*model.Array); ok {
-			id, _ := a.Get(int64(0))
-			text, _ := a.Get(int64(1))
-			out = append(out, scanTok{id: int(id.(int64)), text: text.(string)})
-			return true
+	toks := parser.TokenGetAll(src)
+	out := make([]scanTok, 0, len(toks))
+	for _, val := range toks {
+		switch tok := val.(type) {
+		case []any:
+			out = append(out, scanTok{id: int(tok[0].(int64)), text: tok[1].(string)})
+		case string:
+			out = append(out, scanTok{text: tok})
 		}
-		if s, ok := val.(string); ok {
-			out = append(out, scanTok{text: s})
-		}
-		return true
-	})
+	}
 	return out
 }
 

--- a/model/array_test.go
+++ b/model/array_test.go
@@ -1,0 +1,760 @@
+package model
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// legacyArray is the map-backed *Array as it was before list mode: every array
+// allocated a map[any]any and a key slice up front. The differential test below
+// replays operation sequences against both implementations and requires
+// identical observable behaviour; the benchmarks measure what list mode saves.
+// Following docs/allocation-performance.md ("keep the old implementation as a
+// second binding so the benchmark measures the change instead of asserting it").
+type legacyArray struct {
+	keys   []any
+	values map[any]any
+	nextID int64
+}
+
+func newLegacyArray() *legacyArray { return &legacyArray{values: map[any]any{}} }
+
+func newLegacyArraySize(n int) *legacyArray {
+	if n <= 0 {
+		return newLegacyArray()
+	}
+	return &legacyArray{keys: make([]any, 0, n), values: make(map[any]any, n)}
+}
+
+func (a *legacyArray) Set(key, val any) {
+	if _, ok := a.values[key]; !ok {
+		a.keys = append(a.keys, key)
+	}
+	a.values[key] = val
+	if i, ok := key.(int64); ok && i >= a.nextID {
+		a.nextID = i + 1
+	}
+}
+
+func (a *legacyArray) Append(val any) { a.Set(a.nextID, val) }
+func (a *legacyArray) Get(key any) (any, bool) {
+	v, ok := a.values[key]
+	return v, ok
+}
+func (a *legacyArray) Len() int    { return len(a.keys) }
+func (a *legacyArray) Keys() []any { return a.keys }
+func (a *legacyArray) Range(fn func(key, val any) bool) {
+	for _, k := range a.keys {
+		if !fn(k, a.values[k]) {
+			return
+		}
+	}
+}
+func (a *legacyArray) Map() map[string]any {
+	result := make(map[string]any, len(a.keys))
+	for _, key := range a.keys {
+		result[fmt.Sprint(key)] = a.values[key]
+	}
+	return result
+}
+func (a *legacyArray) Clear() {
+	a.keys = nil
+	a.values = map[any]any{}
+	a.nextID = 0
+}
+
+// entries collects an array's key/value pairs in iteration order.
+func entries(a *Array) [][2]any {
+	var out [][2]any
+	a.Range(func(k, v any) bool {
+		out = append(out, [2]any{k, v})
+		return true
+	})
+	return out
+}
+
+func legacyEntries(a *legacyArray) [][2]any {
+	var out [][2]any
+	a.Range(func(k, v any) bool {
+		out = append(out, [2]any{k, v})
+		return true
+	})
+	return out
+}
+
+func TestArrayListModeAppend(t *testing.T) {
+	a := NewArray()
+	if !a.isList() {
+		t.Fatal("a fresh array should start in list mode")
+	}
+	for i := range 5 {
+		a.Append("v" + strconv.Itoa(i))
+	}
+	if !a.isList() {
+		t.Fatal("appends alone must not promote the array")
+	}
+	if a.values != nil || a.keys != nil {
+		t.Fatalf("list mode must not allocate a map or key slice: keys=%v values=%v", a.keys, a.values)
+	}
+	if got := a.Len(); got != 5 {
+		t.Fatalf("Len() = %d, want 5", got)
+	}
+	if got, want := a.Keys(), []any{int64(0), int64(1), int64(2), int64(3), int64(4)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() = %v, want %v", got, want)
+	}
+	for i := range 5 {
+		v, ok := a.Get(int64(i))
+		if !ok || v != "v"+strconv.Itoa(i) {
+			t.Fatalf("Get(%d) = %v, %v", i, v, ok)
+		}
+	}
+	if _, ok := a.Get(int64(5)); ok {
+		t.Fatal("Get(5) on a 5-element list should miss")
+	}
+	if _, ok := a.Get(int64(-1)); ok {
+		t.Fatal("Get(-1) should miss, not panic or wrap")
+	}
+	want := [][2]any{{int64(0), "v0"}, {int64(1), "v1"}, {int64(2), "v2"}, {int64(3), "v3"}, {int64(4), "v4"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+}
+
+func TestArrayNewArraySizePresizesListOnly(t *testing.T) {
+	a := NewArraySize(8)
+	if !a.isList() {
+		t.Fatal("NewArraySize should return a list-mode array")
+	}
+	if a.values != nil || a.keys != nil {
+		t.Fatal("NewArraySize must not allocate a map or key slice")
+	}
+	if cap(a.list) != 8 {
+		t.Fatalf("cap(list) = %d, want 8", cap(a.list))
+	}
+	if a.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0", a.Len())
+	}
+	if NewArraySize(0).list != nil {
+		t.Fatal("NewArraySize(0) should allocate nothing")
+	}
+}
+
+// TestArrayMixedLiteral is PHP's array("a", "b", "k" => "c", "d"), whose keys
+// are 0, 1, "k", 2 in that order: the string key does not advance the append
+// index. A list-mode implementation that dropped insertion order or restarted
+// the index at the string key would fail here.
+func TestArrayMixedLiteral(t *testing.T) {
+	a := NewArray()
+	a.Append("a")
+	a.Append("b")
+	a.Set("k", "c")
+	a.Append("d")
+
+	if a.isList() {
+		t.Fatal("a string key must promote the array to map mode")
+	}
+	want := [][2]any{{int64(0), "a"}, {int64(1), "b"}, {"k", "c"}, {int64(2), "d"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+	if got := a.Len(); got != 4 {
+		t.Fatalf("Len() = %d, want 4", got)
+	}
+	if got, want := a.Keys(), []any{int64(0), int64(1), "k", int64(2)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() = %v, want %v", got, want)
+	}
+	if v, ok := a.Get("k"); !ok || v != "c" {
+		t.Fatalf(`Get("k") = %v, %v`, v, ok)
+	}
+	if v, ok := a.Get(int64(1)); !ok || v != "b" {
+		t.Fatalf("Get(1) = %v, %v; the promoted elements must survive", v, ok)
+	}
+}
+
+// TestArraySparseIntKeys covers PHP's array(5 => "a", "b"): the next append
+// lands at 6, and a later low key does not move.
+func TestArraySparseIntKeys(t *testing.T) {
+	a := NewArray()
+	a.Set(int64(5), "a")
+	if a.isList() {
+		t.Fatal("a sparse int key must promote")
+	}
+	a.Append("b")
+	a.Set(int64(0), "c")
+
+	want := [][2]any{{int64(5), "a"}, {int64(6), "b"}, {int64(0), "c"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+	if a.nextID != 7 {
+		t.Fatalf("nextID = %d, want 7 (a low key must not rewind the append index)", a.nextID)
+	}
+}
+
+// TestArrayOutOfOrderSetPromotes: writing key 1 before key 0 is not a list.
+// Its iteration order is 1 then 0, which a naive "append into the slice"
+// implementation would silently reorder.
+func TestArrayOutOfOrderSetPromotes(t *testing.T) {
+	a := NewArray()
+	a.Set(int64(1), "b")
+	if a.isList() {
+		t.Fatal("Set(1) on an empty array must promote")
+	}
+	a.Set(int64(0), "a")
+
+	want := [][2]any{{int64(1), "b"}, {int64(0), "a"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+	if a.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", a.Len())
+	}
+}
+
+// TestArrayListModeOverwrite: an in-range int64 key overwrites in place, keeps
+// the array in list mode, and does not change Len or the append index.
+func TestArrayListModeOverwrite(t *testing.T) {
+	a := NewArray()
+	a.Append("a")
+	a.Append("b")
+	a.Append("c")
+
+	a.Set(int64(1), "B")
+	if !a.isList() {
+		t.Fatal("overwriting an existing index must not promote")
+	}
+	if a.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3 (an overwrite is not an insert)", a.Len())
+	}
+	if a.nextID != 3 {
+		t.Fatalf("nextID = %d, want 3", a.nextID)
+	}
+	a.Set(int64(3), "d") // exactly at the end: still a list
+	if !a.isList() {
+		t.Fatal("setting the key one past the end is an append, not a promotion")
+	}
+	want := [][2]any{{int64(0), "a"}, {int64(1), "B"}, {int64(2), "c"}, {int64(3), "d"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+}
+
+// TestArrayNegativeKey: PHP 7 semantics as this Array models them — a negative
+// key does not lower the append index (see the `i >= a.nextID` guard).
+func TestArrayNegativeKey(t *testing.T) {
+	a := NewArray()
+	a.Set(int64(-3), "x")
+	if a.isList() {
+		t.Fatal("a negative key must promote")
+	}
+	a.Append("y")
+	want := [][2]any{{int64(-3), "x"}, {int64(0), "y"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+}
+
+// TestArrayKeysAreOpaque locks in that the Array itself does not normalise
+// keys: "0", int(0) and int64(0) are three distinct keys. Normalisation is the
+// runner's job (runner.normalizeKey), so list mode must only recognise int64.
+func TestArrayKeysAreOpaque(t *testing.T) {
+	a := NewArray()
+	a.Set(int(0), "int")
+	if a.isList() {
+		t.Fatal("an int (not int64) key must promote: it is a different map key")
+	}
+	a.Set("0", "string")
+	a.Set(int64(0), "int64")
+
+	if a.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3 distinct keys", a.Len())
+	}
+	if a.nextID != 1 {
+		t.Fatalf("nextID = %d, want 1 (only an int64 key advances it)", a.nextID)
+	}
+	for key, want := range map[any]string{int(0): "int", "0": "string", int64(0): "int64"} {
+		if v, ok := a.Get(key); !ok || v != want {
+			t.Fatalf("Get(%#v) = %v, %v; want %q", key, v, ok, want)
+		}
+	}
+
+	// The same distinction has to hold in list mode, where only int64 hits.
+	b := NewArray()
+	b.Append("v")
+	if _, ok := b.Get(int(0)); ok {
+		t.Fatal("Get(int(0)) must miss in list mode, matching the map-backed array")
+	}
+	if _, ok := b.Get("0"); ok {
+		t.Fatal(`Get("0") must miss in list mode`)
+	}
+	if _, ok := b.Get(int64(0)); !ok {
+		t.Fatal("Get(int64(0)) must hit in list mode")
+	}
+}
+
+func TestArrayFloatKeyPromotes(t *testing.T) {
+	a := NewArray()
+	a.Set(float64(0), "f")
+	if a.isList() {
+		t.Fatal("a float key must promote")
+	}
+	a.Append("v")
+	want := [][2]any{{float64(0), "f"}, {int64(0), "v"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+}
+
+// TestArrayClearReturnsToListMode covers array_splice/usort, which Clear an
+// array and rebuild it with Append.
+func TestArrayClearReturnsToListMode(t *testing.T) {
+	a := NewArray()
+	a.Set("k", "v")
+	a.Append("x")
+	if a.isList() {
+		t.Fatal("string key should have promoted")
+	}
+
+	a.Clear()
+	if !a.isList() {
+		t.Fatal("Clear must return the array to list mode")
+	}
+	if a.Len() != 0 || a.nextID != 0 {
+		t.Fatalf("after Clear: Len=%d nextID=%d, want 0/0", a.Len(), a.nextID)
+	}
+	if _, ok := a.Get("k"); ok {
+		t.Fatal("Clear must drop the old keys")
+	}
+	if _, ok := a.Get(int64(0)); ok {
+		t.Fatal("Clear must drop the old values")
+	}
+	a.Append("a")
+	a.Append("b")
+	want := [][2]any{{int64(0), "a"}, {int64(1), "b"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() after Clear = %v, want %v", got, want)
+	}
+}
+
+func TestArrayRangeStopsEarly(t *testing.T) {
+	for _, mode := range []string{"list", "map"} {
+		a := NewArray()
+		if mode == "map" {
+			a.Set("k", "promoted")
+		}
+		for i := range 4 {
+			a.Append(i)
+		}
+		var seen int
+		a.Range(func(_, _ any) bool {
+			seen++
+			return seen < 2
+		})
+		if seen != 2 {
+			t.Fatalf("%s mode: Range visited %d entries after the callback stopped, want 2", mode, seen)
+		}
+	}
+}
+
+// TestArrayPromoteDuringRange is the hazard list mode introduces: a script may
+// add a string key from inside its own foreach. Promotion must not scramble the
+// slice the in-flight Range is walking.
+func TestArrayPromoteDuringRange(t *testing.T) {
+	a := NewArray()
+	a.Append("a")
+	a.Append("b")
+	a.Append("c")
+
+	var got [][2]any
+	a.Range(func(k, v any) bool {
+		got = append(got, [2]any{k, v})
+		if k == int64(0) {
+			a.Set("added", "z")
+		}
+		return true
+	})
+	want := [][2]any{{int64(0), "a"}, {int64(1), "b"}, {int64(2), "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range during promotion = %v, want %v", got, want)
+	}
+	if v, ok := a.Get("added"); !ok || v != "z" {
+		t.Fatalf(`Get("added") = %v, %v`, v, ok)
+	}
+	if a.Len() != 4 {
+		t.Fatalf("Len() = %d, want 4", a.Len())
+	}
+}
+
+func TestArrayMapStringKeys(t *testing.T) {
+	list := NewArray()
+	list.Append("a")
+	list.Append("b")
+	if got, want := list.Map(), map[string]any{"0": "a", "1": "b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("list Map() = %v, want %v", got, want)
+	}
+
+	mixed := NewArray()
+	mixed.Append("a")
+	mixed.Set("k", "c")
+	if got, want := mixed.Map(), map[string]any{"0": "a", "k": "c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("map Map() = %v, want %v", got, want)
+	}
+}
+
+func TestArrayZeroValueIsUsable(t *testing.T) {
+	var a Array
+	a.Append("x")
+	a.Set("k", "v")
+	if a.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", a.Len())
+	}
+	if v, ok := a.Get(int64(0)); !ok || v != "x" {
+		t.Fatalf("Get(0) = %v, %v", v, ok)
+	}
+}
+
+func TestToArrayListFastPath(t *testing.T) {
+	src := []any{"a", "b", "c"}
+	a := ToArray(src)
+	if !a.isList() {
+		t.Fatal("ToArray of a []any should produce a list-mode array")
+	}
+	if a.nextID != 3 {
+		t.Fatalf("nextID = %d, want 3", a.nextID)
+	}
+	want := [][2]any{{int64(0), "a"}, {int64(1), "b"}, {int64(2), "c"}}
+	if got := entries(a); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+	a.Append("d")
+	if len(src) != 3 {
+		t.Fatal("ToArray must copy: appending to the Array wrote through to the source slice")
+	}
+	a.Set(int64(0), "A")
+	if src[0] != "a" {
+		t.Fatal("ToArray must copy: Set wrote through to the source slice")
+	}
+
+	m := ToArray(map[string]any{"k": "v"})
+	if m.isList() {
+		t.Fatal("ToArray of a string-keyed map must be map mode")
+	}
+	if v, ok := m.Get("k"); !ok || v != "v" {
+		t.Fatalf(`Get("k") = %v, %v`, v, ok)
+	}
+}
+
+func TestRangeValuesAndLenValuesOnBothModes(t *testing.T) {
+	list := NewArray()
+	list.Append("a")
+	list.Append("b")
+
+	mapped := NewArray()
+	mapped.Append("a")
+	mapped.Set("k", "b")
+
+	for name, a := range map[string]*Array{"list": list, "map": mapped} {
+		n, ok := LenValues(a)
+		if !ok || n != 2 {
+			t.Fatalf("%s: LenValues = %d, %v; want 2, true", name, n, ok)
+		}
+		if !IsCollection(a) {
+			t.Fatalf("%s: IsCollection = false", name)
+		}
+		var count int
+		RangeValues(a, func(_, _ any) bool { count++; return true })
+		if count != 2 {
+			t.Fatalf("%s: RangeValues visited %d entries, want 2", name, count)
+		}
+	}
+}
+
+// op is one step of the differential test below.
+type op struct {
+	kind string // "append", "set", "clear"
+	key  any
+	val  any
+}
+
+// TestArrayMatchesLegacyImplementation replays operation sequences against the
+// list-mode Array and against the map-backed implementation it replaces, and
+// requires identical keys, values, iteration order, Len and append index. Any
+// list-mode shortcut that gets PHP's key rules wrong shows up here.
+func TestArrayMatchesLegacyImplementation(t *testing.T) {
+	sequences := map[string][]op{
+		"pure list": {
+			{kind: "append", val: "a"}, {kind: "append", val: "b"}, {kind: "append", val: "c"},
+		},
+		"explicit dense int keys": {
+			{kind: "set", key: int64(0), val: "a"}, {kind: "set", key: int64(1), val: "b"},
+		},
+		"literal with string key in the middle": {
+			{kind: "append", val: "a"}, {kind: "set", key: "k", val: "c"}, {kind: "append", val: "d"},
+		},
+		"string key first": {
+			{kind: "set", key: "k", val: "v"}, {kind: "append", val: "a"}, {kind: "append", val: "b"},
+		},
+		"sparse": {
+			{kind: "set", key: int64(5), val: "a"}, {kind: "append", val: "b"},
+			{kind: "set", key: int64(2), val: "c"},
+		},
+		"reverse order": {
+			{kind: "set", key: int64(2), val: "c"}, {kind: "set", key: int64(1), val: "b"},
+			{kind: "set", key: int64(0), val: "a"},
+		},
+		"overwrite in place": {
+			{kind: "append", val: "a"}, {kind: "append", val: "b"},
+			{kind: "set", key: int64(0), val: "A"}, {kind: "append", val: "c"},
+		},
+		"duplicate key": {
+			{kind: "set", key: int64(0), val: "a"}, {kind: "set", key: int64(0), val: "b"},
+		},
+		"negative key": {
+			{kind: "set", key: int64(-2), val: "n"}, {kind: "append", val: "a"},
+			{kind: "set", key: int64(-2), val: "N"},
+		},
+		"non-int64 numeric keys": {
+			{kind: "set", key: int(1), val: "int"}, {kind: "set", key: "1", val: "string"},
+			{kind: "append", val: "a"},
+		},
+		"clear then rebuild": {
+			{kind: "append", val: "a"}, {kind: "set", key: "k", val: "v"},
+			{kind: "clear"}, {kind: "append", val: "x"}, {kind: "append", val: "y"},
+		},
+		"clear a list then use string keys": {
+			{kind: "append", val: "a"}, {kind: "clear"},
+			{kind: "set", key: "k", val: "v"}, {kind: "append", val: "b"},
+		},
+		"append past 255 boxes": {
+			{kind: "set", key: int64(300), val: "a"}, {kind: "append", val: "b"},
+		},
+		"nil value": {
+			{kind: "append", val: nil}, {kind: "set", key: "k", val: nil}, {kind: "append", val: nil},
+		},
+	}
+
+	probes := []any{int64(-2), int64(0), int64(1), int64(2), int64(5), int64(300), int64(301),
+		int(0), int(1), "0", "1", "k", "missing", float64(0)}
+
+	for name, ops := range sequences {
+		t.Run(name, func(t *testing.T) {
+			got, want := NewArray(), newLegacyArray()
+			for _, o := range ops {
+				switch o.kind {
+				case "append":
+					got.Append(o.val)
+					want.Append(o.val)
+				case "set":
+					got.Set(o.key, o.val)
+					want.Set(o.key, o.val)
+				case "clear":
+					got.Clear()
+					want.Clear()
+				default:
+					t.Fatalf("unknown op %q", o.kind)
+				}
+			}
+
+			if got.Len() != want.Len() {
+				t.Fatalf("Len() = %d, want %d", got.Len(), want.Len())
+			}
+			if got.nextID != want.nextID {
+				t.Fatalf("nextID = %d, want %d", got.nextID, want.nextID)
+			}
+			if g, w := entries(got), legacyEntries(want); !reflect.DeepEqual(g, w) {
+				t.Fatalf("Range() = %v, want %v", g, w)
+			}
+			if g, w := got.Keys(), want.Keys(); !keysEqual(g, w) {
+				t.Fatalf("Keys() = %v, want %v", g, w)
+			}
+			if g, w := got.Map(), want.Map(); !reflect.DeepEqual(g, w) {
+				t.Fatalf("Map() = %v, want %v", g, w)
+			}
+			for _, probe := range probes {
+				gv, gok := got.Get(probe)
+				wv, wok := want.Get(probe)
+				if gok != wok || !reflect.DeepEqual(gv, wv) {
+					t.Fatalf("Get(%#v) = %v, %v; want %v, %v", probe, gv, gok, wv, wok)
+				}
+			}
+		})
+	}
+}
+
+// keysEqual compares key slices, treating nil and empty as the same (list mode
+// materialises its keys, so an empty array yields an empty non-nil slice).
+func keysEqual(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Benchmarks. Run with:
+//
+//	go test ./model/ -run XXX -bench BenchmarkArray -benchmem
+//
+// The Legacy variants build the same array through the pre-list-mode
+// implementation, so the delta is the change itself.
+
+func benchValues(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = "value-" + strconv.Itoa(i)
+	}
+	return out
+}
+
+func benchArrayAppend(b *testing.B, n int, presize bool) {
+	values := benchValues(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var a *Array
+		if presize {
+			a = NewArraySize(n)
+		} else {
+			a = NewArray()
+		}
+		for _, v := range values {
+			a.Append(v)
+		}
+		if a.Len() != n {
+			b.Fatal("short array")
+		}
+	}
+}
+
+func benchLegacyAppend(b *testing.B, n int, presize bool) {
+	values := benchValues(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var a *legacyArray
+		if presize {
+			a = newLegacyArraySize(n)
+		} else {
+			a = newLegacyArray()
+		}
+		for _, v := range values {
+			a.Append(v)
+		}
+		if a.Len() != n {
+			b.Fatal("short array")
+		}
+	}
+}
+
+func BenchmarkArrayAppend5(b *testing.B)             { benchArrayAppend(b, 5, false) }
+func BenchmarkArrayAppend5Legacy(b *testing.B)       { benchLegacyAppend(b, 5, false) }
+func BenchmarkArrayAppend5Sized(b *testing.B)        { benchArrayAppend(b, 5, true) }
+func BenchmarkArrayAppend5SizedLegacy(b *testing.B)  { benchLegacyAppend(b, 5, true) }
+func BenchmarkArrayAppend50(b *testing.B)            { benchArrayAppend(b, 50, false) }
+func BenchmarkArrayAppend50Legacy(b *testing.B)      { benchLegacyAppend(b, 50, false) }
+func BenchmarkArrayAppend50Sized(b *testing.B)       { benchArrayAppend(b, 50, true) }
+func BenchmarkArrayAppend50SizedLegacy(b *testing.B) { benchLegacyAppend(b, 50, true) }
+
+// The Ints variants store values in 0..255, which the runtime boxes for free
+// (staticuint64s), so what is left is the array's own structural cost.
+func BenchmarkArrayAppend5Ints(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		a := NewArraySize(5)
+		for i := range 5 {
+			a.Append(int64(i))
+		}
+	}
+}
+
+func BenchmarkArrayAppend5IntsLegacy(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		a := newLegacyArraySize(5)
+		for i := range 5 {
+			a.Append(int64(i))
+		}
+	}
+}
+
+// The string-keyed build is the case list mode must not make worse: the array
+// promotes on the first key, so it should cost what the map-backed one did.
+func BenchmarkArrayStringKeys5(b *testing.B) {
+	keys := benchValues(5)
+	b.ReportAllocs()
+	for range b.N {
+		a := NewArraySize(5)
+		for i, k := range keys {
+			a.Set(k, i)
+		}
+	}
+}
+
+func BenchmarkArrayStringKeys5Legacy(b *testing.B) {
+	keys := benchValues(5)
+	b.ReportAllocs()
+	for range b.N {
+		a := newLegacyArraySize(5)
+		for i, k := range keys {
+			a.Set(k, i)
+		}
+	}
+}
+
+// A five-element list literal with one string key: the mixed shape that pays
+// for promotion.
+func BenchmarkArrayMixedLiteral(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		a := NewArray()
+		a.Append("a")
+		a.Append("b")
+		a.Set("k", "c")
+		a.Append("d")
+		a.Append("e")
+	}
+}
+
+func BenchmarkArrayMixedLiteralLegacy(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		a := newLegacyArray()
+		a.Append("a")
+		a.Append("b")
+		a.Set("k", "c")
+		a.Append("d")
+		a.Append("e")
+	}
+}
+
+func BenchmarkArrayRange50(b *testing.B) {
+	a := NewArraySize(50)
+	for _, v := range benchValues(50) {
+		a.Append(v)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var n int
+		a.Range(func(any, any) bool { n++; return true })
+	}
+}
+
+func BenchmarkArrayRange50Legacy(b *testing.B) {
+	a := newLegacyArraySize(50)
+	for _, v := range benchValues(50) {
+		a.Append(v)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var n int
+		a.Range(func(any, any) bool { n++; return true })
+	}
+}

--- a/model/collection.go
+++ b/model/collection.go
@@ -20,7 +20,8 @@ import "reflect"
 // RangeValues iterates a collection in order, calling fn for each key/value
 // pair until fn returns false. It accepts:
 //
-//	*Array          insertion order, hybrid int64/string keys
+//	*Array          insertion order, hybrid int64/string keys (a list-mode
+//	                Array walks its []any directly, with no map lookup)
 //	slice, array    int64 keys in index order
 //	map             key order is Go's (unordered), keys as declared
 //
@@ -138,6 +139,14 @@ func IsCollection(v any) bool {
 func ToArray(v any) *Array {
 	if arr, ok := v.(*Array); ok && arr != nil {
 		return arr
+	}
+	// A Go slice is already a list: hand its elements straight to a list-mode
+	// Array (one allocation for the copy) instead of paying a Set per element.
+	if items, ok := v.([]any); ok {
+		out := NewArraySize(len(items))
+		out.list = append(out.list, items...)
+		out.nextID = int64(len(items))
+		return out
 	}
 	n, _ := LenValues(v)
 	out := NewArraySize(n)

--- a/model/value.go
+++ b/model/value.go
@@ -1,6 +1,9 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // PHP runtime values are represented with plain Go types so that they flow
 // transparently in and out of the expr-lang VM (which works against native Go
@@ -21,33 +24,97 @@ import "fmt"
 
 // Array is PHP's ordered hash map. It preserves insertion order and allows both
 // integer and string keys, so it doubles as list and dictionary.
+//
+// It has two internal representations and switches between them by itself:
+//
+//	list mode  values live in `list`, the key of element i is int64(i).
+//	           `keys` and `values` are nil, so the array costs one slice.
+//	map mode   `values` holds key->value and `keys` holds insertion order.
+//
+// A new array starts in list mode, which is what `$a[] = v` (Append) and a PHP
+// list literal produce, and stays there for as long as every key so far is the
+// dense sequence 0,1,...,n-1. The first key that breaks the invariant — a
+// string key, a negative or sparse integer, an int that is not an int64 —
+// promotes the array to map mode, permanently. See promote.
+//
+// Nothing about the observable behaviour differs between the two modes;
+// list mode exists only so that the common case does not allocate a
+// map[any]any, a key slice, and an interface box per key. Keys are still
+// treated as opaque: an Array never normalises "1" to 1 (its callers do, see
+// runner.normalizeKey), and only an int64 key advances the append index.
 type Array struct {
-	keys   []any
+	list   []any // list mode only: element i is the value of key int64(i)
+	keys   []any // map mode only: keys in insertion order
 	values map[any]any
 	nextID int64
 }
 
 // NewArray returns an empty ordered array.
 func NewArray() *Array {
-	return &Array{values: map[any]any{}}
+	return &Array{}
 }
 
 // NewArraySize returns an empty ordered array with room for n entries. Building
-// an array of known size through it avoids the key slice's growth reallocations
-// (a 5-entry array grows 1->2->4->8), which is most of what an *Array costs
-// beyond its map.
+// an array of known size through it avoids the backing slice's growth
+// reallocations (a 5-entry array grows 1->2->4->8), which is most of what an
+// *Array costs while it stays in list mode.
 func NewArraySize(n int) *Array {
 	if n <= 0 {
 		return NewArray()
 	}
-	return &Array{
-		keys:   make([]any, 0, n),
-		values: make(map[any]any, n),
+	return &Array{list: make([]any, 0, n)}
+}
+
+// isList reports whether the array is still in list mode.
+func (a *Array) isList() bool { return a.values == nil }
+
+// promote switches the array from list mode to map mode, materialising the
+// implicit integer keys. It is the only place the map and the key slice are
+// allocated.
+//
+// The empty case reuses the list's backing array as the key slice, so a
+// presized array whose first key is a string (json_decode of an object, the
+// sorted introspection listings) still costs exactly the map. A non-empty list
+// gets a fresh key slice on purpose: a script may promote an array from inside
+// its own foreach, and Range is walking the backing array we would otherwise
+// be overwriting with keys.
+func (a *Array) promote() {
+	n := len(a.list)
+	size := n
+	if c := cap(a.list); c > size {
+		size = c
 	}
+	a.values = make(map[any]any, size)
+	for i, v := range a.list {
+		a.values[int64(i)] = v
+	}
+	if n == 0 {
+		a.keys = a.list[:0]
+	} else {
+		a.keys = make([]any, n, size)
+		for i := range a.keys {
+			a.keys[i] = int64(i)
+		}
+	}
+	a.list = nil
 }
 
 // Set assigns key=val, appending the key if new.
 func (a *Array) Set(key, val any) {
+	if a.isList() {
+		// In list mode nextID is always len(list), so an int64 key inside
+		// [0, len] either overwrites an element or extends the list by one.
+		if i, ok := key.(int64); ok && i >= 0 && i <= int64(len(a.list)) {
+			if i == int64(len(a.list)) {
+				a.list = append(a.list, val)
+				a.nextID = i + 1
+			} else {
+				a.list[i] = val
+			}
+			return
+		}
+		a.promote()
+	}
 	if _, ok := a.values[key]; !ok {
 		a.keys = append(a.keys, key)
 	}
@@ -59,23 +126,57 @@ func (a *Array) Set(key, val any) {
 
 // Append adds val at the next integer index (PHP `$a[] = v`).
 func (a *Array) Append(val any) {
+	if a.isList() {
+		a.list = append(a.list, val)
+		a.nextID++
+		return
+	}
 	a.Set(a.nextID, val)
 }
 
 // Get returns the value for key and whether it existed.
 func (a *Array) Get(key any) (any, bool) {
+	if a.isList() {
+		if i, ok := key.(int64); ok && i >= 0 && i < int64(len(a.list)) {
+			return a.list[i], true
+		}
+		return nil, false
+	}
 	v, ok := a.values[key]
 	return v, ok
 }
 
 // Len reports the number of entries.
-func (a *Array) Len() int { return len(a.keys) }
+func (a *Array) Len() int {
+	if a.isList() {
+		return len(a.list)
+	}
+	return len(a.keys)
+}
 
-// Keys returns keys in insertion order.
-func (a *Array) Keys() []any { return a.keys }
+// Keys returns keys in insertion order. A list-mode array materialises them on
+// each call, since it does not store them.
+func (a *Array) Keys() []any {
+	if a.isList() {
+		keys := make([]any, len(a.list))
+		for i := range keys {
+			keys[i] = int64(i)
+		}
+		return keys
+	}
+	return a.keys
+}
 
 // Range iterates entries in insertion order.
 func (a *Array) Range(fn func(key, val any) bool) {
+	if a.isList() {
+		for i, v := range a.list {
+			if !fn(int64(i), v) {
+				return
+			}
+		}
+		return
+	}
 	for _, k := range a.keys {
 		if !fn(k, a.values[k]) {
 			return
@@ -86,6 +187,13 @@ func (a *Array) Range(fn func(key, val any) bool) {
 // Map returns the array as a string-keyed map for Go APIs that accept named
 // values. PHP integer keys are represented by their decimal string form.
 func (a *Array) Map() map[string]any {
+	if a.isList() {
+		result := make(map[string]any, len(a.list))
+		for i, v := range a.list {
+			result[strconv.Itoa(i)] = v
+		}
+		return result
+	}
 	result := make(map[string]any, len(a.keys))
 	for _, key := range a.keys {
 		result[fmt.Sprint(key)] = a.values[key]
@@ -93,10 +201,12 @@ func (a *Array) Map() map[string]any {
 	return result
 }
 
-// Clear removes all entries and resets list indexing.
+// Clear removes all entries and resets list indexing, returning the array to
+// list mode.
 func (a *Array) Clear() {
+	a.list = nil
 	a.keys = nil
-	a.values = map[any]any{}
+	a.values = nil
 	a.nextID = 0
 }
 

--- a/parser/alloc.go
+++ b/parser/alloc.go
@@ -1,0 +1,175 @@
+package parser
+
+import "github.com/titpetric/phpscript/model"
+
+// Allocation strategy for the AST.
+//
+// Parsing a 10 KB PHP file builds a few thousand AST nodes and a few hundred
+// child slices. Both were allocated one object at a time; this file replaces
+// that with two chunked structures, mirroring parser/tokenizer.go's emitArr.
+// See docs/allocation-performance.md rules 6 and 7.
+//
+//   - nodeChunk carves nodes of one concrete type out of a backing array.
+//     Every node keeps its own address, is handed out exactly once and is
+//     never reset or reused, so pointer identity — which runner.compileExpr
+//     relies on for its map[model.Expr]*compiledExpr cache — is preserved.
+//     The trade is retention: a chunk stays reachable while any node in it
+//     does. That costs nothing here because the AST is retained as a whole
+//     (a *model.Program), and a failed parse drops all of it at once.
+//
+//   - scratch is a per-type stack used to collect the children of a node
+//     whose count is only known once parsed (call arguments, statement
+//     bodies, parameters, array items). Pushing onto the shared stack and
+//     copying out once yields one exactly-sized allocation per list instead
+//     of the 1→2→4→8 growth of appending to a nil slice. It is re-entrant:
+//     nested lists push and pop above the outer mark, so the outer elements
+//     stay contiguous.
+
+const (
+	nodeChunkMin = 16
+	nodeChunkMax = 128
+)
+
+// nodeChunk hands out individually addressable *T values from chunked backing
+// arrays. Chunks start small and double so a two-line script does not pay for
+// a large block and a whole file amortises the per-node allocation away.
+type nodeChunk[T any] struct {
+	free []T
+	size int
+}
+
+func (c *nodeChunk[T]) new() *T {
+	if len(c.free) == 0 {
+		switch {
+		case c.size == 0:
+			c.size = nodeChunkMin
+		case c.size < nodeChunkMax:
+			c.size *= 2
+		}
+		c.free = make([]T, c.size)
+	}
+	n := &c.free[0]
+	c.free = c.free[1:]
+	return n
+}
+
+// scratch is a re-entrant stack of pending list elements.
+type scratch[T any] struct {
+	buf []T
+}
+
+// mark records the current top of the stack.
+func (s *scratch[T]) mark() int { return len(s.buf) }
+
+func (s *scratch[T]) push(v T) { s.buf = append(s.buf, v) }
+
+// take pops everything pushed since mark and returns it as a slice with
+// cap == len. It returns nil for an empty list, matching what appending to a
+// nil slice produced before.
+func (s *scratch[T]) take(mark int) []T {
+	n := len(s.buf) - mark
+	if n == 0 {
+		s.buf = s.buf[:mark]
+		return nil
+	}
+	out := make([]T, n)
+	copy(out, s.buf[mark:])
+	s.buf = s.buf[:mark]
+	return out
+}
+
+// drop abandons everything pushed since mark. Used on error paths so a
+// recovered parser does not leak elements onto the stack.
+func (s *scratch[T]) drop(mark int) { s.buf = s.buf[:mark] }
+
+// ---------------------------------------------------------------------------
+// Node constructors
+//
+// One per chunked node type. Chunk memory is zeroed by make, and every node is
+// handed out once, so a constructor that leaves a field unset is equivalent to
+// a composite literal that omits it.
+// ---------------------------------------------------------------------------
+
+func (p *parser) newVar(name string) *model.Var {
+	n := p.varNodes.new()
+	n.Name = name
+	return n
+}
+
+func (p *parser) newLit(v any) *model.Lit {
+	n := p.litNodes.new()
+	n.Value = v
+	return n
+}
+
+func (p *parser) newBinary(op string, left, right model.Expr) *model.Binary {
+	n := p.binaryNodes.new()
+	n.Op, n.Left, n.Right = op, left, right
+	return n
+}
+
+func (p *parser) newIndex(base, index model.Expr) *model.Index {
+	n := p.indexNodes.new()
+	n.Base, n.Index = base, index
+	return n
+}
+
+func (p *parser) newProp(base model.Expr, name string) *model.PropAccess {
+	n := p.propNodes.new()
+	n.Base, n.Name = base, name
+	return n
+}
+
+func (p *parser) newMethodCall(base model.Expr, method string, args []model.Expr) *model.MethodCall {
+	n := p.methodNodes.new()
+	n.Base, n.Method, n.Args = base, method, args
+	return n
+}
+
+func (p *parser) newCall(name, fallback string, args []model.Expr) *model.Call {
+	n := p.callNodes.new()
+	n.Name, n.Fallback, n.Args = name, fallback, args
+	return n
+}
+
+func (p *parser) newParen(x model.Expr) *model.Parenthesized {
+	n := p.parenNodes.new()
+	n.X = x
+	return n
+}
+
+func (p *parser) newUnary(op string, x model.Expr, postfix bool) *model.Unary {
+	n := p.unaryNodes.new()
+	n.Op, n.X, n.Postfix = op, x, postfix
+	return n
+}
+
+func (p *parser) newAssignExpr(target model.Expr, op string, value model.Expr, line int) *model.AssignExpr {
+	n := p.assignExprNodes.new()
+	n.Target, n.Op, n.Value, n.Line = target, op, value, line
+	return n
+}
+
+func (p *parser) newExprStmt(x model.Expr) *model.ExprStmt {
+	n := p.exprStmtNodes.new()
+	n.X = x
+	return n
+}
+
+func (p *parser) newAssign(target model.Expr, op string, value model.Expr) *model.Assign {
+	n := p.assignNodes.new()
+	n.Target, n.Op, n.Value = target, op, value
+	return n
+}
+
+func (p *parser) newArrayLit(items []model.ArrayItem) *model.ArrayLit {
+	n := p.arrayLitNodes.new()
+	n.Items = items
+	return n
+}
+
+func (p *parser) newEcho(args []model.Expr) *model.Echo {
+	n := p.echoNodes.new()
+	n.Args = args
+	return n
+}

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -39,7 +39,7 @@ func (p *parser) parseAssign() (model.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &model.AssignExpr{Target: left, Op: op, Value: right, Line: t.line}, nil
+		return p.newAssignExpr(left, op, right, t.line), nil
 	}
 	return left, nil
 }
@@ -98,7 +98,7 @@ func (p *parser) parseBinary(minPrec int) (model.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		left = &model.Binary{Op: op, Left: left, Right: right}
+		left = p.newBinary(op, left, right)
 	}
 	return left, nil
 }
@@ -132,7 +132,7 @@ func (p *parser) parseUnary() (model.Expr, error) {
 		if !isLValue(x) {
 			return nil, fmt.Errorf("line %d: %s requires assignable target", p.cur().line, op)
 		}
-		return &model.Unary{Op: op, X: x}, nil
+		return p.newUnary(op, x, false), nil
 	}
 	if p.isOp("!") || p.isOp("-") || p.isOp("+") {
 		op := p.next().val
@@ -140,7 +140,7 @@ func (p *parser) parseUnary() (model.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &model.Unary{Op: op, X: x}, nil
+		return p.newUnary(op, x, false), nil
 	}
 	// `@expr` error suppression and `&expr` reference are parse-level no-ops
 	// (the VM has no by-reference values; callable arrays carry the marker
@@ -176,16 +176,16 @@ func (p *parser) parsePostfix() (model.Expr, error) {
 				if err != nil {
 					return nil, err
 				}
-				e = &model.MethodCall{Base: e, Method: name, Args: args}
+				e = p.newMethodCall(e, name, args)
 			} else {
-				e = &model.PropAccess{Base: e, Name: name}
+				e = p.newProp(e, name)
 			}
 		case p.isOp("["):
 			p.next()
 			if p.isOp("]") {
 				// `$a[]` append target — represented as Index with nil index.
 				p.next()
-				e = &model.Index{Base: e, Index: nil}
+				e = p.newIndex(e, nil)
 				continue
 			}
 			idx, err := p.parseExpr()
@@ -195,9 +195,9 @@ func (p *parser) parsePostfix() (model.Expr, error) {
 			if err := p.eatOp("]"); err != nil {
 				return nil, err
 			}
-			e = &model.Index{Base: e, Index: idx}
+			e = p.newIndex(e, idx)
 		case (p.isOp("++") || p.isOp("--")) && isLValue(e):
-			e = &model.Unary{Op: p.next().val, X: e, Postfix: true}
+			e = p.newUnary(p.next().val, e, true)
 		default:
 			return e, nil
 		}
@@ -209,7 +209,7 @@ func (p *parser) parsePrimary() (model.Expr, error) {
 	switch t.kind {
 	case tVar:
 		p.next()
-		return &model.Var{Name: t.val}, nil
+		return p.newVar(t.val), nil
 
 	case tInt, tFloat:
 		p.next()
@@ -217,11 +217,11 @@ func (p *parser) parsePrimary() (model.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &model.Lit{Value: v}, nil
+		return p.newLit(v), nil
 
 	case tString:
 		p.next()
-		return &model.Lit{Value: t.val}, nil
+		return p.newLit(t.val), nil
 
 	case tIdent:
 		return p.parseIdentExpr()
@@ -243,7 +243,7 @@ func (p *parser) parsePrimary() (model.Expr, error) {
 			if err := p.eatOp(")"); err != nil {
 				return nil, err
 			}
-			return &model.Parenthesized{X: e}, nil
+			return p.newParen(e), nil
 		case "[":
 			return p.parseArrayLiteral("[", "]")
 		case "{":
@@ -259,11 +259,11 @@ func (p *parser) parseIdentExpr() (model.Expr, error) {
 	t := p.next()
 	switch t.val {
 	case "true", "TRUE", "True":
-		return &model.Lit{Value: true}, nil
+		return p.newLit(true), nil
 	case "false", "FALSE", "False":
-		return &model.Lit{Value: false}, nil
+		return p.newLit(false), nil
 	case "null", "NULL", "Null":
-		return &model.Lit{Value: nil}, nil
+		return p.newLit(nil), nil
 	case "new":
 		return p.parseNew()
 	case "fn", "func", "function":
@@ -276,7 +276,7 @@ func (p *parser) parseIdentExpr() (model.Expr, error) {
 		if p.isOp("(") {
 			return p.parseArrayLiteral("(", ")")
 		}
-		return &model.Lit{Value: nil}, nil
+		return p.newLit(nil), nil
 	}
 	name := t.val
 	for p.isOp("\\") {
@@ -307,17 +307,17 @@ func (p *parser) parseNamedExpr(name string, absolute bool) (model.Expr, error) 
 			return nil, err
 		}
 		if !absolute && p.namespace != "" && !strings.ContainsRune(name, '\\') {
-			return &model.Call{Name: p.qualify(name, false), Fallback: name, Args: args}, nil
+			return p.newCall(p.qualify(name, false), name, args), nil
 		}
-		return &model.Call{Name: p.qualify(name, absolute), Args: args}, nil
+		return p.newCall(p.qualify(name, absolute), "", args), nil
 	}
 	// Bare identifier: a constant. Model it as a Var so the env can resolve it,
 	// or as a literal string fallback. We use Call-free Var-like lookup via a
 	// no-arg marker is overkill; represent as a Var reference.
 	if name == "__NAMESPACE__" {
-		return &model.Lit{Value: p.namespace}, nil
+		return p.newLit(p.namespace), nil
 	}
-	return &model.Var{Name: name}, nil
+	return p.newVar(name), nil
 }
 
 // parseClosure parses an anonymous function `function(params) [use(...)] { body }`.
@@ -347,23 +347,24 @@ func (p *parser) parseList() (model.Expr, error) {
 	if err := p.eatOp("("); err != nil {
 		return nil, err
 	}
-	lst := &model.ListExpr{}
+	mark := p.exprs.mark()
 	for !p.isOp(")") {
 		if p.isOp(",") {
-			lst.Elems = append(lst.Elems, nil)
+			p.exprs.push(nil)
 			p.next()
 			continue
 		}
 		e, err := p.parseExpr()
 		if err != nil {
+			p.exprs.drop(mark)
 			return nil, err
 		}
-		lst.Elems = append(lst.Elems, e)
+		p.exprs.push(e)
 		if p.isOp(",") {
 			p.next()
 		}
 	}
-	return lst, p.eatOp(")")
+	return &model.ListExpr{Elems: p.exprs.take(mark)}, p.eatOp(")")
 }
 
 func (p *parser) parseNew() (model.Expr, error) {
@@ -386,30 +387,32 @@ func (p *parser) parseArgs() ([]model.Expr, error) {
 	if err := p.eatOp("("); err != nil {
 		return nil, err
 	}
-	var args []model.Expr
+	mark := p.exprs.mark()
 	for !p.isOp(")") {
 		e, err := p.parseExpr()
 		if err != nil {
+			p.exprs.drop(mark)
 			return nil, err
 		}
-		args = append(args, e)
+		p.exprs.push(e)
 		if p.isOp(",") {
 			p.next()
 			continue
 		}
 		break
 	}
-	return args, p.eatOp(")")
+	return p.exprs.take(mark), p.eatOp(")")
 }
 
 func (p *parser) parseArrayLiteral(open, close string) (model.Expr, error) {
 	if err := p.eatOp(open); err != nil {
 		return nil, err
 	}
-	lit := &model.ArrayLit{}
+	mark := p.items.mark()
 	for !p.isOp(close) {
 		first, err := p.parseExpr()
 		if err != nil {
+			p.items.drop(mark)
 			return nil, err
 		}
 		item := model.ArrayItem{Val: first}
@@ -417,16 +420,17 @@ func (p *parser) parseArrayLiteral(open, close string) (model.Expr, error) {
 			p.next()
 			val, err := p.parseExpr()
 			if err != nil {
+				p.items.drop(mark)
 				return nil, err
 			}
 			item = model.ArrayItem{Key: first, Val: val}
 		}
-		lit.Items = append(lit.Items, item)
+		p.items.push(item)
 		if p.isOp(",") {
 			p.next()
 			continue
 		}
 		break
 	}
-	return lit, p.eatOp(close)
+	return p.newArrayLit(p.items.take(mark)), p.eatOp(close)
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // tokKind enumerates lexical token classes.
@@ -50,7 +52,49 @@ var multiCharOps = []string{
 	".=", "+=", "-=", "*=", "/=", "%=", "::",
 }
 
+// singleCharOps lists every one-byte operator. It is a constant, so slicing it
+// (singleOpText below) yields a string header pointing into the binary's
+// read-only data — emitting an operator token allocates nothing, where
+// `string(c)` allocated a fresh 1-byte string per token (rule 7).
+const singleCharOps = "+-*/%.,;()[]{}=<>!&|?:@\\"
+
+// singleOpText[c] is the token text for the single-character operator c, or ""
+// when c does not start an operator. Built once at package scope (rule 7).
+var singleOpText = func() [utf8.RuneSelf]string {
+	var out [utf8.RuneSelf]string
+	for i := 0; i < len(singleCharOps); i++ {
+		out[singleCharOps[i]] = singleCharOps[i : i+1]
+	}
+	return out
+}()
+
+// multiOpsByFirst buckets multiCharOps by their first byte, longest first, so
+// lexOperator compares against the two or three candidates that can match
+// rather than walking the whole table. Longest-first ordering is what keeps
+// "===" from being split into "==" and "=".
+var multiOpsByFirst = func() [utf8.RuneSelf][]string {
+	var out [utf8.RuneSelf][]string
+	for _, op := range multiCharOps {
+		c := op[0]
+		out[c] = append(out[c], op)
+	}
+	for c := range out {
+		ops := out[c]
+		sort.SliceStable(ops, func(i, j int) bool { return len(ops[i]) > len(ops[j]) })
+	}
+	return out
+}()
+
+// bytesPerToken estimates how many source bytes one token consumes, used to
+// presize the token slice (rule 6). Measured over the in-tree PHP fixtures the
+// ratio is 3.7–5.2 bytes per token (whitespace and comments are dropped, so the
+// count is well below the tokenizer's). Four is the conservative end: it costs
+// a little slack on comment-heavy files and avoids the doubling — which copies
+// the whole slice — on dense ones.
+const bytesPerToken = 4
+
 func (l *lexer) run() ([]token, error) {
+	l.tokens = make([]token, 0, len(l.src)/bytesPerToken+8)
 	l.skipShebang()
 	for l.pos < len(l.src) {
 		if !l.inPHP {
@@ -191,7 +235,32 @@ func (l *lexer) lexNumber() {
 
 func (l *lexer) lexString(quote byte) error {
 	l.advanceRune() // opening quote
+
+	// Fast path: a literal with no escape sequence is a substring of the
+	// source, so it needs neither a Builder nor a copy.
+	start := l.pos
+	for i := start; i < len(l.src); i++ {
+		c := l.src[i]
+		if c == '\\' {
+			break
+		}
+		if c == quote {
+			val := l.src[start:i]
+			l.advance(i - start) // keeps the line counter accurate
+			l.advanceRune()      // closing quote
+			l.emit(tString, val)
+			return nil
+		}
+	}
+
+	// Slow path: the literal contains at least one escape. Presize the builder
+	// (rule 6) — the decoded string is never longer than the raw source up to
+	// the next unescaped quote, and the first quote found is a lower bound for
+	// that, so one Grow replaces the 8/16/32 doubling.
 	var b strings.Builder
+	if end := strings.IndexByte(l.src[start:], quote); end > 0 {
+		b.Grow(end)
+	}
 	for l.pos < len(l.src) {
 		c := l.src[l.pos]
 		if c == '\\' && l.pos+1 < len(l.src) {
@@ -223,19 +292,27 @@ func (l *lexer) lexString(quote byte) error {
 	return fmt.Errorf("line %d: unterminated string", l.line)
 }
 
+// lexOperator emits one operator token, matching multi-character operators
+// greedily. Every token text comes from a package-level table, so no operator
+// allocates.
 func (l *lexer) lexOperator() bool {
-	for _, op := range multiCharOps {
-		if strings.HasPrefix(l.src[l.pos:], op) {
+	c := l.src[l.pos]
+	if c >= utf8.RuneSelf {
+		return false
+	}
+	rest := l.src[l.pos:]
+	for _, op := range multiOpsByFirst[c] {
+		if strings.HasPrefix(rest, op) {
 			l.emit(tOp, op)
-			l.advance(len(op))
+			// Operator text never contains a newline, so the line counter
+			// does not need advanceRune's per-byte check.
+			l.pos += len(op)
 			return true
 		}
 	}
-	const singles = "+-*/%.,;()[]{}=<>!&|?:@\\"
-	c := l.src[l.pos]
-	if strings.IndexByte(singles, c) >= 0 {
-		l.emit(tOp, string(c))
-		l.advanceRune()
+	if text := singleOpText[c]; text != "" {
+		l.emit(tOp, text)
+		l.pos++
 		return true
 	}
 	return false

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -1,0 +1,207 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lexAll runs the lexer over src and fails the test on error.
+func lexAll(t *testing.T, src string) []token {
+	t.Helper()
+	toks, err := newLexer(src).run()
+	if err != nil {
+		t.Fatalf("lex %q: %v", src, err)
+	}
+	return toks
+}
+
+// singleCharOperators lists every one-byte operator lexOperator accepts. It is
+// spelled out here (rather than referencing the implementation constant) so the
+// test fails if the set silently changes.
+const singleCharOperators = "+-*/%.,;()[]{}=<>!&|?:@\\"
+
+func TestLexSingleCharOperators(t *testing.T) {
+	for i := 0; i < len(singleCharOperators); i++ {
+		op := singleCharOperators[i : i+1]
+		toks := lexAll(t, "<?php "+op)
+		if len(toks) != 2 {
+			t.Fatalf("%q: got %d tokens, want 2: %v", op, len(toks), toks)
+		}
+		if toks[0].kind != tOp || toks[0].val != op {
+			t.Errorf("%q: got %v, want tOp(%q)", op, toks[0], op)
+		}
+		if toks[1].kind != tEOF {
+			t.Errorf("%q: last token %v, want tEOF", op, toks[1])
+		}
+	}
+}
+
+func TestLexMultiCharOperators(t *testing.T) {
+	for _, op := range multiCharOps {
+		toks := lexAll(t, "<?php "+op)
+		if len(toks) != 2 {
+			t.Fatalf("%q: got %d tokens, want 2: %v", op, len(toks), toks)
+		}
+		if toks[0].kind != tOp || toks[0].val != op {
+			t.Errorf("%q: got %v, want tOp(%q) (mis-split?)", op, toks[0], op)
+		}
+	}
+}
+
+// TestLexOperatorGreedy pins the boundaries between operators that share a
+// prefix, so a table reordering cannot silently split "===" into "==" + "=".
+func TestLexOperatorGreedy(t *testing.T) {
+	cases := []struct {
+		src  string
+		want []string
+	}{
+		{"===", []string{"==="}},
+		{"====", []string{"===", "="}},
+		{"==", []string{"=="}},
+		{"=", []string{"="}},
+		{"!==", []string{"!=="}},
+		{"!=", []string{"!="}},
+		{"!", []string{"!"}},
+		{"<=", []string{"<="}},
+		{"<<=", []string{"<<="}},
+		{"<<", []string{"<", "<"}},
+		{">>=", []string{">>="}},
+		{">=", []string{">="}},
+		{"**=", []string{"**="}},
+		{"**", []string{"*", "*"}},
+		{"->", []string{"->"}},
+		{"-", []string{"-"}},
+		{"--", []string{"--"}},
+		{"---", []string{"--", "-"}},
+		{"=>", []string{"=>"}},
+		{"++", []string{"++"}},
+		{"+=", []string{"+="}},
+		{".=", []string{".="}},
+		{"..", []string{".", "."}},
+		{"::", []string{"::"}},
+		{":", []string{":"}},
+		{":::", []string{"::", ":"}},
+		{"&&", []string{"&&"}},
+		{"&", []string{"&"}},
+		{"||", []string{"||"}},
+		{"|", []string{"|"}},
+		{"*=", []string{"*="}},
+		{"/=", []string{"/="}},
+		{"%=", []string{"%="}},
+		{"-=", []string{"-="}},
+	}
+	for _, tc := range cases {
+		toks := lexAll(t, "<?php "+tc.src)
+		var got []string
+		for _, tok := range toks {
+			if tok.kind == tEOF {
+				break
+			}
+			if tok.kind != tOp {
+				t.Fatalf("%q: unexpected non-operator token %v", tc.src, tok)
+			}
+			got = append(got, tok.val)
+		}
+		if strings.Join(got, "\x00") != strings.Join(tc.want, "\x00") {
+			t.Errorf("%q: got %q, want %q", tc.src, got, tc.want)
+		}
+	}
+}
+
+// TestLexOperatorNoAlloc is the regression test for the boxed operator table:
+// emitting an operator token must not allocate a string.
+func TestLexOperatorNoAlloc(t *testing.T) {
+	for _, src := range []string{
+		strings.Repeat("(", 64),   // single-char
+		strings.Repeat(";", 64),   // single-char
+		strings.Repeat("+", 64),   // lexes as "++" pairs
+		strings.Repeat("===", 64), // multi-char, longest match
+		strings.Repeat("->", 64),  // multi-char
+	} {
+		l := &lexer{src: src, line: 1, inPHP: true, tokens: make([]token, 0, 256)}
+		allocs := testing.AllocsPerRun(50, func() {
+			l.pos = 0
+			l.tokens = l.tokens[:0]
+			for l.pos < len(l.src) {
+				if !l.lexOperator() {
+					t.Fatalf("lexOperator rejected %q", l.src[l.pos])
+				}
+			}
+		})
+		if allocs != 0 {
+			t.Errorf("lexing %q...: %.0f allocs/run, want 0", src[:3], allocs)
+		}
+	}
+}
+
+func TestLexOperatorPositionsAndLines(t *testing.T) {
+	src := "<?php\n$a->b;\n$c[1] = 2;\n"
+	toks := lexAll(t, src)
+	type want struct {
+		kind tokKind
+		val  string
+		line int
+	}
+	wants := []want{
+		{tVar, "a", 2}, {tOp, "->", 2}, {tIdent, "b", 2}, {tOp, ";", 2},
+		{tVar, "c", 3}, {tOp, "[", 3}, {tInt, "1", 3}, {tOp, "]", 3},
+		{tOp, "=", 3}, {tInt, "2", 3}, {tOp, ";", 3},
+		{tEOF, "", 4},
+	}
+	if len(toks) != len(wants) {
+		t.Fatalf("got %d tokens, want %d: %v", len(toks), len(wants), toks)
+	}
+	for i, w := range wants {
+		got := toks[i]
+		if got.kind != w.kind || got.val != w.val || got.line != w.line {
+			t.Errorf("token %d: got %v line %d, want %v(%q) line %d", i, got, got.line, w.kind, w.val, w.line)
+		}
+	}
+}
+
+func TestLexLineNumbersAcrossConstructs(t *testing.T) {
+	src := "a\n<?php\n// comment\n/* two\nlines */\n$x = \"str\";\n?>\nhtml\n<?php $y = 1;"
+	toks := lexAll(t, src)
+	byVal := map[string]int{}
+	for _, tok := range toks {
+		if tok.kind == tVar {
+			byVal[tok.val] = tok.line
+		}
+	}
+	if byVal["x"] != 6 {
+		t.Errorf("$x on line %d, want 6", byVal["x"])
+	}
+	if byVal["y"] != 9 {
+		t.Errorf("$y on line %d, want 9", byVal["y"])
+	}
+}
+
+func TestLexRejectsUnknownCharacter(t *testing.T) {
+	if _, err := newLexer("<?php ~").run(); err == nil {
+		t.Fatal("expected an error for an unsupported character")
+	}
+}
+
+// fixtureSource reads a PHP file from the repository fixtures. The fixtures are
+// read-only inputs for the parser benchmarks.
+func fixtureSource(tb testing.TB, name string) string {
+	tb.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "tests", "fixtures", "code", name))
+	if err != nil {
+		tb.Skipf("fixture %s unavailable: %v", name, err)
+	}
+	return string(b)
+}
+
+func BenchmarkLexCompiler(b *testing.B) {
+	src := fixtureSource(b, "Compiler.php")
+	b.SetBytes(int64(len(src)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := newLexer(src).run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,9 @@ func Parse(src string) (*model.Program, error) {
 	if err != nil {
 		return nil, err
 	}
-	p := &parser{toks: toks, spans: make(map[model.Stmt]model.SourceSpan)}
+	// One span per statement; statements run around one per sixteen tokens, so
+	// the hint saves the map's rehash-and-copy cycle (rule 6).
+	p := &parser{toks: toks, spans: make(map[model.Stmt]model.SourceSpan, len(toks)/16+8)}
 	stmts, err := p.parseStmts(true)
 	if err != nil {
 		return nil, err
@@ -39,6 +41,27 @@ type parser struct {
 	topLevel  bool
 	topSeen   bool
 	spans     map[model.Stmt]model.SourceSpan
+
+	// Chunked node storage and list scratch stacks; see alloc.go.
+	varNodes        nodeChunk[model.Var]
+	litNodes        nodeChunk[model.Lit]
+	binaryNodes     nodeChunk[model.Binary]
+	indexNodes      nodeChunk[model.Index]
+	propNodes       nodeChunk[model.PropAccess]
+	methodNodes     nodeChunk[model.MethodCall]
+	callNodes       nodeChunk[model.Call]
+	parenNodes      nodeChunk[model.Parenthesized]
+	unaryNodes      nodeChunk[model.Unary]
+	assignExprNodes nodeChunk[model.AssignExpr]
+	exprStmtNodes   nodeChunk[model.ExprStmt]
+	assignNodes     nodeChunk[model.Assign]
+	echoNodes       nodeChunk[model.Echo]
+	arrayLitNodes   nodeChunk[model.ArrayLit]
+
+	exprs  scratch[model.Expr]
+	stmts  scratch[model.Stmt]
+	params scratch[model.Param]
+	items  scratch[model.ArrayItem]
 }
 
 func (p *parser) cur() token { return p.toks[p.i] }
@@ -87,13 +110,14 @@ func (p *parser) parseStmts(top bool) ([]model.Stmt, error) {
 	wasTopLevel := p.topLevel
 	p.topLevel = top
 	defer func() { p.topLevel = wasTopLevel }()
-	var out []model.Stmt
+	mark := p.stmts.mark()
 	for !p.atEOF() {
 		if !top && p.isOp("}") {
 			break
 		}
 		s, err := p.parseStmt()
 		if err != nil {
+			p.stmts.drop(mark)
 			return nil, err
 		}
 		if s != nil {
@@ -104,13 +128,14 @@ func (p *parser) parseStmts(top bool) ([]model.Stmt, error) {
 				switch s.(type) {
 				case *model.ClassDecl, *model.FuncDecl:
 				default:
+					p.stmts.drop(mark)
 					return nil, fmt.Errorf("line %d: namespaced files may only declare symbols", p.cur().line)
 				}
 			}
-			out = append(out, s)
+			p.stmts.push(s)
 		}
 	}
-	return out, nil
+	return p.stmts.take(mark), nil
 }
 
 func (p *parser) parseStmt() (model.Stmt, error) {
@@ -234,7 +259,13 @@ func (p *parser) parseQualifiedName(leading bool) (string, bool, error) {
 	if p.cur().kind != tIdent {
 		return "", absolute, fmt.Errorf("expected name, got %s", p.cur())
 	}
-	parts := []string{p.next().val}
+	first := p.next().val
+	// Unqualified name (the common case): the token text is the whole name, so
+	// neither the parts slice nor the Join copy is needed.
+	if !p.isOp("\\") {
+		return first, absolute, nil
+	}
+	parts := []string{first}
 	for p.isOp("\\") {
 		p.next()
 		if p.cur().kind != tIdent {
@@ -254,13 +285,14 @@ func (p *parser) qualify(name string, absolute bool) string {
 
 func (p *parser) parseEcho() (model.Stmt, error) {
 	p.next() // echo
-	var args []model.Expr
+	mark := p.exprs.mark()
 	for {
 		e, err := p.parseExpr()
 		if err != nil {
+			p.exprs.drop(mark)
 			return nil, err
 		}
-		args = append(args, e)
+		p.exprs.push(e)
 		if p.isOp(",") {
 			p.next()
 			continue
@@ -268,7 +300,7 @@ func (p *parser) parseEcho() (model.Stmt, error) {
 		break
 	}
 	p.optSemi()
-	return &model.Echo{Args: args}, nil
+	return p.newEcho(p.exprs.take(mark)), nil
 }
 
 func (p *parser) parseIf() (model.Stmt, error) {
@@ -587,17 +619,18 @@ func (p *parser) parseSwitch() (model.Stmt, error) {
 
 // parseCaseBody parses statements until the next case/default or closing brace.
 func (p *parser) parseCaseBody() ([]model.Stmt, error) {
-	var out []model.Stmt
+	mark := p.stmts.mark()
 	for !p.isOp("}") && !p.atEOF() && !p.isKw("case") && !p.isKw("default") {
 		s, err := p.parseStmt()
 		if err != nil {
+			p.stmts.drop(mark)
 			return nil, err
 		}
 		if s != nil {
-			out = append(out, s)
+			p.stmts.push(s)
 		}
 	}
-	return out, nil
+	return p.stmts.take(mark), nil
 }
 
 func (p *parser) parseFunction() (model.Stmt, error) {
@@ -637,9 +670,10 @@ func (p *parser) parseParams() ([]model.Param, error) {
 	if err := p.eatOp("("); err != nil {
 		return nil, err
 	}
-	var params []model.Param
+	mark := p.params.mark()
 	for !p.isOp(")") {
 		if p.cur().kind != tVar {
+			p.params.drop(mark)
 			return nil, fmt.Errorf("line %d: expected parameter $var", p.cur().line)
 		}
 		pr := model.Param{Name: p.next().val}
@@ -647,16 +681,17 @@ func (p *parser) parseParams() ([]model.Param, error) {
 			p.next()
 			def, err := p.parseExpr()
 			if err != nil {
+				p.params.drop(mark)
 				return nil, err
 			}
 			pr.Default = def
 		}
-		params = append(params, pr)
+		p.params.push(pr)
 		if p.isOp(",") {
 			p.next()
 		}
 	}
-	return params, p.eatOp(")")
+	return p.params.take(mark), p.eatOp(")")
 }
 
 func (p *parser) parseClass(abstract bool) (model.Stmt, error) {
@@ -862,9 +897,9 @@ func (p *parser) parseSimpleStmt() (model.Stmt, error) {
 	// parseExpr already folds assignment into an AssignExpr; lower it to a
 	// statement-level Assign so the interpreter's mutation path handles it.
 	if ae, ok := model.UnwrapParenthesized(lhs).(*model.AssignExpr); ok {
-		return &model.Assign{Target: ae.Target, Op: ae.Op, Value: ae.Value}, nil
+		return p.newAssign(ae.Target, ae.Op, ae.Value), nil
 	}
-	return &model.ExprStmt{X: lhs}, nil
+	return p.newExprStmt(lhs), nil
 }
 
 func isAssignOp(v string) bool {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,260 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+func mustParse(t *testing.T, src string) *model.Program {
+	t.Helper()
+	prog, err := Parse(src)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	return prog
+}
+
+func TestParseEchoArgs(t *testing.T) {
+	prog := mustParse(t, `<?php echo "a", $b, 1 + 2;`)
+	if len(prog.Stmts) != 1 {
+		t.Fatalf("got %d statements, want 1", len(prog.Stmts))
+	}
+	e, ok := prog.Stmts[0].(*model.Echo)
+	if !ok {
+		t.Fatalf("got %T, want *model.Echo", prog.Stmts[0])
+	}
+	if len(e.Args) != 3 {
+		t.Fatalf("got %d echo args, want 3", len(e.Args))
+	}
+	if cap(e.Args) != len(e.Args) {
+		t.Errorf("echo args cap %d, want exactly %d", cap(e.Args), len(e.Args))
+	}
+	if lit, ok := e.Args[0].(*model.Lit); !ok || lit.Value != "a" {
+		t.Errorf("arg 0 = %#v, want Lit(\"a\")", e.Args[0])
+	}
+	if v, ok := e.Args[1].(*model.Var); !ok || v.Name != "b" {
+		t.Errorf("arg 1 = %#v, want Var(b)", e.Args[1])
+	}
+	if bin, ok := e.Args[2].(*model.Binary); !ok || bin.Op != "+" {
+		t.Errorf("arg 2 = %#v, want Binary(+)", e.Args[2])
+	}
+}
+
+func TestParseBinaryPrecedence(t *testing.T) {
+	prog := mustParse(t, `<?php $r = 1 + 2 * 3 . "x" == $y;`)
+	as, ok := prog.Stmts[0].(*model.Assign)
+	if !ok {
+		t.Fatalf("got %T, want *model.Assign", prog.Stmts[0])
+	}
+	eq, ok := as.Value.(*model.Binary)
+	if !ok || eq.Op != "==" {
+		t.Fatalf("top = %#v, want Binary(==)", as.Value)
+	}
+	concat, ok := eq.Left.(*model.Binary)
+	if !ok || concat.Op != "." {
+		t.Fatalf("left = %#v, want Binary(.)", eq.Left)
+	}
+	add, ok := concat.Left.(*model.Binary)
+	if !ok || add.Op != "+" {
+		t.Fatalf("concat left = %#v, want Binary(+)", concat.Left)
+	}
+	mul, ok := add.Right.(*model.Binary)
+	if !ok || mul.Op != "*" {
+		t.Fatalf("add right = %#v, want Binary(*)", add.Right)
+	}
+}
+
+func TestParsePostfixChain(t *testing.T) {
+	prog := mustParse(t, `<?php $a = $this->b[0]->c($d)[1];`)
+	as := prog.Stmts[0].(*model.Assign)
+	idx, ok := as.Value.(*model.Index)
+	if !ok {
+		t.Fatalf("got %T, want *model.Index", as.Value)
+	}
+	call, ok := idx.Base.(*model.MethodCall)
+	if !ok || call.Method != "c" {
+		t.Fatalf("index base = %#v, want MethodCall(c)", idx.Base)
+	}
+	prop, ok := call.Base.(*model.Index)
+	if !ok {
+		t.Fatalf("call base = %#v, want Index", call.Base)
+	}
+	if pa, ok := prop.Base.(*model.PropAccess); !ok || pa.Name != "b" {
+		t.Fatalf("inner = %#v, want PropAccess(b)", prop.Base)
+	}
+}
+
+// TestParseNodesAreDistinct guards the chunked node allocation: every AST node
+// must keep its own address, because runner.compileExpr caches compiled
+// expressions in a map keyed by model.Expr pointer identity.
+func TestParseNodesAreDistinct(t *testing.T) {
+	prog := mustParse(t, `<?php
+	$a = $x + $x + $x;
+	$b = 1 + 1 + 1;
+	f($x, $x, $x);
+	$c = $x->y->y->y;
+	`)
+	seen := map[model.Expr]bool{}
+	var walk func(e model.Expr)
+	walk = func(e model.Expr) {
+		if e == nil {
+			return
+		}
+		if seen[e] {
+			t.Fatalf("expression node %#v reused at two positions in the AST", e)
+		}
+		seen[e] = true
+		switch n := e.(type) {
+		case *model.Binary:
+			walk(n.Left)
+			walk(n.Right)
+		case *model.Unary:
+			walk(n.X)
+		case *model.Parenthesized:
+			walk(n.X)
+		case *model.Index:
+			walk(n.Base)
+			walk(n.Index)
+		case *model.PropAccess:
+			walk(n.Base)
+		case *model.MethodCall:
+			walk(n.Base)
+			for _, a := range n.Args {
+				walk(a)
+			}
+		case *model.Call:
+			for _, a := range n.Args {
+				walk(a)
+			}
+		}
+	}
+	for _, s := range prog.Stmts {
+		switch n := s.(type) {
+		case *model.Assign:
+			walk(n.Target)
+			walk(n.Value)
+		case *model.ExprStmt:
+			walk(n.X)
+		}
+	}
+	if len(seen) < 20 {
+		t.Fatalf("walked only %d nodes, expected the full tree", len(seen))
+	}
+}
+
+func TestParseSourceSpansPerStatement(t *testing.T) {
+	prog := mustParse(t, "<?php\n$a = 1;\n\n$b =\n  2;\n")
+	if len(prog.Stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(prog.Stmts))
+	}
+	if got := prog.SourceSpans[prog.Stmts[0]]; got.Start != 2 || got.End != 2 {
+		t.Errorf("stmt 0 span %+v, want {2 2}", got)
+	}
+	if got := prog.SourceSpans[prog.Stmts[1]]; got.Start != 4 || got.End != 5 {
+		t.Errorf("stmt 1 span %+v, want {4 5}", got)
+	}
+}
+
+func TestParseStructuralSlicesAreExact(t *testing.T) {
+	prog := mustParse(t, `<?php
+	function f($a, $b, $c) {
+		$x = array(1, 2, 3);
+		g($a, $b);
+		return $x;
+	}
+	class K {
+		var $one = 1, $two = 2;
+		const A = 1, B = 2;
+		function m() { return 1; }
+	}
+	`)
+	if got := len(prog.Stmts); got != 2 {
+		t.Fatalf("got %d statements, want 2", got)
+	}
+	if cap(prog.Stmts) != len(prog.Stmts) {
+		t.Errorf("program stmts cap %d, want %d", cap(prog.Stmts), len(prog.Stmts))
+	}
+	fn := prog.Stmts[0].(*model.FuncDecl)
+	if len(fn.Params) != 3 || cap(fn.Params) != 3 {
+		t.Errorf("params len/cap = %d/%d, want 3/3", len(fn.Params), cap(fn.Params))
+	}
+	if len(fn.Body) != 3 || cap(fn.Body) != 3 {
+		t.Errorf("body len/cap = %d/%d, want 3/3", len(fn.Body), cap(fn.Body))
+	}
+	call := fn.Body[1].(*model.ExprStmt).X.(*model.Call)
+	if len(call.Args) != 2 || cap(call.Args) != 2 {
+		t.Errorf("args len/cap = %d/%d, want 2/2", len(call.Args), cap(call.Args))
+	}
+	arr := fn.Body[0].(*model.Assign).Value.(*model.ArrayLit)
+	if len(arr.Items) != 3 || cap(arr.Items) != 3 {
+		t.Errorf("array items len/cap = %d/%d, want 3/3", len(arr.Items), cap(arr.Items))
+	}
+	cls := prog.Stmts[1].(*model.ClassDecl)
+	if len(cls.Fields) != 2 {
+		t.Errorf("got %d fields, want 2", len(cls.Fields))
+	}
+	if len(cls.Consts) != 2 {
+		t.Errorf("got %d consts, want 2", len(cls.Consts))
+	}
+	if len(cls.Methods) != 1 {
+		t.Errorf("got %d methods, want 1", len(cls.Methods))
+	}
+}
+
+func TestParseNestedArgumentLists(t *testing.T) {
+	prog := mustParse(t, `<?php f(g(1, 2), h(3, i(4, 5), 6), 7);`)
+	outer := prog.Stmts[0].(*model.ExprStmt).X.(*model.Call)
+	if outer.Name != "f" || len(outer.Args) != 3 {
+		t.Fatalf("outer = %s/%d args, want f/3", outer.Name, len(outer.Args))
+	}
+	g := outer.Args[0].(*model.Call)
+	if g.Name != "g" || len(g.Args) != 2 {
+		t.Fatalf("g = %s/%d args, want g/2", g.Name, len(g.Args))
+	}
+	h := outer.Args[1].(*model.Call)
+	if h.Name != "h" || len(h.Args) != 3 {
+		t.Fatalf("h = %s/%d args, want h/3", h.Name, len(h.Args))
+	}
+	i := h.Args[1].(*model.Call)
+	if i.Name != "i" || len(i.Args) != 2 {
+		t.Fatalf("i = %s/%d args, want i/2", i.Name, len(i.Args))
+	}
+	if lit := outer.Args[2].(*model.Lit); lit.Value != int64(7) {
+		t.Errorf("last arg = %#v, want Lit(7)", lit.Value)
+	}
+}
+
+func TestParseFixtures(t *testing.T) {
+	for _, name := range []string{
+		"Compiler.php", "Template.php", "TestCase.php", "functions.php",
+		"TemplateTest_phpscript.php",
+	} {
+		src := fixtureSource(t, name)
+		if _, err := Parse(src); err != nil {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+}
+
+func BenchmarkParseCompiler(b *testing.B) {
+	src := fixtureSource(b, "Compiler.php")
+	b.SetBytes(int64(len(src)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := Parse(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseTemplate(b *testing.B) {
+	src := fixtureSource(b, "Template.php")
+	b.SetBytes(int64(len(src)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := Parse(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/parser/tokenizer.go
+++ b/parser/tokenizer.go
@@ -3,8 +3,7 @@ package parser
 import (
 	"strings"
 	"unicode"
-
-	"github.com/titpetric/phpscript/model"
+	"unicode/utf8"
 )
 
 // This file provides a PHP-compatible tokenizer: TokenGetAll / TokenName plus
@@ -17,8 +16,15 @@ import (
 //   - a single-character string (e.g. "(", ")", ";"), or
 //   - a 3-element array [int id, string text, int line].
 //
-// We reproduce that shape using the VM's own *model.Array so the result flows
-// straight into transpiled PHP code (foreach, $v[0], $v[1], is_array, ...).
+// We reproduce that shape with native Go values — a []any of single-char
+// strings and []any{int64 id, string text, int64 line} triples. The VM reads
+// slices through model.RangeValues / reflection, so the result still flows
+// straight into transpiled PHP code (foreach, $v[0], $v[1], is_array, count,
+// and element writes such as $v[0] = token_name($v[0])). It does not support
+// `$tokens[] = ...`; no in-tree caller appends to a token list. See
+// docs/allocation-performance.md rules 2, 4 and 6 for why this beats the
+// *model.Array of *model.Array it replaced.
+//
 // Register it on a runtime with:
 //
 //	rt.RegisterFunc("token_get_all", parser.TokenGetAll)
@@ -180,23 +186,68 @@ func TokenName(id int) string {
 	return "UNKNOWN"
 }
 
-// TokenGetAll tokenizes src the way PHP's token_get_all does, returning a
-// *model.Array of single-char strings and [id, text, line] arrays.
-func TokenGetAll(src string) *model.Array {
+// boxedInts holds pre-boxed int64 values so that emitting a token id or a line
+// number costs no allocation. The runtime only interns 0–255 itself
+// (runtime.staticuint64s); every T_* id is >= 256 and templates run past line
+// 255, so both would otherwise allocate 8 bytes per token.
+var boxedInts = func() [boxedIntMax]any {
+	var out [boxedIntMax]any
+	for i := range out {
+		out[i] = int64(i)
+	}
+	return out
+}()
+
+const boxedIntMax = 1024
+
+func boxInt(v int) any {
+	if v >= 0 && v < boxedIntMax {
+		return boxedInts[v]
+	}
+	return int64(v)
+}
+
+// boxedChars holds pre-boxed one-byte strings for the single-character tokens
+// ("(", ")", ";", ...), which are the most frequent tokens in any source file.
+var boxedChars = func() [utf8.RuneSelf]any {
+	var out [utf8.RuneSelf]any
+	for i := range out {
+		out[i] = string(rune(i))
+	}
+	return out
+}()
+
+// The [id, text, line] triples are carved out of chunked backing arrays rather
+// than allocated one by one. Chunks start small and double so that a two-line
+// minitpl expression does not pay for a large block, and a whole file amortises
+// the per-token allocation away. Each triple is handed to PHP as a 3-element
+// slice with cap == len, so a script cannot scribble past its own token.
+const (
+	tokenChunkMin = 8
+	tokenChunkMax = 64
+)
+
+// TokenGetAll tokenizes src the way PHP's token_get_all does, returning a []any
+// of single-char strings and []any{id, text, line} triples.
+func TokenGetAll(src string) []any {
 	tk := &phpTokenizer{src: src, line: 1}
 	return tk.run()
 }
 
 type phpTokenizer struct {
-	src   string
-	pos   int
-	line  int
-	inPHP bool
-	out   *model.Array
+	src       string
+	pos       int
+	line      int
+	inPHP     bool
+	out       []any
+	chunk     []any
+	chunkSize int
 }
 
-func (t *phpTokenizer) run() *model.Array {
-	t.out = model.NewArray()
+func (t *phpTokenizer) run() []any {
+	// Presize (rule 6): PHP averages a little under one token every four bytes
+	// once whitespace runs and inline HTML are collapsed into single tokens.
+	t.out = make([]any, 0, len(t.src)/4+8)
 	for t.pos < len(t.src) {
 		if !t.inPHP {
 			t.scanInlineHTML()
@@ -209,15 +260,31 @@ func (t *phpTokenizer) run() *model.Array {
 
 // emitArr appends an [id, text, line] token.
 func (t *phpTokenizer) emitArr(id int, text string, line int) {
-	a := model.NewArray()
-	a.Append(int64(id))
-	a.Append(text)
-	a.Append(int64(line))
-	t.out.Append(a)
+	if len(t.chunk) == 0 {
+		switch {
+		case t.chunkSize == 0:
+			t.chunkSize = tokenChunkMin
+		case t.chunkSize < tokenChunkMax:
+			t.chunkSize *= 2
+		}
+		t.chunk = make([]any, 3*t.chunkSize)
+	}
+	triple := t.chunk[0:3:3]
+	t.chunk = t.chunk[3:]
+	triple[0] = boxInt(id)
+	triple[1] = text
+	triple[2] = boxInt(line)
+	t.out = append(t.out, triple)
 }
 
 // emitChar appends a single-character (string) token.
-func (t *phpTokenizer) emitChar(text string) { t.out.Append(text) }
+func (t *phpTokenizer) emitChar(c byte) {
+	if c < utf8.RuneSelf {
+		t.out = append(t.out, boxedChars[c])
+		return
+	}
+	t.out = append(t.out, string(c))
+}
 
 func (t *phpTokenizer) scanInlineHTML() {
 	start := t.pos
@@ -278,7 +345,7 @@ func (t *phpTokenizer) scanPHP() {
 		default:
 			if !t.scanOperator() {
 				// Unknown byte: emit as a single-char token (PHP-ish).
-				t.emitChar(string(c))
+				t.emitChar(c)
 				t.advance()
 			}
 		}
@@ -398,7 +465,7 @@ func (t *phpTokenizer) scanOperator() bool {
 	const singles = "+-*/%.,;()[]{}=<>!&|?:@~^"
 	c := t.src[t.pos]
 	if strings.IndexByte(singles, c) >= 0 {
-		t.emitChar(string(c))
+		t.emitChar(c)
 		t.advance()
 		return true
 	}

--- a/parser/tokenizer_test.go
+++ b/parser/tokenizer_test.go
@@ -1,9 +1,9 @@
 package parser_test
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 )
 
@@ -14,13 +14,14 @@ func tokTriple(t *testing.T, v any) (int, string) {
 	if s, ok := v.(string); ok {
 		return -1, s
 	}
-	arr, ok := v.(*model.Array)
+	tok, ok := v.([]any)
 	if !ok {
-		t.Fatalf("token is neither string nor *Array: %T", v)
+		t.Fatalf("token is neither string nor []any: %T", v)
 	}
-	id, _ := arr.Get(int64(0))
-	text, _ := arr.Get(int64(1))
-	return int(id.(int64)), text.(string)
+	if len(tok) != 3 {
+		t.Fatalf("token has %d elements, want 3: %v", len(tok), tok)
+	}
+	return int(tok[0].(int64)), tok[1].(string)
 }
 
 func TestTokenGetAllShape(t *testing.T) {
@@ -31,14 +32,13 @@ func TestTokenGetAllShape(t *testing.T) {
 		id   int
 		text string
 	}
-	toks.Range(func(_, v any) bool {
+	for _, v := range toks {
 		id, text := tokTriple(t, v)
 		got = append(got, struct {
 			id   int
 			text string
 		}{id, text})
-		return true
-	})
+	}
 
 	// Verify key tokens are classified the way minitpl's _split_exp expects.
 	var sawOpenTag, sawIf, sawVar, sawArrow bool
@@ -60,6 +60,46 @@ func TestTokenGetAllShape(t *testing.T) {
 	}
 }
 
+// TestTokenTripleIsIsolated guards the chunked backing array: each triple must
+// report cap 3 so a PHP-side append cannot scribble over the next token.
+func TestTokenTripleIsIsolated(t *testing.T) {
+	toks := parser.TokenGetAll("<?php $a = 1;\n$b = 2;\n$c = 3;\n")
+	var triples int
+	for _, v := range toks {
+		tok, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		triples++
+		if len(tok) != 3 || cap(tok) != 3 {
+			t.Fatalf("triple %v has len %d cap %d, want 3/3", tok, len(tok), cap(tok))
+		}
+	}
+	if triples == 0 {
+		t.Fatal("no array-form tokens produced")
+	}
+}
+
+// TestTokenLineNumbers checks that lines beyond the runtime's interned-int
+// range (0..255) still box correctly through boxInt.
+func TestTokenLineNumbers(t *testing.T) {
+	src := "<?php\n" + strings.Repeat("$a;\n", 1500) + "$last;"
+	toks := parser.TokenGetAll(src)
+	var lastLine int
+	for _, v := range toks {
+		tok, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		if tok[0].(int64) == int64(parser.T_VARIABLE) && tok[1].(string) == "$last" {
+			lastLine = int(tok[2].(int64))
+		}
+	}
+	if lastLine != 1502 {
+		t.Fatalf("$last reported on line %d, want 1502", lastLine)
+	}
+}
+
 func TestIfConditionSyntax(t *testing.T) {
 	if _, err := parser.Parse(`<?php $foo = false; if !$foo { echo "no"; }`); err != nil {
 		t.Fatalf("unwrapped if condition failed to parse: %v", err)
@@ -73,12 +113,11 @@ func TestIfConditionSyntax(t *testing.T) {
 func TestTokenSingleCharStrings(t *testing.T) {
 	toks := parser.TokenGetAll(`<?php ($a);`)
 	var parens int
-	toks.Range(func(_, v any) bool {
+	for _, v := range toks {
 		if s, ok := v.(string); ok && (s == "(" || s == ")" || s == ";") {
 			parens++
 		}
-		return true
-	})
+	}
 	if parens != 3 {
 		t.Fatalf("expected 3 single-char tokens, got %d", parens)
 	}
@@ -104,17 +143,61 @@ func TestTokenVariableWithDotMarker(t *testing.T) {
 	// part of one T_VARIABLE; verify that holds.
 	toks := parser.TokenGetAll(`<?php $foo__1bar`)
 	var found string
-	toks.Range(func(_, v any) bool {
-		if arr, ok := v.(*model.Array); ok {
-			id, _ := arr.Get(int64(0))
-			if int(id.(int64)) == parser.T_VARIABLE {
-				txt, _ := arr.Get(int64(1))
-				found = txt.(string)
+	for _, v := range toks {
+		if tok, ok := v.([]any); ok {
+			if int(tok[0].(int64)) == parser.T_VARIABLE {
+				found = tok[1].(string)
 			}
 		}
-		return true
-	})
+	}
 	if found != "$foo__1bar" {
 		t.Fatalf("got %q, want $foo__1bar", found)
+	}
+}
+
+// benchTemplate is a minitpl-shaped template: inline HTML interleaved with
+// short PHP expressions, which is what the compiler tokenizes on every include.
+const benchTemplate = `<html>
+<head><title><?php echo $this->_vars['title']; ?></title></head>
+<body>
+<?php if ($this->_vars['user']) { ?>
+	<p>Hello, <?php echo $this->_vars['user']['name']; ?>!</p>
+<?php } else { ?>
+	<p>Please <a href="/login">sign in</a>.</p>
+<?php } ?>
+<ul>
+<?php foreach ($this->_vars['items'] as $k => $item) { ?>
+	<li id="item-<?php echo $k; ?>">
+		<span class="name"><?php echo $item['name']; ?></span>
+		<span class="price"><?php echo number_format($item['price'], 2); ?></span>
+	</li>
+<?php } ?>
+</ul>
+<!-- a comment -->
+<?php echo $this->_render_footer(); // trailing line comment ?>
+</body>
+</html>
+`
+
+func BenchmarkTokenGetAllTemplate(b *testing.B) {
+	src := strings.Repeat(benchTemplate, 8)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	for b.Loop() {
+		if toks := parser.TokenGetAll(src); len(toks) == 0 {
+			b.Fatal("no tokens")
+		}
+	}
+}
+
+// BenchmarkTokenGetAllExpr measures the hot minitpl path: one wrapped
+// expression tokenized per template tag.
+func BenchmarkTokenGetAllExpr(b *testing.B) {
+	const src = `<?php if ($this->_vars__1user__1name) { ?>`
+	b.ReportAllocs()
+	for b.Loop() {
+		if toks := parser.TokenGetAll(src); len(toks) == 0 {
+			b.Fatal("no tokens")
+		}
 	}
 }

--- a/runner/compile_test.go
+++ b/runner/compile_test.go
@@ -1,0 +1,181 @@
+package runner
+
+import (
+	"io"
+	"maps"
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/checker/nature"
+	"github.com/expr-lang/expr/conf"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+// TestTypeEnvNatureMatchesExprEnv pins the invariant behind typeEnvNature: the
+// nature it builds by hand must be the one conf.EnvWithCache derives by walking
+// the same map reflectively. TestCompileMatchesExprEnv covers the consequence
+// (identical bytecode); this covers the cause, so a change in expr's env
+// derivation is reported here rather than as a mystery compile difference.
+func TestTypeEnvNatureMatchesExprEnv(t *testing.T) {
+	rt := New(io.Discard, Options{})
+	rt.RegisterFunc("strlen", func(args ...any) any { return nil })
+	rt.RegisterFunc("count", func(args ...any) any { return nil })
+	env := rt.typeEnvBase()
+
+	var mine, theirs nature.Cache
+	got := typeEnvNature(&mine, env)
+	want := conf.EnvWithCache(&theirs, env)
+
+	if got.Type != want.Type || got.Kind != want.Kind || got.Strict != want.Strict {
+		t.Fatalf("nature = %v/%v/strict=%v, want %v/%v/strict=%v",
+			got.Type, got.Kind, got.Strict, want.Type, want.Kind, want.Strict)
+	}
+	if len(got.Fields) != len(want.Fields) || len(got.Fields) != len(env) {
+		t.Fatalf("fields = %d, want %d (env has %d)", len(got.Fields), len(want.Fields), len(env))
+	}
+	for name := range env {
+		g, gok := got.Get(&mine, name)
+		w, wok := want.Get(&theirs, name)
+		if !gok || !wok {
+			t.Fatalf("Get(%q) = %v/%v, want both found", name, gok, wok)
+		}
+		if g.Type != w.Type || g.Kind != w.Kind || g.Method != w.Method || g.Nil != w.Nil {
+			t.Fatalf("field %q = %v/%v, want %v/%v", name, g.Type, g.Kind, w.Type, w.Kind)
+		}
+		// The memoised, type-derived facts the checker asks for must agree, since
+		// every field shares one TypeData in the hand-built nature.
+		if g.NumIn() != w.NumIn() || g.NumOut() != w.NumOut() || g.IsVariadic() != w.IsVariadic() {
+			t.Fatalf("field %q signature = in %d/out %d/variadic %v, want in %d/out %d/variadic %v",
+				name, g.NumIn(), g.NumOut(), g.IsVariadic(), w.NumIn(), w.NumOut(), w.IsVariadic())
+		}
+		if a, b := g.Out(&mine, 0), w.Out(&theirs, 0); a.Type != b.Type {
+			t.Fatalf("field %q returns %v, want %v", name, a.Type, b.Type)
+		}
+	}
+	if _, ok := got.Get(&mine, "no_such_name"); ok {
+		t.Fatal("Get on an unregistered name: want not found")
+	}
+}
+
+// TestCompileMatchesExprEnv pins the invariant behind the cached compile
+// configuration: compiling with a config built once per function-table
+// generation, with PHP variables left undefined, must produce exactly the
+// bytecode expr.Compile produces when handed a full type env per call.
+//
+// The comparison is the disassembled program, so any difference in operator
+// resolution, deref insertion or call opcode selection fails here.
+func TestCompileMatchesExprEnv(t *testing.T) {
+	rt := New(io.Discard, Options{})
+	// A function table with names that collide with expr's own builtins and
+	// predicate syntax (count, filter, map, len, sum), which is why the type env
+	// still carries the function table at all.
+	for _, name := range []string{"count", "filter", "map", "len", "sum", "strlen", "implode", "usort", "preg_match", "sprintf"} {
+		rt.RegisterFunc(name, func(args ...any) any { return nil })
+	}
+
+	v := func(name string) model.Expr { return &model.Var{Name: name} }
+	lit := func(val any) model.Expr { return &model.Lit{Value: val} }
+
+	exprs := []model.Expr{
+		v("a"),
+		lit("s"),
+		&model.Binary{Op: ".", Left: v("a"), Right: lit(" b")},
+		&model.Binary{Op: "+", Left: v("a"), Right: v("b")},
+		&model.Binary{Op: "===", Left: v("a"), Right: lit(1)},
+		&model.Binary{Op: "===", Left: lit("x"), Right: lit("y")},
+		&model.Binary{Op: "===", Left: lit(1), Right: lit(2)},
+		&model.Binary{Op: "<", Left: v("a"), Right: lit(3)},
+		&model.Binary{Op: "&&", Left: v("a"), Right: v("b")},
+		&model.Unary{Op: "!", X: v("a")},
+		&model.Unary{Op: "-", X: v("a")},
+		&model.Ternary{Cond: v("a"), Then: lit(1), Else: v("b")},
+		&model.Index{Base: v("a"), Index: lit("k")},
+		&model.Index{Base: &model.Index{Base: v("a"), Index: lit(0)}, Index: v("i")},
+		&model.PropAccess{Base: v("obj"), Name: "field"},
+		&model.MethodCall{Base: v("obj"), Method: "run", Args: []model.Expr{v("a")}},
+		&model.New{Class: "Foo", Args: []model.Expr{v("a")}},
+		&model.Cast{Type: "int", X: v("a")},
+		&model.ClassConst{Class: "Foo", Name: "BAR"},
+		&model.AssignExpr{Target: v("a"), Op: "=", Value: lit(1)},
+		&model.ArrayLit{Items: []model.ArrayItem{{Val: v("a")}, {Key: lit("k"), Val: lit(2)}}},
+		&model.Call{Name: "count", Args: []model.Expr{v("a")}},
+		&model.Call{Name: "filter", Args: []model.Expr{v("a")}},
+		&model.Call{Name: "map", Args: []model.Expr{v("a"), v("b")}},
+		&model.Call{Name: "len", Args: []model.Expr{v("a")}},
+		&model.Call{Name: "sum", Args: []model.Expr{v("a")}},
+		&model.Call{Name: "strlen", Args: []model.Expr{&model.Binary{Op: ".", Left: v("a"), Right: v("b")}}},
+		&model.Call{Name: "preg_match", Args: []model.Expr{lit("/x/"), v("s"), v("m")}},
+		&model.Call{Name: `App\f`, Fallback: "f", Args: []model.Expr{v("a")}},
+		&model.Call{Name: "usort", Args: []model.Expr{v("a"), &model.Closure{}}},
+	}
+
+	// dyn is the sentinel the type env used to carry for every PHP variable: a
+	// pointer to an empty interface, which expr dereferences to "any".
+	dyn := new(any)
+
+	for _, e := range exprs {
+		tr := NewTranspiler()
+		src, vars, err := tr.Transpile(e)
+		if err != nil {
+			t.Fatalf("Transpile: %v", err)
+		}
+
+		base := rt.typeEnvBase()
+		typeEnv := make(map[string]any, len(base)+len(vars))
+		maps.Copy(typeEnv, base)
+		for id := range tr.Closures() {
+			typeEnv[id] = typeEnvStub
+		}
+		for _, name := range vars {
+			typeEnv[varIdent(name)] = dyn
+		}
+
+		want, err := expr.Compile(src, expr.Env(typeEnv), expr.DisableAllBuiltins())
+		if err != nil {
+			t.Fatalf("expr.Compile %q: %v", src, err)
+		}
+		got, err := compileWith(src, rt.exprConfig())
+		if err != nil {
+			t.Fatalf("compileWith %q: %v", src, err)
+		}
+		if a, b := want.Disassemble(), got.Disassemble(); a != b {
+			t.Errorf("bytecode differs for %q\n--- expr.Env ---\n%s--- cached config ---\n%s", src, a, b)
+		}
+	}
+}
+
+// TestCompileConfigIsRebuiltOnRegistration asserts that a function registered
+// after the first compile is visible to the next one — the config is cached per
+// function-table generation, not forever.
+func TestCompileConfigIsRebuiltOnRegistration(t *testing.T) {
+	rt := New(io.Discard, Options{})
+	first := rt.exprConfig()
+	if same := rt.exprConfig(); same != first {
+		t.Fatal("exprConfig rebuilt without a function-table change")
+	}
+	rt.RegisterFunc("count", func(args ...any) any { return nil })
+	next := rt.exprConfig()
+	if next == first {
+		t.Fatal("exprConfig not rebuilt after RegisterFunc")
+	}
+	if _, ok := next.Env.Get(&next.NtCache, "count"); !ok {
+		t.Fatal("count missing from the rebuilt compile config")
+	}
+}
+
+// TestCompileUndefinedFunctionIsARuntimeError documents the one behavioural
+// difference from compiling with a full type env: a call to a function that is
+// not registered is no longer rejected at compile time. PHP reports the same
+// condition at runtime ("call to undefined function"), so the error simply
+// moves from Compile to Run.
+func TestCompileUndefinedFunctionIsARuntimeError(t *testing.T) {
+	rt := New(io.Discard, Options{})
+	prog, err := rt.compile("no_such_function(v_x)")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if _, err := expr.Run(prog, map[string]any{"v_x": 1}); err == nil {
+		t.Fatal("running a call to an undefined function: want error, got nil")
+	}
+}

--- a/runner/expr_cache.go
+++ b/runner/expr_cache.go
@@ -10,11 +10,41 @@ import (
 )
 
 type compiledExpr struct {
-	src      string
-	vars     []string
+	src  string
+	vars []string
+	// idents holds the expr identifier for each entry of vars (varIdent), built
+	// once at compile time so Eval does not rebuild the "v_"-prefixed strings on
+	// every evaluation.
+	idents []string
+	// calls holds the registered-function names the expression calls as bare env
+	// identifiers, so Eval can install exactly those closures into the evaluation
+	// environment instead of the whole function table (see Runtime.buildEnv).
+	calls    []string
 	closures map[string]*model.Closure
 	exprs    map[string]model.Expr
 	prog     *vm.Program
+}
+
+// newCompiledExpr snapshots one compiled expression. vars, idents and calls come
+// from the pooled transpiler and are copied into a single backing array here,
+// both because the transpiler reuses its own storage and because one allocation
+// is cheaper than three.
+func newCompiledExpr(src string, vars, idents, calls []string, closures map[string]*model.Closure, exprs map[string]model.Expr, prog *vm.Program) *compiledExpr {
+	n := len(vars)
+	c := len(calls)
+	buf := make([]string, 2*n+c)
+	copy(buf, vars)
+	copy(buf[n:], idents)
+	copy(buf[2*n:], calls)
+	return &compiledExpr{
+		src:      src,
+		vars:     buf[:n:n],
+		idents:   buf[n : 2*n : 2*n],
+		calls:    buf[2*n:],
+		closures: closures,
+		exprs:    exprs,
+		prog:     prog,
+	}
 }
 
 // ExprCache stores immutable compiled expression programs by transpiled source

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -33,15 +33,15 @@ type flatHost struct {
 }
 
 func (h flatHost) Construct(class string, args []any) (any, error) {
-	return h.runtime.helperNew(NewScope())(strings.TrimPrefix(class, "\\"), args...)
+	return h.runtime.helperNew(&scopeRef{scope: NewScope()})(strings.TrimPrefix(class, "\\"), args...)
 }
 
 func (h flatHost) CallMethod(receiver any, method string, args []any) (any, error) {
-	return h.runtime.helperCall(NewScope())(receiver, method, args...)
+	return h.runtime.helperCall(&scopeRef{scope: NewScope()})(receiver, method, args...)
 }
 
 func (h flatHost) GetProperty(receiver any, name string) any {
-	return h.runtime.helperGet(nil)(receiver, name)
+	return h.runtime.helperGet(&scopeRef{})(receiver, name)
 }
 
 func (h flatHost) Echo(value any) error {
@@ -172,5 +172,5 @@ func (h flatHost) Entries(value any) []flatvm.Entry {
 }
 
 func (h flatHost) Call(name, fallback string, args []any) (any, error) {
-	return h.runtime.helperFunc(NewScope())(name, fallback, args...)
+	return h.runtime.helperFunc(&scopeRef{scope: NewScope()})(name, fallback, args...)
 }

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -120,8 +120,11 @@ func helperIndex(base, idx any) any {
 // PHP object has no matching property but has a method by that name, it returns
 // a callable bound to that object; this supports PHP idioms such as
 // `call_user_func_array($this->query, $args)`.
-func (rt *Runtime) helperGet(scope *Scope) func(base any, name string) any {
+func (rt *Runtime) helperGet(ref *scopeRef) func(base any, name string) any {
 	return func(base any, name string) any {
+		// A bound callable produced here can outlive the expression that read it,
+		// so the scope is captured by value rather than through the reference.
+		scope := ref.scope
 		switch b := base.(type) {
 		case *model.Object:
 			if v, ok := b.Props[name]; ok {
@@ -253,8 +256,9 @@ func coerceArg(v any, want reflect.Type) reflect.Value {
 // model.Object instances back into the interpreter, and otherwise invokes a Go
 // method on the value by reflection (the "invoke from values on the stack"
 // capability the README relies on).
-func (rt *Runtime) helperCall(scope *Scope) func(base any, method string, args ...any) (any, error) {
+func (rt *Runtime) helperCall(ref *scopeRef) func(base any, method string, args ...any) (any, error) {
 	return func(base any, method string, args ...any) (any, error) {
+		scope := ref.scope
 		if obj, ok := base.(*model.Object); ok && obj.Class != nil {
 			if decl, ok := lookupPHPMethod(obj.Class, method); ok {
 				return rt.invokeMethod(obj, decl, args, scope)
@@ -278,9 +282,12 @@ func lookupPHPMethod(class *model.Class, method string) (*model.FuncDecl, bool) 
 
 // helperNew implements `new Class(args...)`: instantiate from the class table,
 // apply field defaults, and run the same-named constructor method if present.
-func (rt *Runtime) helperNew(scope *Scope) func(class string, args ...any) (any, error) {
+func (rt *Runtime) helperNew(ref *scopeRef) func(class string, args ...any) (any, error) {
 	return func(class string, args ...any) (any, error) {
-		defer rt.trace(scope, "new "+class)()
+		scope := ref.scope
+		if len(rt.observers) > 0 {
+			defer rt.trace(scope, "new "+class)()
+		}
 
 		class = strings.TrimPrefix(class, "\\")
 		if !rt.hasClass(class) {

--- a/runner/request.go
+++ b/runner/request.go
@@ -215,7 +215,7 @@ func mapToArray(m map[string]string) *model.Array {
 	if len(m) == 0 {
 		return model.NewArray()
 	}
-	arr := model.NewArray()
+	arr := model.NewArraySize(len(m))
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -471,7 +471,14 @@ func (rt *Runtime) evalInclude(n *model.Include, scope *Scope) (any, error) {
 	return rt.includeFile(phpString(path), scope)
 }
 
+// noopTrace is the span closer returned when no observer is registered. It
+// captures nothing, so returning it does not allocate.
+func noopTrace() {}
+
 func (rt *Runtime) trace(scope *Scope, message string) func() {
+	if len(rt.observers) == 0 {
+		return noopTrace
+	}
 	span := rt.traceContext(contextWithScope(rt.ctx, scope), message)
 	return func() {
 		if span != nil {
@@ -481,6 +488,9 @@ func (rt *Runtime) trace(scope *Scope, message string) func() {
 }
 
 func (rt *Runtime) traceRegion(scope *Scope, message string, flags ...model.Flag) func() {
+	if len(rt.observers) == 0 {
+		return noopTrace
+	}
 	ctx := contextWithScope(rt.ctx, scope)
 	rt.traceContext(ctx, message, append(flags, model.OpenSpan)...)
 	return func() {
@@ -930,18 +940,22 @@ func (rt *Runtime) invokeMethod(obj *model.Object, decl *model.FuncDecl, args []
 	if obj.Class != nil {
 		scope.Set("__class__", obj.Class.Name)
 	}
-	name := obj.ID
-	if name == "" && obj.Class != nil {
-		name = obj.Class.Name
+	// The span name costs two string builds, so it is only assembled when an
+	// observer is listening.
+	if len(rt.observers) > 0 {
+		name := obj.ID
+		if name == "" && obj.Class != nil {
+			name = obj.Class.Name
+		}
+		if name != "" {
+			name += "."
+		}
+		traceScope := caller
+		if traceScope == nil {
+			traceScope = scope
+		}
+		defer rt.trace(traceScope, name+decl.Name)()
 	}
-	if name != "" {
-		name += "."
-	}
-	traceScope := caller
-	if traceScope == nil {
-		traceScope = scope
-	}
-	defer rt.trace(traceScope, name+decl.Name)()
 	if err := rt.bindParams(decl, args, scope); err != nil {
 		return nil, err
 	}
@@ -986,6 +1000,9 @@ func (rt *Runtime) runDeferred(scope *Scope, mark int) error {
 }
 
 func (rt *Runtime) runShutdown() error {
+	if len(rt.shutdown) == 0 {
+		return nil
+	}
 	var errs []error
 	scope := NewScope()
 	for len(rt.shutdown) > 0 {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -422,10 +422,9 @@ echo $out;`)
 	rt := runner.New(&out, runner.Options{})
 	rt.RegisterFunc("token_get_all", parser.TokenGetAll)
 	rt.RegisterFunc("token_name", parser.TokenName)
-	rt.RegisterFunc("is_array", func(a any) bool {
-		_, ok := a.(*model.Array)
-		return ok
-	})
+	// Shape-agnostic, like the real stdlib is_array: TokenGetAll returns a
+	// []any of []any, not an *model.Array.
+	rt.RegisterFunc("is_array", model.IsCollection)
 	// minitpl-style wrapped expression with the "." -> "__1" marker.
 	rt.SetGlobal("code", `<?php if ($this->_vars) { ?>`)
 
@@ -462,5 +461,199 @@ func TestClassExistsPropagatesAutoloaderError(t *testing.T) {
 	}
 	if !errors.Is(err, want) {
 		t.Fatalf("got error %v, want %v", err, want)
+	}
+}
+
+// TestRegisterFuncBetweenRuns proves the reusable evaluation environment picks
+// up function-table changes: a Runtime that has already evaluated expressions
+// must see a function registered (or replaced) afterwards.
+func TestRegisterFuncBetweenRuns(t *testing.T) {
+	first, err := parser.Parse(`<?php echo greet("a");`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	second, err := parser.Parse(`<?php echo greet("b") . shout("c");`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	rt.RegisterFunc("greet", func(s string) string { return "hello " + s })
+	if err := rt.Run(first); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() != "hello a" {
+		t.Fatalf("got %q, want %q", out.String(), "hello a")
+	}
+
+	out.Reset()
+	// Replace one function and add another after the environment was built.
+	rt.RegisterFunc("greet", func(s string) string { return "hi " + s })
+	rt.RegisterFunc("shout", strings.ToUpper)
+	if err := rt.Run(second); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() != "hi bC" {
+		t.Fatalf("got %q, want %q", out.String(), "hi bC")
+	}
+}
+
+// TestNestedEvalScopes proves that reused environments never leak a scope: a
+// user function called from inside an expression must see its own frame, and
+// the caller's variables must survive the nested evaluation.
+func TestNestedEvalScopes(t *testing.T) {
+	got := run(t, `<?php
+function inner($x) {
+	$local = $x * 2;
+	return $local;
+}
+function outer($x) {
+	$local = "outer";
+	$sum = inner($x) + inner($x + 1);
+	return $local . ":" . $sum;
+}
+$local = "top";
+echo outer(2) . "|" . $local;`)
+	if got != "outer:10|top" {
+		t.Fatalf("got %q, want %q", got, "outer:10|top")
+	}
+}
+
+// TestLazyEnvInstallsFunctionsOnDemand covers the environments' on-demand
+// population. A registered function is wrapped into an environment the first
+// time an expression evaluated with that environment calls it, so the places a
+// call can hide from a naive "top-level expressions only" scan are what matters:
+// a closure body, a user function body, a method body, a nested/recursive call
+// and a by-reference call.
+func TestLazyEnvInstallsFunctionsOnDemand(t *testing.T) {
+	src := `<?php
+function shout($s) {
+	return strtoupper($s) . strlen($s);
+}
+class Box {
+	public $items = [];
+	public function add($v) {
+		$this->items[] = shout($v);
+		return $this;
+	}
+	public function render() {
+		return implode(",", $this->items);
+	}
+}
+function depth($n) {
+	if ($n <= 0) {
+		return strtoupper("done");
+	}
+	return depth($n - 1) . strlen("x");
+}
+$b = new Box();
+$b->add("a");
+$b->add("bb");
+$sizes = apply(["cc", "d"], function ($x) { return shout($x) . strlen($x); });
+echo $b->render() . "|" . depth(3) . "|" . implode("-", $sizes);`
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	rt.RegisterFunc("strlen", func(s string) int { return len(s) })
+	rt.RegisterFunc("strtoupper", strings.ToUpper)
+	rt.RegisterFunc("implode", func(sep string, items any) string {
+		var parts []string
+		model.RangeValues(items, func(_, v any) bool {
+			parts = append(parts, fmt.Sprint(v))
+			return true
+		})
+		return strings.Join(parts, sep)
+	})
+	// apply drives a PHP closure from Go, which re-enters Eval with a fresh
+	// environment while the caller's is still live.
+	rt.RegisterFunc("apply", func(items any, fn func(...any) (any, error)) ([]any, error) {
+		var out []any
+		var err error
+		model.RangeValues(items, func(_, v any) bool {
+			var mapped any
+			if mapped, err = fn(v); err != nil {
+				return false
+			}
+			out = append(out, mapped)
+			return true
+		})
+		return out, err
+	})
+	if err := rt.Run(prog); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if want := "A1,BB2|DONE111|CC22-D11"; out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+// TestLazyEnvSeesFunctionsRegisteredAfterPooling asserts that an environment
+// which has already been used (and returned to the free list) still resolves a
+// function registered afterwards, and picks up a replacement implementation of a
+// name it had already installed.
+func TestLazyEnvSeesFunctionsRegisteredAfterPooling(t *testing.T) {
+	warm, err := parser.Parse(`<?php echo greet("a");`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	later, err := parser.Parse(`<?php echo greet("b") . shout("c") . nested();`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	rt.RegisterFunc("greet", func(s string) string { return "hello " + s })
+	if err := rt.Run(warm); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	out.Reset()
+
+	// Registered after every environment this runtime holds has been built,
+	// used and pooled.
+	rt.RegisterFunc("greet", func(s string) string { return "hi " + s })
+	rt.RegisterFunc("shout", strings.ToUpper)
+	rt.RegisterFunc("nested", func() string { return "!" })
+	if err := rt.Run(later); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if want := "hi bC!"; out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+// TestLazyEnvRecursiveEvalNestsDeeperThanTheFreeList drives evaluation deeper
+// than the pooled environment free list, so environments are built, nested,
+// discarded and reused while a call to a lazily installed function is live at
+// every level.
+func TestLazyEnvRecursiveEvalNestsDeeperThanTheFreeList(t *testing.T) {
+	got := run(t, `<?php
+function down($n) {
+	if ($n <= 0) {
+		return strtoupper("x");
+	}
+	return down($n - 1) . strlen("ab");
+}
+echo down(40);`)
+	if want := "X" + strings.Repeat("2", 40); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestLazyEnvUndefinedFunctionStillErrors asserts the diagnostic for a call to
+// a function that is not registered: it is a runtime error, not a silent nil.
+func TestLazyEnvUndefinedFunctionStillErrors(t *testing.T) {
+	prog, err := parser.Parse(`<?php echo no_such_function(1);`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rt := runner.New(io.Discard, runner.Options{})
+	if err := rt.Run(prog); err == nil {
+		t.Fatal("calling an unregistered function: want error, got nil")
 	}
 }

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -9,12 +9,19 @@ import (
 	"maps"
 	"os"
 	"path"
+	"reflect"
 	goruntime "runtime"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/checker"
+	"github.com/expr-lang/expr/checker/nature"
+	"github.com/expr-lang/expr/compiler"
+	"github.com/expr-lang/expr/conf"
+	"github.com/expr-lang/expr/file"
+	"github.com/expr-lang/expr/optimizer"
 	"github.com/expr-lang/expr/vm"
 
 	"github.com/titpetric/phpscript/model"
@@ -37,7 +44,6 @@ type Runtime struct {
 	observers  []Observer
 	funcs      map[string]any
 	userFns    map[string]struct{}
-	wrapped    map[string]func(...any) (any, error)
 	classes    map[string]*model.Class
 
 	// Env is the environment visible to PHP for this Runtime. New snapshots the
@@ -78,22 +84,81 @@ type Runtime struct {
 	// classConsts caches evaluated class constants (Class::NAME) per class.
 	classConsts map[string]map[string]any
 
-	mu        sync.Mutex
-	cache     map[string]*vm.Program // expr source -> compiled program
-	exprCache *ExprCache
-	compiled  map[model.Expr]*compiledExpr
-	helpers   map[string]func(...any) (any, error)
+	mu    sync.Mutex
+	cache map[string]*vm.Program // expr source -> compiled program
+	// exprConf is the expr-lang compile configuration derived from the
+	// compile-time type env. Deriving it is the expensive half of a compile
+	// (expr walks the whole function table reflectively), so it is built once per
+	// function-table generation and reused. Guarded by mu, which compile holds.
+	exprConf    *conf.Config
+	exprConfGen uint64
+	exprCache   *ExprCache
+	compiled    map[model.Expr]*compiledExpr
+	helpers     map[string]func(...any) (any, error)
+
+	// funcsGen is bumped whenever the function table changes (RegisterFunc, a
+	// hoisted user function). Prebuilt evaluation environments and the cached
+	// compile-time type env are stamped with the generation they were built
+	// from and rebuilt when they fall behind.
+	funcsGen uint64
+
+	// envMu guards envFree, the free list of reusable evaluation environments.
+	envMu      sync.Mutex
+	envFree    []*evalEnv
+	typeEnv    map[string]any
+	typeEnvGen uint64
 
 	sourceSpans map[model.Stmt]model.SourceSpan
 	currentLine int
 }
 
-// evalEnvPool is shared by runtimes because HTTP integrations commonly create
-// one Runtime per request. A per-Runtime pool never survived long enough to
-// reuse its first environment map. releaseEnv removes every value (including
-// closures over the Runtime and Scope) before returning a map to this pool.
-var evalEnvPool = sync.Pool{
-	New: func() any { return make(map[string]any, 128) },
+// maxFreeEnvs bounds the per-Runtime free list of evaluation environments. Each
+// entry retains one closure per registered function, so the list is kept small;
+// nesting deeper than this simply builds (and discards) an environment the way
+// every Eval used to.
+const maxFreeEnvs = 16
+
+// envSizeHint presizes an evaluation environment's map. It used to be the size
+// of the whole function table, which is no longer what an environment holds:
+// since installFunc adds registered functions on demand, an environment carries
+// the ~16 PHP-semantic helpers, the functions its expressions actually call, and
+// a handful of layered per-expression keys. The hint only has to avoid the first
+// few rehashes; an environment that outgrows it grows once and is then reused.
+const envSizeHint = 48
+
+// scopeRef is the indirection that lets the environment's closures be built
+// once and still see the scope of the evaluation currently using them. Helpers
+// read ref.scope at call time; anything that outlives the evaluation (a bound
+// method, a by-reference setter) copies the scope out of the ref first.
+type scopeRef struct {
+	scope *Scope
+}
+
+// evalEnv is one reusable expr environment: the registered functions and the
+// PHP-semantic helpers, built once per function-table generation, plus the
+// per-expression keys layered on top by Eval and removed again on release.
+type evalEnv struct {
+	ref     *scopeRef
+	env     map[string]any
+	exprs   map[string]model.Expr
+	layered []string
+	shadow  map[string]any
+	gen     uint64
+	built   bool
+}
+
+// layer installs a per-expression key, remembering it so release can remove it.
+// A key that already exists in the prebuilt base (only possible if a registered
+// function is named like a variable identifier) is restored rather than deleted.
+func (st *evalEnv) layer(key string, val any) {
+	if old, ok := st.env[key]; ok {
+		if st.shadow == nil {
+			st.shadow = map[string]any{}
+		}
+		st.shadow[key] = old
+	}
+	st.layered = append(st.layered, key)
+	st.env[key] = val
 }
 
 // ExitError is returned when PHP die()/exit() interrupts script execution.
@@ -141,7 +206,6 @@ func New(w io.Writer, opts Options) *Runtime {
 		includeCache: NewIncludeCache(),
 		funcs:        map[string]any{},
 		userFns:      map[string]struct{}{},
-		wrapped:      map[string]func(...any) (any, error){},
 		classes:      map[string]*model.Class{},
 		constructors: map[string]any{},
 		includePath:  ".",
@@ -353,7 +417,11 @@ func (rt *Runtime) Const(name string) (any, bool) {
 // { return len(s) }) makes `strlen($x)` work in transpiled code.
 func (rt *Runtime) RegisterFunc(name string, fn any) {
 	rt.funcs[name] = fn
-	rt.wrapped[name] = adapt(fn)
+	// Prebuilt evaluation environments hold one closure per registered function;
+	// bumping the generation makes them rebuild before their next use.
+	rt.envMu.Lock()
+	rt.funcsGen++
+	rt.envMu.Unlock()
 }
 
 func (rt *Runtime) registerUserFunc(name string, fn any) {
@@ -492,13 +560,6 @@ func (rt *Runtime) OnError(fn func(error)) {
 	rt.errorHandler = fn
 }
 
-// dynamicType is the sentinel value used in the compile-time type env to mark a
-// variable as dynamically typed. expr-lang auto-dereferences the pointer and
-// sees a bare interface{}, so it allows any operation on the value (PHP is
-// dynamically typed). Without this, expr would infer concrete types and reject
-// e.g. arithmetic across call sites where the type differs.
-var dynamicType = new(any)
-
 // Eval transpiles e, binds the referenced variables from scope, and runs the
 // resulting program through the expr-lang VM.
 func (rt *Runtime) Eval(e model.Expr, scope *Scope) (any, error) {
@@ -517,20 +578,31 @@ func (rt *Runtime) Eval(e model.Expr, scope *Scope) (any, error) {
 		return nil, err
 	}
 
-	base := rt.baseEnv(scope)
-	defer rt.releaseEnv(base)
+	st := rt.acquireEnv(scope)
+	st.exprs = ce.exprs
+	base := st.env
+	defer rt.releaseEnv(st)
+
+	// Registered functions are installed on demand: an environment carries the
+	// PHP-semantic helpers plus whatever the expressions evaluated with it have
+	// called so far, rather than a closure per entry of the function table. The
+	// installed closures persist across evaluations (see installFunc).
+	for _, name := range ce.calls {
+		rt.installFunc(st, name)
+	}
 
 	// Anonymous functions become callables in the env (bound by their synthetic
-	// identifier) so transpiled code can pass them, e.g. usort's comparator.
+	// identifier) so transpiled code can pass them, e.g. usort's comparator. They
+	// capture the scope directly rather than reading it through st: a closure
+	// assigned to a variable outlives this evaluation.
 	for id, cl := range ce.closures {
 		decl := cl
 		filename, _ := scope.Get("__FILE__")
 		directory, _ := scope.Get("__DIR__")
-		base[id] = adapt(func(args ...any) (any, error) {
+		st.layer(id, adapt(func(args ...any) (any, error) {
 			return rt.invokeClosure(decl, args, filename, directory)
-		})
+		}))
 	}
-	base["__eval"] = adapt(rt.helperEval(scope, ce.exprs))
 
 	// Run env: same functions/helpers, but variables carry their real values.
 	// Bare identifiers that are not set in the current scope fall back to the
@@ -538,15 +610,15 @@ func (rt *Runtime) Eval(e model.Expr, scope *Scope) (any, error) {
 	// variables are confined to their frame). This is what lets a method body
 	// reference T_VARIABLE / a define()d constant the same way top-level code
 	// can.
-	for _, name := range ce.vars {
+	for i, name := range ce.vars {
 		if v, ok := scope.Get(name); ok {
-			base[varIdent(name)] = v
+			st.layer(ce.idents[i], v)
 		} else if c, ok := rt.constants[name]; ok {
-			base[varIdent(name)] = c
+			st.layer(ce.idents[i], c)
 		} else if _, ok := phpSuperglobals[name]; ok {
-			base[varIdent(name)] = rt.globals[name]
+			st.layer(ce.idents[i], rt.globals[name])
 		} else {
-			base[varIdent(name)] = nil
+			st.layer(ce.idents[i], nil)
 		}
 	}
 
@@ -564,37 +636,30 @@ func (rt *Runtime) compileExpr(e model.Expr) (*compiledExpr, error) {
 		}
 	}
 
-	tr := NewTranspiler()
+	// The transpiler is pooled; newCompiledExpr copies the variable slices it
+	// hands out, so nothing survives the release.
+	tr := acquireTranspiler()
+	defer releaseTranspiler(tr)
+
 	src, vars, err := tr.Transpile(e)
 	if err != nil {
 		return nil, err
 	}
+	idents := tr.Idents()
+	calls := tr.Calls()
 	closures := tr.Closures()
 	exprs := tr.Exprs()
 	if prog, ok := rt.exprCache.GetSource(src); ok {
-		ce := &compiledExpr{src: src, vars: vars, closures: closures, exprs: exprs, prog: prog}
+		ce := newCompiledExpr(src, vars, idents, calls, closures, exprs, prog)
 		rt.setCompiledExpr(e, ce)
 		return ce, nil
 	}
 
-	base := rt.typeEnvBase()
-	for id := range closures {
-		base[id] = adapt(func(args ...any) (any, error) { return nil, nil })
-	}
-	if len(exprs) > 0 {
-		base["__eval"] = adapt(func(args ...any) any { return nil })
-	}
-	typeEnv := make(map[string]any, len(base)+len(vars))
-	maps.Copy(typeEnv, base)
-	for _, name := range vars {
-		typeEnv[varIdent(name)] = dynamicType
-	}
-
-	prog, err := rt.compile(src, typeEnv)
+	prog, err := rt.compile(src)
 	if err != nil {
 		return nil, fmt.Errorf("compile %q: %w", src, err)
 	}
-	ce := &compiledExpr{src: src, vars: vars, closures: closures, exprs: exprs, prog: prog}
+	ce := newCompiledExpr(src, vars, idents, calls, closures, exprs, prog)
 	rt.exprCache.SetSource(src, prog)
 	rt.setCompiledExpr(e, ce)
 	return ce, nil
@@ -609,16 +674,25 @@ func (rt *Runtime) setCompiledExpr(e model.Expr, ce *compiledExpr) {
 
 // compile returns a cached compiled program for src.
 //
-// We deliberately compile without expr.Env type information. PHP is
-// dynamically typed and the same expression may see different value types
-// across invocations, so static type checking would be counter-productive here.
-// Identifiers resolve from the runtime env map instead.
+// Expression-local identifiers (PHP variables, closure bindings) are
+// deliberately absent from the compile-time type env: PHP is dynamically typed
+// and the same expression may see different value types across invocations, so
+// static type checking of them would be counter-productive. They are compiled
+// as undefined variables (conf.Strict is off, the equivalent of
+// expr.AllowUndefinedVariables) and resolve from the runtime env map instead.
+//
+// The function table *is* part of the type env, and must be: expr's parser
+// consults it (conf.Config.IsOverridden) to decide that names shared with
+// expr's own predicate builtins — `count`, `map`, `filter`, `find`, `sum`, ...
+// — are user functions rather than builtin predicate syntax. Disabling the
+// builtins is not enough on its own; predicates are parsed before the disabled
+// list is consulted.
 //
 // All expr-lang builtins are disabled. PHP brings its own standard library via
 // forwarded/registered functions (RegisterFunc), and expr's builtins (count,
 // len, all, ...) would otherwise shadow PHP functions of the same name. With
 // builtins off, a registered `count` resolves to the user's implementation.
-func (rt *Runtime) compile(src string, typeEnv map[string]any) (*vm.Program, error) {
+func (rt *Runtime) compile(src string) (*vm.Program, error) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.cache != nil {
@@ -626,7 +700,7 @@ func (rt *Runtime) compile(src string, typeEnv map[string]any) (*vm.Program, err
 			return p, nil
 		}
 	}
-	p, err := expr.Compile(src, expr.Env(typeEnv), expr.DisableAllBuiltins())
+	p, err := compileWith(src, rt.exprConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -637,92 +711,299 @@ func (rt *Runtime) compile(src string, typeEnv map[string]any) (*vm.Program, err
 	return p, nil
 }
 
-// baseEnv builds the env shared by every evaluation: the forwarded/registered
-// functions plus the PHP-semantic helpers. Because expr-lang builtins are
-// disabled (see compile), registered functions are exposed as bare identifiers
-// and called directly by name. Variables are layered on top by Eval.
+// exprConfig returns the expr compile configuration for the current function
+// table, building it on first use and whenever the table changes.
+//
+// This is what expr.Compile(expr.Env(...)) does per call, and the reason it is
+// hoisted: conf.Config.WithEnv walks the ~100-entry function table reflectively
+// (MapKeys, MapIndex, a nature per entry) and used to dominate the interpreter's
+// allocation profile. Nothing in the parse/check/optimize/compile pipeline
+// writes to the Config, so one instance is reusable; the nature cache it carries
+// is filled as a side effect and is guarded by rt.mu, which compile holds.
+//
+// Callers must hold rt.mu.
+func (rt *Runtime) exprConfig() *conf.Config {
+	rt.envMu.Lock()
+	gen := rt.funcsGen
+	rt.envMu.Unlock()
+	if rt.exprConf != nil && rt.exprConfGen == gen {
+		return rt.exprConf
+	}
+
+	env := rt.typeEnvBase()
+	c := conf.CreateNew()
+	c.EnvObject = env
+	c.Env = typeEnvNature(&c.NtCache, env)
+	// expr.AllowUndefinedVariables: PHP variables are not in the type env.
+	c.Strict = false
+	// expr.DisableAllBuiltins, plus the pruning expr.Compile does afterwards.
+	for name := range c.Builtins {
+		c.Disabled[name] = true
+		delete(c.Builtins, name)
+	}
+	c.Check()
+
+	rt.exprConf, rt.exprConfGen = c, gen
+	return c
+}
+
+// compileWith runs expr's parse/check/optimize/compile pipeline against a
+// prebuilt config. It mirrors expr.Compile, which cannot be used here because it
+// insists on constructing a fresh conf.Config (and re-deriving the type env)
+// on every call.
+func compileWith(src string, c *conf.Config) (*vm.Program, error) {
+	tree, err := checker.ParseCheck(src, c)
+	if err != nil {
+		return nil, err
+	}
+	if c.Optimize {
+		if err := optimizer.Optimize(&tree.Node, c); err != nil {
+			var fileError *file.Error
+			if errors.As(err, &fileError) {
+				return nil, fileError.Bind(tree.Source)
+			}
+			return nil, err
+		}
+	}
+	return compiler.Compile(tree, c)
+}
+
+// acquireEnv returns an evaluation environment bound to scope. Environments are
+// reused across evaluations: the expensive part — one closure per registered
+// function plus the PHP-semantic helpers — is built once per function-table
+// generation and thereafter only has its scope rebound.
+func (rt *Runtime) acquireEnv(scope *Scope) *evalEnv {
+	rt.envMu.Lock()
+	var st *evalEnv
+	if n := len(rt.envFree); n > 0 {
+		st = rt.envFree[n-1]
+		rt.envFree[n-1] = nil
+		rt.envFree = rt.envFree[:n-1]
+	}
+	gen := rt.funcsGen
+	rt.envMu.Unlock()
+
+	if st == nil {
+		st = &evalEnv{ref: &scopeRef{}, env: make(map[string]any, envSizeHint)}
+	}
+	if !st.built || st.gen != gen {
+		rt.buildEnv(st, gen)
+	}
+	st.ref.scope = scope
+	return st
+}
+
+// buildEnv fills st with the env shared by every evaluation: the PHP-semantic
+// helpers. Because expr-lang builtins are disabled (see compile), registered
+// functions are exposed as bare identifiers and called directly by name, but
+// they are *not* installed here: installFunc adds the ones an expression
+// actually calls, on demand (see Eval). Variables and other per-expression keys
+// are layered on top by Eval.
 //
 // Every function is wrapped with adapt() into a uniform func(...any) (any,
 // error) signature. This lets the compile-time type env accept dynamically
 // typed PHP arguments and keeps the runtime func type in sync with the type
 // env (see helpers.go::adapt and Eval).
-func (rt *Runtime) baseEnv(scope *Scope) map[string]any {
-	env := evalEnvPool.Get().(map[string]any)
-	for name, fn := range rt.funcs {
-		callable := fn
-		env[name] = func(args ...any) (any, error) {
-			return rt.invokeWithScopeContext(callable, args, scope)
-		}
-	}
-	// PHP-semantic helpers (see helpers.go). They close over rt and scope so
-	// that method dispatch and instantiation can re-enter the interpreter.
+//
+// The closures read the scope through st.ref rather than capturing it, which is
+// what makes the environment reusable.
+func (rt *Runtime) buildEnv(st *evalEnv, gen uint64) {
+	env := st.env
+	clear(env)
+	st.layered = st.layered[:0]
+	clear(st.shadow)
+	ref := st.ref
+	// PHP-semantic helpers (see helpers.go). They close over rt and the scope
+	// reference so that method dispatch and instantiation can re-enter the
+	// interpreter.
 	for name, fn := range rt.helpers {
 		env[name] = fn
 	}
-	env["__call"] = adapt(rt.helperCall(scope))
-	env["__get"] = adapt(rt.helperGet(scope))
-	env["__new"] = adapt(rt.helperNew(scope))
-	env["__classconst"] = adapt(rt.helperClassConst(scope))
-	env["__set"] = adapt(rt.helperSet(scope))
-	env["__ref"] = adapt(rt.helperRef(scope))
-	env["__func"] = adapt(rt.helperFunc(scope))
+	env["__call"] = adapt(rt.helperCall(ref))
+	env["__get"] = adapt(rt.helperGet(ref))
+	env["__new"] = adapt(rt.helperNew(ref))
+	env["__classconst"] = adapt(rt.helperClassConst(ref))
+	env["__set"] = adapt(rt.helperSet(ref))
+	env["__ref"] = adapt(rt.helperRef(ref))
+	env["__func"] = adapt(rt.helperFunc(ref))
+	// Expression markers (`__eval`) resolve against the expression currently
+	// evaluated with this environment, which Eval stores on st.
+	env["__eval"] = adapt(func(id string) (any, error) {
+		e := st.exprs[id]
+		if e == nil {
+			return nil, fmt.Errorf("eval: unknown expression marker %s", id)
+		}
+		return rt.Eval(e, ref.scope)
+	})
 	// func_get_args() needs the current frame's arguments, so it is provided as
 	// a scope-aware helper rather than a plain forwarded function.
 	// The frame already holds its arguments as a []any, which the VM indexes and
 	// iterates directly, so func_get_args() hands that slice back rather than
 	// rebuilding it as an *model.Array.
 	env["func_get_args"] = adapt(func() []any {
-		if v, ok := scope.Get(argsKey); ok {
+		if v, ok := ref.scope.Get(argsKey); ok {
 			if args, ok := v.([]any); ok {
 				return args
 			}
 		}
 		return nil
 	})
-	return env
+	st.gen = gen
+	st.built = true
 }
 
-func (rt *Runtime) releaseEnv(env map[string]any) {
-	oversized := len(env) > 256
-	for k := range env {
-		delete(env, k)
-	}
-	if oversized {
+// installFunc adds the registered function name to st's environment, if it is
+// not already there. The closure is left in the environment (it is not one of
+// the per-expression keys releaseEnv strips), so a function is wrapped at most
+// once per environment per function-table generation: buildEnv clears the map
+// whenever the generation moves, which is exactly when a name could have been
+// re-registered with a different implementation.
+//
+// A name that is not in the function table installs nothing. Calling it is then
+// a runtime error from the VM ("cannot call nil"), which is what an undefined
+// PHP function has done since the compile-time type env stopped listing
+// expression-local identifiers (see compile).
+//
+// Like buildEnv, the closure reads the scope through st.ref at call time rather
+// than capturing it.
+func (rt *Runtime) installFunc(st *evalEnv, name string) {
+	if _, ok := st.env[name]; ok {
 		return
 	}
-	evalEnvPool.Put(env)
+	fn, ok := rt.funcs[name]
+	if !ok {
+		return
+	}
+	ref := st.ref
+	st.env[name] = func(args ...any) (any, error) {
+		return rt.invokeWithScopeContext(fn, args, ref.scope)
+	}
 }
 
-func (rt *Runtime) typeEnvBase() map[string]any {
-	env := make(map[string]any, len(rt.wrapped)+13)
-	for name, fn := range rt.wrapped {
-		env[name] = fn
+// releaseEnv strips the per-expression keys layered on by Eval, drops the
+// references the environment held to the scope and expression, and returns it
+// to the free list.
+func (rt *Runtime) releaseEnv(st *evalEnv) {
+	if len(st.shadow) == 0 {
+		for _, key := range st.layered {
+			delete(st.env, key)
+		}
+	} else {
+		for _, key := range st.layered {
+			if old, ok := st.shadow[key]; ok {
+				st.env[key] = old
+				delete(st.shadow, key)
+				continue
+			}
+			delete(st.env, key)
+		}
 	}
-	stub := adapt(func(args ...any) any { return nil })
-	env["__bool"] = stub
-	env["__concat"] = stub
-	env["__pair"] = stub
-	env["__array"] = stub
-	env["__index"] = stub
-	env["__get"] = stub
-	env["__call"] = stub
-	env["__new"] = stub
-	env["__cast"] = stub
-	env["__arith"] = stub
-	env["__classconst"] = stub
-	env["__set"] = stub
-	env["__ref"] = stub
-	env["__func"] = stub
-	env["func_get_args"] = stub
+	st.layered = st.layered[:0]
+	st.exprs = nil
+	st.ref.scope = nil
+
+	rt.envMu.Lock()
+	if len(rt.envFree) < maxFreeEnvs {
+		rt.envFree = append(rt.envFree, st)
+	}
+	rt.envMu.Unlock()
+}
+
+// typeEnvStub is the value every entry of the compile-time type env holds. The
+// type env carries types, never values — expr derives one "nature" per entry and
+// never calls it — and every callable the runtime exposes has been through
+// adapt(), so they all share this one signature. A single shared stub therefore
+// describes the whole function table exactly as well as a per-function wrapper
+// would, and costs one closure instead of one per registered function.
+var typeEnvStub any = func(...any) (any, error) { return nil, nil }
+
+// typeEnvMapType is the reflect type of the compile-time type env map.
+var typeEnvMapType = reflect.TypeOf(map[string]any(nil))
+
+// typeEnvNature builds the conf.Config.Env nature for the compile-time type env
+// without expr's reflective walk over it.
+//
+// conf.Config.WithEnv -> conf.EnvWithCache derives one nature per entry through
+// reflect.Value.MapKeys + MapIndex + copyVal + a fresh nature.TypeData, which for
+// a ~100-entry function table was the single largest allocation site left in the
+// interpreter (12% of all objects). It exists because a general env map holds
+// values of many different types.
+//
+// This one does not: every entry is typeEnvStub (see above), so every entry's
+// nature is the nature of that one func type. Deriving it once and storing the
+// same value under every key produces a nature that is equal to the one expr
+// builds — TestCompileMatchesExprEnv pins that by comparing emitted bytecode.
+//
+// The shared nature.TypeData that all the entries then point at is written to
+// only by nature's own lazy memoisation (NumIn, NumOut, Out, IsVariadic, the
+// method set), all of which are functions of the type alone and therefore
+// identical for every entry. The one field that carries per-name state,
+// TypeData.Func, is set by the checker only for conf.Config.Functions and
+// Builtins — both empty here — never for a nature that came out of the env.
+func typeEnvNature(cache *nature.Cache, env map[string]any) nature.Nature {
+	n := cache.FromType(typeEnvMapType)
+	if n.TypeData == nil {
+		n.TypeData = new(nature.TypeData)
+	}
+	n.Strict = true
+	n.Fields = make(map[string]nature.Nature, len(env))
+	stub := cache.NatureOf(typeEnvStub)
+	for name := range env {
+		n.Fields[name] = stub
+	}
+	return n
+}
+
+// typeEnvBase returns the compile-time type env for the current function table:
+// every registered function plus the PHP-semantic helpers, each mapped to
+// typeEnvStub.
+//
+// It exists so expr knows which names are functions. Two things depend on that:
+// the parser, which must not read `count(...)` as its own builtin predicate
+// (conf.Config.IsOverridden), and the checker, which resolves a call on a known
+// name to (any, error). The result is cached per function-table generation and
+// must be treated as read-only by callers.
+func (rt *Runtime) typeEnvBase() map[string]any {
+	rt.envMu.Lock()
+	cached, gen, current := rt.typeEnv, rt.typeEnvGen, rt.funcsGen
+	rt.envMu.Unlock()
+	if cached != nil && gen == current {
+		return cached
+	}
+
+	env := make(map[string]any, len(rt.funcs)+16)
+	for name := range rt.funcs {
+		env[name] = typeEnvStub
+	}
+	env["__bool"] = typeEnvStub
+	env["__concat"] = typeEnvStub
+	env["__pair"] = typeEnvStub
+	env["__array"] = typeEnvStub
+	env["__index"] = typeEnvStub
+	env["__get"] = typeEnvStub
+	env["__call"] = typeEnvStub
+	env["__new"] = typeEnvStub
+	env["__cast"] = typeEnvStub
+	env["__arith"] = typeEnvStub
+	env["__classconst"] = typeEnvStub
+	env["__set"] = typeEnvStub
+	env["__ref"] = typeEnvStub
+	env["__func"] = typeEnvStub
+	env["__eval"] = typeEnvStub
+	env["func_get_args"] = typeEnvStub
+
+	rt.envMu.Lock()
+	rt.typeEnv, rt.typeEnvGen = env, current
+	rt.envMu.Unlock()
 	return env
 }
 
 // helperSet implements assignment used as an expression (AssignExpr with a Var
 // target): it mutates the current scope and returns the assigned value so the
 // surrounding expression (e.g. a comparison) can use it.
-func (rt *Runtime) helperSet(scope *Scope) func(name string, val any) any {
+func (rt *Runtime) helperSet(ref *scopeRef) func(name string, val any) any {
 	return func(name string, val any) any {
-		scope.Set(name, val)
+		ref.scope.Set(name, val)
 		return val
 	}
 }
@@ -766,22 +1047,13 @@ func flattenConcat(e model.Expr, out []model.Expr) []model.Expr {
 	return append(out, e)
 }
 
-func (rt *Runtime) helperEval(scope *Scope, exprs map[string]model.Expr) func(string) (any, error) {
-	return func(id string) (any, error) {
-		e := exprs[id]
-		if e == nil {
-			return nil, fmt.Errorf("eval: unknown expression marker %s", id)
-		}
-		return rt.Eval(e, scope)
-	}
-}
-
 // helperFunc dispatches a (possibly namespace-qualified) free-function call. It
 // looks up name in the runtime function table and, if missing, the global
 // fallback name — matching PHP's namespace resolution where an unqualified call
 // falls back to the global function of the same short name.
-func (rt *Runtime) helperFunc(scope *Scope) func(name, fallback string, args ...any) (any, error) {
+func (rt *Runtime) helperFunc(ref *scopeRef) func(name, fallback string, args ...any) (any, error) {
 	return func(name, fallback string, args ...any) (any, error) {
+		scope := ref.scope
 		if fn, ok := rt.lookupFunc(name); ok {
 			return rt.invokeWithScopeContext(fn, args, scope)
 		}
@@ -808,16 +1080,20 @@ func (rt *Runtime) lookupFunc(name string) (any, bool) {
 
 // helperRef yields a setter for a by-reference output parameter (e.g.
 // preg_match_all's $matches). The shim calls it to write back into scope.
-func (rt *Runtime) helperRef(scope *Scope) func(name string) func(any) {
+func (rt *Runtime) helperRef(ref *scopeRef) func(name string) func(any) {
 	return func(name string) func(any) {
+		// The setter is handed to a shim and may be called after this expression
+		// finishes, so it binds the scope value rather than the reference.
+		scope := ref.scope
 		return func(v any) { scope.Set(name, v) }
 	}
 }
 
 // helperClassConst resolves Class::NAME (and self::NAME), evaluating the
 // constant's expression once and caching it.
-func (rt *Runtime) helperClassConst(scope *Scope) func(class, name string) (any, error) {
+func (rt *Runtime) helperClassConst(ref *scopeRef) func(class, name string) (any, error) {
 	return func(class, name string) (any, error) {
+		scope := ref.scope
 		if class == "self" || class == "static" {
 			if c, ok := scope.Get("__class__"); ok {
 				class, _ = c.(string)

--- a/runner/transpile.go
+++ b/runner/transpile.go
@@ -2,9 +2,9 @@ package runner
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/titpetric/phpscript/model"
 )
@@ -12,46 +12,134 @@ import (
 // Transpiler lowers expression AST nodes into type-agnostic expr-lang source
 // that delegates PHP-specific behavior to runtime helpers.
 type Transpiler struct {
-	// vars collects every variable referenced by the expression so the runtime
-	// knows which scope values to bind into the expr env.
-	vars map[string]struct{}
+	// vars collects every variable referenced by the expression, in first-use
+	// order, so the runtime knows which scope values to bind into the expr env.
+	// A slice with a linear scan beats a map here: expressions reference a
+	// handful of variables and the result is handed to the compiled expression
+	// as a slice anyway.
+	vars []string
+	// idents holds the expr identifier (varIdent) for each entry of vars. It is
+	// collected here because emit already builds the string.
+	idents []string
+	// calls collects, deduplicated and in first-use order, every function name
+	// emitted as a bare env identifier (see emitCall). It is what lets the
+	// runtime populate an evaluation environment with the handful of registered
+	// functions an expression actually calls instead of the whole table.
+	// Namespaced and fallback calls are not collected: they dispatch through the
+	// __func helper, which resolves against the function table directly.
+	calls []string
 	// closures collects anonymous functions encountered while emitting, keyed by
 	// the synthetic env identifier they are bound to (__cl0, __cl1, ...). The
-	// runtime turns each into a callable before evaluation.
+	// runtime turns each into a callable before evaluation. Both maps stay nil
+	// until something is put in them: most expressions have neither a closure nor
+	// an evaluation marker, and the maps outlive the transpiler (the compiled
+	// expression retains them), so they cannot be reused.
 	closures map[string]*model.Closure
 	exprs    map[string]model.Expr
 }
 
 // NewTranspiler returns a fresh transpiler.
 func NewTranspiler() *Transpiler {
-	return &Transpiler{vars: map[string]struct{}{}, closures: map[string]*model.Closure{}, exprs: map[string]model.Expr{}}
+	return &Transpiler{}
+}
+
+// transpilers pools transpilers across compiles. A transpiler holds no state
+// between runs beyond the collections Reset drops, and compiling an expression
+// is a leaf operation (emit never re-enters the runtime), so one instance is
+// enough per goroutine in flight.
+var transpilers sync.Pool
+
+// acquireTranspiler returns a reset transpiler from the pool.
+func acquireTranspiler() *Transpiler {
+	if t, ok := transpilers.Get().(*Transpiler); ok {
+		t.Reset()
+		return t
+	}
+	return NewTranspiler()
+}
+
+// releaseTranspiler returns t to the pool. The caller must not hold on to the
+// slices returned by Transpile — Reset keeps their backing arrays.
+func releaseTranspiler(t *Transpiler) {
+	t.Reset()
+	transpilers.Put(t)
+}
+
+// Reset clears the state collected by the last Transpile, keeping the backing
+// arrays of the variable slices.
+func (t *Transpiler) Reset() {
+	t.vars = t.vars[:0]
+	t.idents = t.idents[:0]
+	t.calls = t.calls[:0]
+	t.closures = nil
+	t.exprs = nil
 }
 
 // Transpile converts e into expr-lang source and returns the source plus the
-// sorted set of variable names it references.
+// set of variable names it references, in first-use order.
+//
+// The returned slice aliases the transpiler's own storage; copy it (or use
+// Idents, which is kept in step with it) before the transpiler is reused.
 func (t *Transpiler) Transpile(e model.Expr) (src string, vars []string, err error) {
-	t.vars = map[string]struct{}{}
-	t.closures = map[string]*model.Closure{}
-	t.exprs = map[string]model.Expr{}
+	t.vars = t.vars[:0]
+	t.idents = t.idents[:0]
+	t.calls = t.calls[:0]
+	t.closures = nil
+	t.exprs = nil
 	src, err = t.emit(e)
 	if err != nil {
 		return "", nil, err
 	}
-	for name := range t.vars {
-		vars = append(vars, name)
+	return src, t.vars, nil
+}
+
+// Idents returns the expr identifiers of the variables collected during the
+// last Transpile, positionally matching its vars result.
+func (t *Transpiler) Idents() []string { return t.idents }
+
+// Calls returns the function names the last Transpile emitted as bare env
+// identifiers, deduplicated and in first-use order. Like Idents, it aliases the
+// transpiler's own storage.
+func (t *Transpiler) Calls() []string { return t.calls }
+
+// addCall records a function name emitted as a bare env identifier. Expressions
+// call a handful of distinct functions, so a linear scan beats a map for the
+// same reason addVar uses one.
+func (t *Transpiler) addCall(name string) {
+	for _, have := range t.calls {
+		if have == name {
+			return
+		}
 	}
-	sort.Strings(vars)
-	return src, vars, nil
+	t.calls = append(t.calls, name)
 }
 
 // Closures returns the anonymous functions collected during the last Transpile,
-// keyed by their env identifier.
+// keyed by their env identifier. It is nil when the expression has none.
 func (t *Transpiler) Closures() map[string]*model.Closure { return t.closures }
 
+// Exprs returns the sub-expressions marked for deferred evaluation during the
+// last Transpile. It is nil when the expression has none.
 func (t *Transpiler) Exprs() map[string]model.Expr { return t.exprs }
 
+// addVar records a referenced variable and returns its expr identifier.
+func (t *Transpiler) addVar(name string) string {
+	for i, have := range t.vars {
+		if have == name {
+			return t.idents[i]
+		}
+	}
+	ident := varIdent(name)
+	t.vars = append(t.vars, name)
+	t.idents = append(t.idents, ident)
+	return ident
+}
+
 func (t *Transpiler) mark(e model.Expr) string {
-	id := fmt.Sprintf("%d__expr", len(t.exprs))
+	id := strconv.Itoa(len(t.exprs)) + "__expr"
+	if t.exprs == nil {
+		t.exprs = make(map[string]model.Expr, 1)
+	}
 	t.exprs[id] = e
 	return id
 }
@@ -72,13 +160,11 @@ func (t *Transpiler) emit(e model.Expr) (string, error) {
 		return litSource(n.Value), nil
 
 	case *model.Var:
-		t.vars[n.Name] = struct{}{}
-		return varIdent(n.Name), nil
+		return t.addVar(n.Name), nil
 
 	case *model.Unary:
 		if n.Op == "++" || n.Op == "--" {
-			id := t.mark(n)
-			return fmt.Sprintf("__eval(%q)", id), nil
+			return "__eval(" + strconv.Quote(t.mark(n)) + ")", nil
 		}
 		x, err := t.emit(n.X)
 		if err != nil {
@@ -130,27 +216,27 @@ func (t *Transpiler) emit(e model.Expr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("__index(%s, %s)", base, idx), nil
+		return "__index(" + base + ", " + idx + ")", nil
 
 	case *model.PropAccess:
 		base, err := t.emit(n.Base)
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("__get(%s, %q)", base, n.Name), nil
+		return "__get(" + base + ", " + strconv.Quote(n.Name) + ")", nil
 
 	case *model.Call:
 		return t.emitCall(n)
 
 	case *model.ClassConst:
-		return fmt.Sprintf("__classconst(%q, %q)", n.Class, n.Name), nil
+		return "__classconst(" + strconv.Quote(n.Class) + ", " + strconv.Quote(n.Name) + ")", nil
 
 	case *model.Cast:
 		x, err := t.emit(n.X)
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("__cast(%q, %s)", n.Type, x), nil
+		return "__cast(" + strconv.Quote(n.Type) + ", " + x + ")", nil
 
 	case *model.AssignExpr:
 		v, ok := model.UnwrapParenthesized(n.Target).(*model.Var)
@@ -165,14 +251,16 @@ func (t *Transpiler) emit(e model.Expr) (string, error) {
 		if n.Op != "=" && n.Op != "" {
 			return "", fmt.Errorf("transpile: assignment expression op %q unsupported", n.Op)
 		}
-		return fmt.Sprintf("__set(%q, %s)", v.Name, val), nil
+		return "__set(" + strconv.Quote(v.Name) + ", " + val + ")", nil
 
 	case *model.Include:
-		id := t.mark(n)
-		return fmt.Sprintf("__eval(%q)", id), nil
+		return "__eval(" + strconv.Quote(t.mark(n)) + ")", nil
 
 	case *model.Closure:
-		id := fmt.Sprintf("__cl%d", len(t.closures))
+		id := "__cl" + strconv.Itoa(len(t.closures))
+		if t.closures == nil {
+			t.closures = make(map[string]*model.Closure, 1)
+		}
 		t.closures[id] = n
 		return id, nil
 
@@ -185,16 +273,14 @@ func (t *Transpiler) emit(e model.Expr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		parts := append([]string{base, strconv.Quote(n.Method)}, args...)
-		return fmt.Sprintf("__call(%s)", strings.Join(parts, ", ")), nil
+		return joinCall("__call", base, strconv.Quote(n.Method), args), nil
 
 	case *model.New:
 		args, err := t.emitArgs(n.Args)
 		if err != nil {
 			return "", err
 		}
-		parts := append([]string{strconv.Quote(n.Class)}, args...)
-		return fmt.Sprintf("__new(%s)", strings.Join(parts, ", ")), nil
+		return joinCall("__new", strconv.Quote(n.Class), "", args), nil
 
 	default:
 		return "", fmt.Errorf("transpile: unsupported expression %T", e)
@@ -219,8 +305,8 @@ func (t *Transpiler) emitCall(n *model.Call) (string, error) {
 	for i, a := range n.Args {
 		if refs[i] {
 			if v, ok := model.UnwrapParenthesized(a).(*model.Var); ok {
-				t.vars[v.Name] = struct{}{}
-				args = append(args, fmt.Sprintf("__ref(%q)", v.Name))
+				t.addVar(v.Name)
+				args = append(args, "__ref("+strconv.Quote(v.Name)+")")
 				continue
 			}
 		}
@@ -235,10 +321,50 @@ func (t *Transpiler) emitCall(n *model.Call) (string, error) {
 	// resolves Name then Fallback in the runtime function table. Plain, global
 	// calls keep resolving as a bare env identifier (the fast, original path).
 	if n.Fallback != "" || strings.ContainsRune(n.Name, '\\') {
-		parts := append([]string{strconv.Quote(n.Name), strconv.Quote(n.Fallback)}, args...)
-		return fmt.Sprintf("__func(%s)", strings.Join(parts, ", ")), nil
+		return joinCall("__func", strconv.Quote(n.Name), strconv.Quote(n.Fallback), args), nil
 	}
-	return fmt.Sprintf("%s(%s)", n.Name, strings.Join(args, ", ")), nil
+	t.addCall(n.Name)
+	return joinCall(n.Name, "", "", args), nil
+}
+
+// joinCall renders `name(lead1, lead2, args...)` into one presized buffer.
+// Empty leading arguments are omitted — nothing the transpiler emits is the
+// empty string (a quoted empty PHP string is `""`, two characters).
+func joinCall(name, lead1, lead2 string, args []string) string {
+	size := len(name) + 2
+	for _, a := range args {
+		size += len(a) + 2
+	}
+	if lead1 != "" {
+		size += len(lead1) + 2
+	}
+	if lead2 != "" {
+		size += len(lead2) + 2
+	}
+	var b strings.Builder
+	b.Grow(size)
+	b.WriteString(name)
+	b.WriteByte('(')
+	first := true
+	for _, s := range [2]string{lead1, lead2} {
+		if s == "" {
+			continue
+		}
+		if !first {
+			b.WriteString(", ")
+		}
+		first = false
+		b.WriteString(s)
+	}
+	for _, a := range args {
+		if !first {
+			b.WriteString(", ")
+		}
+		first = false
+		b.WriteString(a)
+	}
+	b.WriteByte(')')
+	return b.String()
 }
 
 func (t *Transpiler) emitBinary(n *model.Binary) (string, error) {
@@ -253,21 +379,55 @@ func (t *Transpiler) emitBinary(n *model.Binary) (string, error) {
 	switch n.Op {
 	case ".":
 		// PHP string concatenation -> helper (expr `+` is numeric/typed).
-		return fmt.Sprintf("__concat(%s, %s)", l, r), nil
+		return concat("__concat(", l, ", ", r, ")"), nil
 	case "===":
-		return fmt.Sprintf("(%s) == (%s)", l, r), nil
+		return concat("(", l, ") == (", r, ")"), nil
 	case "!==":
-		return fmt.Sprintf("(%s) != (%s)", l, r), nil
-	case "&&", "||":
+		return concat("(", l, ") != (", r, ")"), nil
+	case "&&":
 		// Logical operators need bool operands in expr-lang.
-		return fmt.Sprintf("__bool(%s) %s __bool(%s)", l, n.Op, r), nil
-	case "+", "-", "*", "/", "%":
-		return fmt.Sprintf("__arith(%q, %s, %s)", n.Op, l, r), nil
-	case "==", "!=", "<", "<=", ">", ">=":
-		return fmt.Sprintf("(%s) %s (%s)", l, n.Op, r), nil
+		return concat("__bool(", l, ") && __bool(", r, ")"), nil
+	case "||":
+		return concat("__bool(", l, ") || __bool(", r, ")"), nil
+	case "+":
+		return concat(`__arith("+", `, l, ", ", r, ")"), nil
+	case "-":
+		return concat(`__arith("-", `, l, ", ", r, ")"), nil
+	case "*":
+		return concat(`__arith("*", `, l, ", ", r, ")"), nil
+	case "/":
+		return concat(`__arith("/", `, l, ", ", r, ")"), nil
+	case "%":
+		return concat(`__arith("%", `, l, ", ", r, ")"), nil
+	case "==":
+		return concat("(", l, ") == (", r, ")"), nil
+	case "!=":
+		return concat("(", l, ") != (", r, ")"), nil
+	case "<":
+		return concat("(", l, ") < (", r, ")"), nil
+	case "<=":
+		return concat("(", l, ") <= (", r, ")"), nil
+	case ">":
+		return concat("(", l, ") > (", r, ")"), nil
+	case ">=":
+		return concat("(", l, ") >= (", r, ")"), nil
 	default:
 		return "", fmt.Errorf("transpile: unsupported operator %q", n.Op)
 	}
+}
+
+// concat joins five fragments into one presized string. The Go compiler folds
+// the constant fragments, so this is one allocation where a Sprintf would box
+// its arguments and grow a buffer.
+func concat(a, b, c, d, e string) string {
+	var sb strings.Builder
+	sb.Grow(len(a) + len(b) + len(c) + len(d) + len(e))
+	sb.WriteString(a)
+	sb.WriteString(b)
+	sb.WriteString(c)
+	sb.WriteString(d)
+	sb.WriteString(e)
+	return sb.String()
 }
 
 func (t *Transpiler) emitArray(n *model.ArrayLit) (string, error) {
@@ -285,9 +445,9 @@ func (t *Transpiler) emitArray(n *model.ArrayLit) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		pairs = append(pairs, fmt.Sprintf("__pair(%s, %s)", key, val))
+		pairs = append(pairs, concat("__pair(", key, ", ", val, ")"))
 	}
-	return fmt.Sprintf("__array(%s)", strings.Join(pairs, ", ")), nil
+	return joinCall("__array", "", "", pairs), nil
 }
 
 func (t *Transpiler) emitArgs(args []model.Expr) ([]string, error) {

--- a/runner/transpile_test.go
+++ b/runner/transpile_test.go
@@ -1,0 +1,374 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+// TestTranspileSource pins the exact expr-lang source emitted for every node
+// kind. The compiled program is cached by this string, so a change here is a
+// change to the whole compile pipeline; the literals below are the reference.
+func TestTranspileSource(t *testing.T) {
+	v := func(name string) model.Expr { return &model.Var{Name: name} }
+	lit := func(val any) model.Expr { return &model.Lit{Value: val} }
+
+	cases := []struct {
+		name string
+		expr model.Expr
+		want string
+		vars []string
+	}{
+		{
+			name: "literals",
+			expr: &model.ArrayLit{Items: []model.ArrayItem{
+				{Val: lit(nil)},
+				{Val: lit(true)},
+				{Val: lit(false)},
+				{Val: lit("a\"b")},
+				{Val: lit(7)},
+				{Val: lit(int64(8))},
+				{Val: lit(1.5)},
+			}},
+			want: `__array(__pair(nil, nil), __pair(nil, true), __pair(nil, false), __pair(nil, "a\"b"), __pair(nil, 7), __pair(nil, 8), __pair(nil, 1.5))`,
+		},
+		{
+			name: "keyed array",
+			expr: &model.ArrayLit{Items: []model.ArrayItem{{Key: lit("k"), Val: v("x")}}},
+			want: `__array(__pair("k", v_x))`,
+			vars: []string{"x"},
+		},
+		{
+			name: "empty array",
+			expr: &model.ArrayLit{},
+			want: `__array()`,
+		},
+		{
+			name: "concat",
+			expr: &model.Binary{Op: ".", Left: v("a"), Right: lit(" b")},
+			want: `__concat(v_a, " b")`,
+			vars: []string{"a"},
+		},
+		{
+			name: "arithmetic",
+			expr: &model.Binary{Op: "+", Left: v("a"), Right: &model.Binary{Op: "%", Left: v("b"), Right: lit(2)}},
+			want: `__arith("+", v_a, __arith("%", v_b, 2))`,
+			vars: []string{"a", "b"},
+		},
+		{
+			name: "identity comparison",
+			expr: &model.Binary{Op: "===", Left: v("a"), Right: lit(1)},
+			want: `(v_a) == (1)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "not identical",
+			expr: &model.Binary{Op: "!==", Left: v("a"), Right: lit(1)},
+			want: `(v_a) != (1)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "loose comparison",
+			expr: &model.Binary{Op: ">=", Left: v("a"), Right: lit(1)},
+			want: `(v_a) >= (1)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "logical and",
+			expr: &model.Binary{Op: "&&", Left: v("a"), Right: v("b")},
+			want: `__bool(v_a) && __bool(v_b)`,
+			vars: []string{"a", "b"},
+		},
+		{
+			name: "logical or",
+			expr: &model.Binary{Op: "||", Left: v("a"), Right: v("b")},
+			want: `__bool(v_a) || __bool(v_b)`,
+			vars: []string{"a", "b"},
+		},
+		{
+			name: "negation and grouping",
+			expr: &model.Unary{Op: "!", X: &model.Parenthesized{X: &model.Unary{Op: "-", X: v("a")}}},
+			want: `!__bool((-(v_a)))`,
+			vars: []string{"a"},
+		},
+		{
+			name: "ternary",
+			expr: &model.Ternary{Cond: v("a"), Then: lit(1), Else: lit(2)},
+			want: `(__bool(v_a)) ? (1) : (2)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "index",
+			expr: &model.Index{Base: v("a"), Index: lit("k")},
+			want: `__index(v_a, "k")`,
+			vars: []string{"a"},
+		},
+		{
+			name: "property",
+			expr: &model.PropAccess{Base: v("obj"), Name: "field"},
+			want: `__get(v_obj, "field")`,
+			vars: []string{"obj"},
+		},
+		{
+			name: "class constant",
+			expr: &model.ClassConst{Class: "Foo", Name: "BAR"},
+			want: `__classconst("Foo", "BAR")`,
+		},
+		{
+			name: "cast",
+			expr: &model.Cast{Type: "int", X: v("a")},
+			want: `__cast("int", v_a)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "assignment expression",
+			expr: &model.AssignExpr{Target: v("a"), Op: "=", Value: lit(1)},
+			want: `__set("a", 1)`,
+			vars: nil,
+		},
+		{
+			name: "call",
+			expr: &model.Call{Name: "strlen", Args: []model.Expr{v("a")}},
+			want: `strlen(v_a)`,
+			vars: []string{"a"},
+		},
+		{
+			name: "call without arguments",
+			expr: &model.Call{Name: "time"},
+			want: `time()`,
+		},
+		{
+			name: "call by reference",
+			expr: &model.Call{Name: "preg_match", Args: []model.Expr{lit("/a/"), v("s"), v("m")}},
+			want: `preg_match("/a/", v_s, __ref("m"))`,
+			vars: []string{"s", "m"},
+		},
+		{
+			name: "namespaced call",
+			expr: &model.Call{Name: `App\f`, Fallback: "f", Args: []model.Expr{lit(1)}},
+			want: `__func("App\\f", "f", 1)`,
+		},
+		{
+			name: "method call",
+			expr: &model.MethodCall{Base: v("obj"), Method: "run", Args: []model.Expr{lit(1), v("a")}},
+			want: `__call(v_obj, "run", 1, v_a)`,
+			vars: []string{"obj", "a"},
+		},
+		{
+			name: "method call without arguments",
+			expr: &model.MethodCall{Base: v("obj"), Method: "run"},
+			want: `__call(v_obj, "run")`,
+			vars: []string{"obj"},
+		},
+		{
+			name: "new",
+			expr: &model.New{Class: "Foo", Args: []model.Expr{lit(1)}},
+			want: `__new("Foo", 1)`,
+		},
+		{
+			name: "new without arguments",
+			expr: &model.New{Class: "Foo"},
+			want: `__new("Foo")`,
+		},
+		{
+			name: "this",
+			expr: &model.PropAccess{Base: v("this"), Name: "id"},
+			want: `__get(this, "id")`,
+			vars: []string{"this"},
+		},
+		{
+			name: "repeated variable is collected once",
+			expr: &model.Binary{Op: ".", Left: v("a"), Right: v("a")},
+			want: `__concat(v_a, v_a)`,
+			vars: []string{"a"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTranspiler()
+			src, vars, err := tr.Transpile(tc.expr)
+			if err != nil {
+				t.Fatalf("Transpile: %v", err)
+			}
+			if src != tc.want {
+				t.Errorf("src\n got %s\nwant %s", src, tc.want)
+			}
+			if len(vars) != len(tc.vars) {
+				t.Fatalf("vars = %v, want %v", vars, tc.vars)
+			}
+			for i, name := range tc.vars {
+				if vars[i] != name {
+					t.Fatalf("vars = %v, want %v", vars, tc.vars)
+				}
+				if got, want := tr.Idents()[i], varIdent(name); got != want {
+					t.Errorf("ident %d = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestTranspileMarkers covers the node kinds that register out-of-band state:
+// closures and deferred evaluation markers.
+func TestTranspileMarkers(t *testing.T) {
+	tr := NewTranspiler()
+
+	cl := &model.Closure{}
+	src, _, err := tr.Transpile(&model.Call{Name: "usort", Args: []model.Expr{&model.Var{Name: "a"}, cl}})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `usort(v_a, __cl0)`; src != want {
+		t.Fatalf("src = %s, want %s", src, want)
+	}
+	if got := tr.Closures()["__cl0"]; got != cl {
+		t.Fatalf("closure __cl0 = %v, want the closure node", got)
+	}
+	if len(tr.Exprs()) != 0 {
+		t.Fatalf("exprs = %v, want empty", tr.Exprs())
+	}
+
+	inc := &model.Include{Path: &model.Lit{Value: "x.php"}, Keyword: "include"}
+	src, _, err = tr.Transpile(inc)
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `__eval("0__expr")`; src != want {
+		t.Fatalf("src = %s, want %s", src, want)
+	}
+	if got := tr.Exprs()["0__expr"]; got != model.Expr(inc) {
+		t.Fatalf("expr marker = %v, want the include node", got)
+	}
+	// Transpile resets: the closure from the previous run must be gone.
+	if len(tr.Closures()) != 0 {
+		t.Fatalf("closures = %v, want empty after reset", tr.Closures())
+	}
+
+	src, _, err = tr.Transpile(&model.Unary{Op: "++", X: &model.Var{Name: "i"}, Postfix: true})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `__eval("0__expr")`; src != want {
+		t.Fatalf("src = %s, want %s", src, want)
+	}
+}
+
+// TestTranspileCalls pins the function names collected for lazy environment
+// population. Every name emitted as a bare env identifier must be listed —
+// Runtime.Eval installs exactly these and nothing else, so a missed name is a
+// call to nil at runtime. Names routed through the __func helper must not be,
+// since that helper resolves against the function table directly.
+func TestTranspileCalls(t *testing.T) {
+	v := func(name string) model.Expr { return &model.Var{Name: name} }
+	lit := func(val any) model.Expr { return &model.Lit{Value: val} }
+
+	cases := []struct {
+		name  string
+		expr  model.Expr
+		calls []string
+	}{
+		{
+			name:  "plain call",
+			expr:  &model.Call{Name: "strlen", Args: []model.Expr{v("a")}},
+			calls: []string{"strlen"},
+		},
+		{
+			name:  "no call",
+			expr:  &model.Binary{Op: ".", Left: v("a"), Right: lit("b")},
+			calls: nil,
+		},
+		{
+			name: "nested calls in argument position",
+			expr: &model.Call{Name: "implode", Args: []model.Expr{
+				lit(","),
+				&model.Call{Name: "array_map", Args: []model.Expr{
+					&model.Call{Name: "trim", Args: []model.Expr{v("a")}},
+				}},
+			}},
+			calls: []string{"trim", "array_map", "implode"},
+		},
+		{
+			name: "call inside an array literal, a ternary and a cast",
+			expr: &model.Cast{Type: "int", X: &model.Ternary{
+				Cond: &model.Call{Name: "is_array", Args: []model.Expr{v("a")}},
+				Then: &model.ArrayLit{Items: []model.ArrayItem{
+					{Key: &model.Call{Name: "key_of"}, Val: &model.Call{Name: "count", Args: []model.Expr{v("a")}}},
+				}},
+				Else: &model.Index{Base: &model.Call{Name: "explode"}, Index: lit(0)},
+			}},
+			calls: []string{"is_array", "key_of", "count", "explode"},
+		},
+		{
+			name: "call inside a method call and a constructor argument",
+			expr: &model.MethodCall{Base: &model.New{Class: "Foo", Args: []model.Expr{
+				&model.Call{Name: "getenv", Args: []model.Expr{lit("HOME")}},
+			}}, Method: "run", Args: []model.Expr{&model.Call{Name: "time"}}},
+			calls: []string{"getenv", "time"},
+		},
+		{
+			name:  "repeated call is collected once",
+			expr:  &model.Binary{Op: ".", Left: &model.Call{Name: "time"}, Right: &model.Call{Name: "time"}},
+			calls: []string{"time"},
+		},
+		{
+			name:  "by-reference argument does not hide the call",
+			expr:  &model.Call{Name: "preg_match", Args: []model.Expr{lit("/a/"), v("s"), v("m")}},
+			calls: []string{"preg_match"},
+		},
+		{
+			name:  "namespaced call goes through __func",
+			expr:  &model.Call{Name: `App\f`, Args: []model.Expr{lit(1)}},
+			calls: nil,
+		},
+		{
+			name:  "call with a global fallback goes through __func",
+			expr:  &model.Call{Name: "f", Fallback: "f", Args: []model.Expr{lit(1)}},
+			calls: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTranspiler()
+			if _, _, err := tr.Transpile(tc.expr); err != nil {
+				t.Fatalf("Transpile: %v", err)
+			}
+			got := tr.Calls()
+			if len(got) != len(tc.calls) {
+				t.Fatalf("calls = %v, want %v", got, tc.calls)
+			}
+			for i, name := range tc.calls {
+				if got[i] != name {
+					t.Fatalf("calls = %v, want %v", got, tc.calls)
+				}
+			}
+		})
+	}
+}
+
+// TestTranspilerPoolIsolation asserts that a pooled transpiler does not leak
+// the previous expression's variables or calls into the next one.
+func TestTranspilerPoolIsolation(t *testing.T) {
+	tr := acquireTranspiler()
+	if _, vars, err := tr.Transpile(&model.Call{Name: "strlen", Args: []model.Expr{&model.Var{Name: "a"}}}); err != nil || len(vars) != 1 {
+		t.Fatalf("Transpile = %v, %v", vars, err)
+	}
+	if len(tr.Calls()) != 1 {
+		t.Fatalf("calls = %v, want [strlen]", tr.Calls())
+	}
+	releaseTranspiler(tr)
+
+	tr = acquireTranspiler()
+	defer releaseTranspiler(tr)
+	src, vars, err := tr.Transpile(&model.Var{Name: "b"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if src != "v_b" || len(vars) != 1 || vars[0] != "b" {
+		t.Fatalf("src = %q, vars = %v, want v_b [b]", src, vars)
+	}
+	if len(tr.Calls()) != 0 {
+		t.Fatalf("calls = %v, want empty after reset", tr.Calls())
+	}
+}

--- a/stdlib/exception.go
+++ b/stdlib/exception.go
@@ -9,24 +9,30 @@ type Exception struct {
 // NewException will return a new allocation for an exception.
 // A nil error is returned so a new exception is not thrown immediately
 // whenever a `new Exception` call is made in the runtime.
-func NewException(message string, code int) (Exception, error) {
-	return Exception{
+//
+// The exception is returned as a pointer. Returning the struct by value boxed
+// a copy into the interface the VM holds, which costs the same allocation but
+// loses reference semantics: the boxed copy is not addressable, so
+// `$e->message = "..."` could not write to it and a method could not mutate
+// the instance the script holds.
+func NewException(message string, code int) (*Exception, error) {
+	return &Exception{
 		Message: message,
 		Code:    code,
 	}, nil
 }
 
 // GetCode returns the error code of the exception.
-func (e Exception) GetCode() int {
+func (e *Exception) GetCode() int {
 	return e.Code
 }
 
 // GetMessage returns the error message of the exception.
-func (e Exception) GetMessage() string {
+func (e *Exception) GetMessage() string {
 	return e.Message
 }
 
 // Error is implemented to satisfy an error interface.
-func (e Exception) Error() string {
+func (e *Exception) Error() string {
 	return e.Message
 }

--- a/stdlib/smtp/smtp.go
+++ b/stdlib/smtp/smtp.go
@@ -238,9 +238,12 @@ func envelopeAddress(from string) (string, error) {
 	return address.Address, nil
 }
 
+// headerReplacer is built once rather than per header per message.
+var headerReplacer = strings.NewReplacer("\r", "", "\n", "")
+
 // header strips CR/LF so script-supplied values cannot inject headers.
 func header(value string) string {
-	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
+	return headerReplacer.Replace(value)
 }
 
 func toString(value any) string {

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/titpetric/phpscript/model"
@@ -98,12 +100,50 @@ func registerStrings(rt *runner.Runtime) {
 	rt.RegisterFunc("implode", phpImplode)
 	rt.RegisterFunc("explode", phpExplode)
 	rt.RegisterFunc("htmlspecialchars", func(s string, _ ...any) string {
-		r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&#039;")
-		return r.Replace(s)
+		return htmlSpecialCharsReplacer.Replace(s)
 	})
 	rt.RegisterFunc("sprintf", phpSprintf)
-	rt.RegisterFunc("crc32", func(s string) int64 { return int64(crc32.ChecksumIEEE([]byte(s))) })
+	rt.RegisterFunc("crc32", phpCRC32)
 }
+
+// htmlSpecialCharsReplacer is built once: a strings.Replacer compiles a trie
+// over its pairs, and htmlspecialchars runs once per template variable, so
+// constructing it inside the binding paid for that trie on every call.
+var htmlSpecialCharsReplacer = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	`"`, "&quot;",
+	"'", "&#039;",
+)
+
+// crc32IEEETable is the standard reflected IEEE table, built once.
+var crc32IEEETable = crc32.MakeTable(crc32.IEEE)
+
+// phpCRC32 checksums a string without the []byte(s) conversion the previous
+// implementation paid on every call. Escape analysis confirmed the conversion
+// escaped ("stdlib.go: ([]byte)(s) escapes to heap"): crc32.ChecksumIEEE's
+// argument leaks into the slicing-by-8 and hardware paths, so every crc32()
+// allocated and copied its input. Short strings — every practical use, since
+// crc32 keys and etags are short — run the table loop in place and allocate
+// nothing. Longer ones keep the standard library's implementation, which
+// processes eight bytes at a time and amortises the copy over the input.
+func phpCRC32(s string) int64 {
+	if len(s) > crc32NativeThreshold {
+		return int64(crc32.ChecksumIEEE([]byte(s)))
+	}
+	crc := ^uint32(0)
+	for i := 0; i < len(s); i++ {
+		crc = crc32IEEETable[byte(crc)^s[i]] ^ (crc >> 8)
+	}
+	return int64(^crc)
+}
+
+// crc32NativeThreshold is where the table loop stops winning outright. Below
+// it the loop is several times faster than allocating a copy (8 bytes: 38ns/0
+// allocs against 105ns/1 alloc); at 256 the two are level on this hardware.
+// See BenchmarkCRC32.
+const crc32NativeThreshold = 256
 
 // phpTrim adapts strings.Trim*-style functions to PHP's optional charlist arg.
 func phpTrim(fn func(string, string) string, def string) func(string, ...string) string {
@@ -154,14 +194,18 @@ func phpStrReplace(search, replace, subject any) string {
 	if model.IsCollection(search) {
 		replIsList := model.IsCollection(replace)
 		repl := arrStrings(replace)
+		// A scalar replacement converts once, not once per search term.
+		scalar := ""
+		if !replIsList {
+			scalar = toString(replace)
+		}
 		for i, s := range arrStrings(search) {
-			r := ""
+			r := scalar
 			if replIsList {
+				r = ""
 				if i < len(repl) {
 					r = repl[i]
 				}
-			} else {
-				r = toString(replace)
 			}
 			out = strings.ReplaceAll(out, s, r)
 		}
@@ -250,25 +294,7 @@ func registerArrays(rt *runner.Runtime) {
 		})
 		return out
 	})
-	rt.RegisterFunc("array_merge", func(arrs ...any) *model.Array {
-		size := 0
-		for _, a := range arrs {
-			n, _ := model.LenValues(a)
-			size += n
-		}
-		out := model.NewArraySize(size)
-		for _, a := range arrs {
-			model.RangeValues(a, func(k, v any) bool {
-				if _, isInt := k.(int64); isInt {
-					out.Append(v)
-				} else {
-					out.Set(k, v)
-				}
-				return true
-			})
-		}
-		return out
-	})
+	rt.RegisterFunc("array_merge", phpArrayMerge)
 	rt.RegisterFunc("array_keys", func(a any) []any {
 		n, _ := model.LenValues(a)
 		out := make([]any, 0, n)
@@ -287,10 +313,43 @@ func registerArrays(rt *runner.Runtime) {
 	rt.RegisterFunc("usort", phpUsort)
 }
 
+// phpArrayMerge implements array_merge. PHP renumbers integer keys and lets
+// later string keys win.
+//
+// This returns an *model.Array even when every input is a list. Returning a
+// presized []any for that case is tempting — it is the shape
+// `call_user_func_array($fn, array_merge(...))` forwards with no copy — but
+// rule 4 of docs/allocation-performance.md reserves *model.Array for values
+// the script appends to, and `$x = array_merge($a, $b); $x[] = "z"` is
+// ordinary PHP that a Go slice cannot serve (a slice cannot grow through the
+// interface value holding it). Since model.Array gained its list mode, a
+// merged list costs one struct allocation more than the slice and no map at
+// all, so the appendability is close to free. Measured: 8 allocs either way.
+func phpArrayMerge(arrs ...any) any {
+	size := 0
+	for _, a := range arrs {
+		n, _ := model.LenValues(a)
+		size += n
+	}
+
+	out := model.NewArraySize(size)
+	for _, a := range arrs {
+		model.RangeValues(a, func(k, v any) bool {
+			if _, isInt := k.(int64); isInt {
+				out.Append(v)
+			} else {
+				out.Set(k, v)
+			}
+			return true
+		})
+	}
+	return out
+}
+
 // phpCompact builds an associative map from variables in the calling scope.
 // Names that do not exist are omitted, matching PHP's compact().
 func phpCompact(ctx context.Context, names ...string) map[string]any {
-	out := map[string]any{}
+	out := make(map[string]any, len(names))
 	scope, ok := runner.ScopeFromContext(ctx)
 	if !ok {
 		return out
@@ -521,7 +580,7 @@ func jsonEncodeValue(v any) any {
 		if x == nil {
 			return nil
 		}
-		if jsonArrayIsList(x) {
+		if arrayIsList(x) {
 			out := make([]any, 0, x.Len())
 			x.Range(func(_, v any) bool {
 				out = append(out, jsonEncodeValue(v))
@@ -561,7 +620,9 @@ func jsonEncodeValue(v any) any {
 	}
 }
 
-func jsonArrayIsList(a *model.Array) bool {
+// arrayIsList reports whether an *model.Array's keys are the dense int64
+// sequence 0..n-1, i.e. whether it is a PHP list.
+func arrayIsList(a *model.Array) bool {
 	expect := int64(0)
 	isList := true
 	a.Range(func(k, _ any) bool {
@@ -782,11 +843,17 @@ func toString(v any) string {
 		}
 		return ""
 	case int64:
-		return fmt.Sprintf("%d", x)
+		// strconv formats in place; fmt.Sprintf would box x into an any
+		// (an allocation of its own for values over 255) and run the
+		// formatter. toString sits under implode, str_replace, in_array and
+		// array_unique, so it is worth the two lines.
+		return strconv.FormatInt(x, 10)
 	case int:
-		return fmt.Sprintf("%d", x)
+		return strconv.Itoa(x)
 	case float64:
-		return fmt.Sprintf("%v", x)
+		// %v for a float64 is 'g' with the shortest representation that
+		// round-trips, which is exactly what FormatFloat(-1) produces.
+		return strconv.FormatFloat(x, 'g', -1, 64)
 	default:
 		return fmt.Sprintf("%v", x)
 	}
@@ -806,12 +873,44 @@ func toInt(v any) int64 {
 		}
 		return 0
 	case string:
-		var n int64
-		fmt.Sscanf(x, "%d", &n)
-		return n
+		return leadingInt(x)
 	default:
 		return 0
 	}
+}
+
+// leadingInt reads the integer prefix of s the way fmt.Sscanf(s, "%d", &n) did:
+// leading whitespace and an optional sign, then digits, stopping at the first
+// character that is not one ("12abc" is 12, "abc" is 0). Overflow yields 0, the
+// value Sscanf left behind when it failed. Sscanf allocated a scan state, a
+// reader and an argument box on every call; this reads the string in place.
+func leadingInt(s string) int64 {
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			i++
+			continue
+		}
+		break
+	}
+	negative := false
+	if i < len(s) && (s[i] == '+' || s[i] == '-') {
+		negative = s[i] == '-'
+		i++
+	}
+	var n int64
+	for ; i < len(s) && s[i] >= '0' && s[i] <= '9'; i++ {
+		digit := int64(s[i] - '0')
+		if n > (math.MaxInt64-digit)/10 {
+			return 0
+		}
+		n = n*10 + digit
+	}
+	if negative {
+		return -n
+	}
+	return n
 }
 
 func truthy(v any) bool {

--- a/stdlib/stdlib_internal_test.go
+++ b/stdlib/stdlib_internal_test.go
@@ -1,0 +1,370 @@
+package stdlib
+
+import (
+	"fmt"
+	"hash/crc32"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+// TestPHPCRC32 pins the table implementation to the standard library's result
+// across the threshold that switches between them.
+func TestPHPCRC32(t *testing.T) {
+	inputs := []string{
+		"",
+		"a",
+		"hello world",
+		strings.Repeat("phpscript", 3),
+		strings.Repeat("x", crc32NativeThreshold),
+		strings.Repeat("x", crc32NativeThreshold+1),
+		strings.Repeat("The quick brown fox. ", 512),
+		"\x00\xff\xfe binary \x01",
+	}
+	for _, in := range inputs {
+		want := int64(crc32.ChecksumIEEE([]byte(in)))
+		if got := phpCRC32(in); got != want {
+			t.Errorf("phpCRC32(%d bytes) = %d, want %d", len(in), got, want)
+		}
+	}
+}
+
+// TestHTMLSpecialCharsReplacer asserts the hoisted replacer still produces
+// PHP's default (ENT_QUOTES-style) escaping.
+func TestHTMLSpecialCharsReplacer(t *testing.T) {
+	got := htmlSpecialCharsReplacer.Replace(`<a href="x">Tom & Jerry's</a>`)
+	want := `&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&#039;s&lt;/a&gt;`
+	if got != want {
+		t.Errorf("htmlspecialchars = %q, want %q", got, want)
+	}
+}
+
+// TestPHPArrayMergeShapes covers both key regimes. array_merge always returns
+// an *model.Array so the result stays appendable (see phpArrayMerge); wantList
+// cases assert it came back list-shaped, i.e. dense int64 keys in order.
+func TestPHPArrayMergeShapes(t *testing.T) {
+	assoc := model.NewArray()
+	assoc.Set("a", 1)
+	assoc.Set("b", 2)
+
+	list := model.NewArray()
+	list.Append("x")
+	list.Append("y")
+
+	sparse := model.NewArray()
+	sparse.Set(int64(3), "three")
+
+	cases := []struct {
+		name     string
+		args     []any
+		wantList []any
+		wantMap  map[string]any
+		wantKeys []any
+	}{
+		{
+			name:     "two []string lists",
+			args:     []any{[]string{"a", "b"}, []string{"c"}},
+			wantList: []any{"a", "b", "c"},
+		},
+		{
+			name:     "[]any and list Array",
+			args:     []any{[]any{"q"}, list},
+			wantList: []any{"q", "x", "y"},
+		},
+		{
+			name:     "no arguments",
+			args:     nil,
+			wantList: []any{},
+		},
+		{
+			name:     "nil argument",
+			args:     []any{nil, []string{"a"}},
+			wantList: []any{"a"},
+		},
+		{
+			name:     "string keys keep the Array",
+			args:     []any{assoc, []string{"tail"}},
+			wantMap:  map[string]any{"a": 1, "b": 2},
+			wantKeys: []any{"a", "b", int64(0)},
+		},
+		{
+			name:     "map argument keeps the Array",
+			args:     []any{map[string]any{"k": "v"}},
+			wantMap:  map[string]any{"k": "v"},
+			wantKeys: []any{"k"},
+		},
+		{
+			name:     "sparse int keys keep the Array",
+			args:     []any{sparse, []string{"tail"}},
+			wantKeys: []any{int64(0), int64(1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := phpArrayMerge(tc.args...)
+			arr, ok := got.(*model.Array)
+			if !ok {
+				t.Fatalf("array_merge returned %T, want *model.Array", got)
+			}
+			if tc.wantList != nil {
+				if !arrayIsList(arr) {
+					t.Fatalf("array_merge keys = %v, want the dense 0..n-1 list", arr.Keys())
+				}
+				var vals []any
+				arr.Range(func(_, v any) bool { vals = append(vals, v); return true })
+				if len(vals) != len(tc.wantList) {
+					t.Fatalf("array_merge = %v, want %v", vals, tc.wantList)
+				}
+				for i := range vals {
+					if vals[i] != tc.wantList[i] {
+						t.Fatalf("array_merge = %v, want %v", vals, tc.wantList)
+					}
+				}
+				return
+			}
+			for k, want := range tc.wantMap {
+				if v, ok := arr.Get(k); !ok || v != want {
+					t.Errorf("array_merge[%q] = %v (%v), want %v", k, v, ok, want)
+				}
+			}
+			if tc.wantKeys != nil {
+				keys := arr.Keys()
+				if len(keys) != len(tc.wantKeys) {
+					t.Fatalf("array_merge keys = %v, want %v", keys, tc.wantKeys)
+				}
+				for i := range keys {
+					if keys[i] != tc.wantKeys[i] {
+						t.Fatalf("array_merge keys = %v, want %v", keys, tc.wantKeys)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestPHPArrayMergeCopiesInputs asserts array_merge produces a new array, as
+// PHP does: writing to the result must not reach back into an argument.
+func TestPHPArrayMergeCopiesInputs(t *testing.T) {
+	src := []any{"a", "b"}
+	out, ok := phpArrayMerge(src).(*model.Array)
+	if !ok {
+		t.Fatalf("array_merge returned %T, want *model.Array", out)
+	}
+	out.Set(int64(0), "changed")
+	if src[0] != "a" {
+		t.Errorf("array_merge aliased its argument: src = %v", src)
+	}
+}
+
+// TestPHPArrayMergeResultIsAppendable is the reason array_merge does not
+// return a []any for the all-lists case: a Go slice cannot grow through the
+// interface value holding it, so `$x = array_merge($a, $b); $x[] = "z"` would
+// be an error. Rule 4 of docs/allocation-performance.md.
+func TestPHPArrayMergeResultIsAppendable(t *testing.T) {
+	out, ok := phpArrayMerge([]string{"a"}, []string{"b"}).(*model.Array)
+	if !ok {
+		t.Fatalf("array_merge returned a non-appendable shape")
+	}
+	out.Append("z")
+	if got := out.Len(); got != 3 {
+		t.Fatalf("Len after append = %d, want 3", got)
+	}
+	if v, ok := out.Get(int64(2)); !ok || v != "z" {
+		t.Errorf("appended element = %v (%v), want z", v, ok)
+	}
+}
+
+// TestToString pins the strconv formatting against the fmt formatting it
+// replaced.
+func TestToString(t *testing.T) {
+	values := []any{
+		nil, "", "text", true, false,
+		int64(0), int64(-1), int64(4096), int64(math.MaxInt64), int64(math.MinInt64),
+		0, -1, 4096,
+		0.0, 1.5, -0.25, 1e21, 1e-7, math.Inf(1), math.NaN(),
+		[]string{"a"},
+	}
+	for _, v := range values {
+		want := legacyToString(v)
+		if got := toString(v); got != want {
+			t.Errorf("toString(%#v) = %q, want %q", v, got, want)
+		}
+	}
+}
+
+func legacyToString(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case bool:
+		if x {
+			return "1"
+		}
+		return ""
+	case int64:
+		return fmt.Sprintf("%d", x)
+	case int:
+		return fmt.Sprintf("%d", x)
+	case float64:
+		return fmt.Sprintf("%v", x)
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}
+
+// TestToIntString pins leadingInt against the fmt.Sscanf("%d") behaviour it
+// replaced, including the cases where a scan failed and left zero behind.
+func TestToIntString(t *testing.T) {
+	inputs := []string{
+		"", "0", "42", " 42", "\t42", "42abc", "abc", "-7", "+7",
+		"0x1f", "3.9", "  -12  ", "007", "12 34", "- 5", "1e3",
+		"9223372036854775807", "-9223372036854775807",
+		"99999999999999999999", "-99999999999999999999",
+	}
+	for _, in := range inputs {
+		var want int64
+		fmt.Sscanf(in, "%d", &want)
+		if got := toInt(in); got != want {
+			t.Errorf("toInt(%q) = %d, want %d", in, got, want)
+		}
+	}
+	if got := toInt("-9223372036854775808"); got != 0 && got != math.MinInt64 {
+		t.Errorf("toInt(MinInt64) = %d, want 0 or MinInt64", got)
+	}
+	// One deliberate divergence: Sscanf treats a newline as a terminator, so
+	// it read "\n 42" as nothing. PHP's integer cast skips all leading
+	// whitespace, which is what leadingInt does.
+	if got := toInt("\n 42"); got != 42 {
+		t.Errorf("toInt(%q) = %d, want 42", "\n 42", got)
+	}
+}
+
+func TestPHPStrReplace(t *testing.T) {
+	cases := []struct {
+		search, replace, subject any
+		want                     string
+	}{
+		{"a", "b", "banana", "bbnbnb"},
+		{[]string{"a", "n"}, "-", "banana", "b-----"},
+		{[]string{"a", "n"}, []string{"1", "2"}, "banana", "b12121"},
+		{[]string{"a", "n"}, []string{"1"}, "banana", "b111"},
+		{"a", 1, "banana", "b1n1n1"},
+	}
+	for _, tc := range cases {
+		if got := phpStrReplace(tc.search, tc.replace, tc.subject); got != tc.want {
+			t.Errorf("str_replace(%v, %v, %v) = %q, want %q", tc.search, tc.replace, tc.subject, got, tc.want)
+		}
+	}
+}
+
+func BenchmarkHTMLSpecialChars(b *testing.B) {
+	const s = `<a href="/x?a=1&b=2">Tom & Jerry's</a>`
+	b.Run("hoisted", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = htmlSpecialCharsReplacer.Replace(s)
+		}
+	})
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&#039;")
+			_ = r.Replace(s)
+		}
+	})
+}
+
+func BenchmarkArrayMerge(b *testing.B) {
+	head := []any{"SELECT 1"}
+	tail := []string{"a", "b", "c", "d"}
+
+	b.Run("lists", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = phpArrayMerge(head, tail)
+		}
+	})
+	b.Run("lists_legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = legacyArrayMerge(head, tail)
+		}
+	})
+
+	assoc := model.NewArray()
+	assoc.Set("a", 1)
+	assoc.Set("b", 2)
+	b.Run("string_keys", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = phpArrayMerge(assoc, tail)
+		}
+	})
+}
+
+// legacyArrayMerge is the pre-fast-path implementation, kept so the benchmark
+// measures the change rather than asserting it (see docs/allocation-performance.md).
+func legacyArrayMerge(arrs ...any) *model.Array {
+	size := 0
+	for _, a := range arrs {
+		n, _ := model.LenValues(a)
+		size += n
+	}
+	out := model.NewArraySize(size)
+	for _, a := range arrs {
+		model.RangeValues(a, func(k, v any) bool {
+			if _, isInt := k.(int64); isInt {
+				out.Append(v)
+			} else {
+				out.Set(k, v)
+			}
+			return true
+		})
+	}
+	return out
+}
+
+func BenchmarkCRC32(b *testing.B) {
+	for _, size := range []int{8, 64, 256, 1024} {
+		s := strings.Repeat("a", size)
+		b.Run("table/"+itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = tableCRC32(s)
+			}
+		})
+		b.Run("stdlib/"+itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = int64(crc32.ChecksumIEEE([]byte(s)))
+			}
+		})
+	}
+}
+
+func tableCRC32(s string) int64 {
+	crc := ^uint32(0)
+	for i := 0; i < len(s); i++ {
+		crc = crc32IEEETable[byte(crc)^s[i]] ^ (crc >> 8)
+	}
+	return int64(^crc)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/stdlib/stdlib_script_test.go
+++ b/stdlib/stdlib_script_test.go
@@ -1,0 +1,228 @@
+package stdlib_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+// runScript parses and runs src against a runtime with the stdlib installed,
+// returning its output. The shims are exercised through the VM because that is
+// where their return shape has to hold up: foreach, indexing, count() and
+// property writes all reach the value through reflection.
+func runScript(t *testing.T, src string) string {
+	t.Helper()
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	stdlib.Register(rt)
+	if err := rt.Run(prog); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return out.String()
+}
+
+// TestExceptionSemantics covers what returning *Exception instead of a struct
+// value buys: the instance the script holds is addressable, so its fields are
+// writable and a write is visible through the accessors.
+func TestExceptionSemantics(t *testing.T) {
+	cases := []struct {
+		name string
+		php  string
+		want string
+	}{
+		{
+			name: "accessors",
+			php:  `<?php $e = new Exception("boom", 7); echo $e->getMessage() . ":" . $e->getCode();`,
+			want: "boom:7",
+		},
+		{
+			name: "default code",
+			php:  `<?php $e = new Exception("boom"); echo $e->getMessage() . ":" . $e->getCode();`,
+			want: "boom:0",
+		},
+		{
+			name: "field write is visible to the accessor",
+			php:  `<?php $e = new Exception("boom", 7); $e->message = "changed"; echo $e->getMessage();`,
+			want: "changed",
+		},
+		{
+			name: "code field write",
+			php:  `<?php $e = new Exception("boom", 7); $e->code = 404; echo $e->getCode();`,
+			want: "404",
+		},
+		{
+			name: "echo renders the message through the error interface",
+			php:  `<?php $e = new Exception("boom", 7); echo $e;`,
+			want: "boom",
+		},
+		{
+			name: "reference semantics across a call",
+			php: `<?php
+function rename($e) { $e->message = "renamed"; }
+$e = new Exception("boom");
+rename($e);
+echo $e->getMessage();`,
+			want: "renamed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runScript(t, tc.php); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestArrayMergeScript pins array_merge's behaviour through the VM: the list
+// fast path must be indistinguishable from the *model.Array it replaced for
+// everything except appending.
+func TestArrayMergeScript(t *testing.T) {
+	cases := []struct {
+		name string
+		php  string
+		want string
+	}{
+		{
+			name: "lists are renumbered and concatenated",
+			php:  `<?php $a = array_merge(array("a", "b"), array("c")); echo implode(",", $a) . "|" . count($a) . "|" . $a[2];`,
+			want: "a,b,c|3|c",
+		},
+		{
+			name: "foreach over a merged list",
+			php:  `<?php foreach (array_merge(array("a"), array("b", "c")) as $k => $v) { echo $k . ":" . $v . " "; }`,
+			want: "0:a 1:b 2:c ",
+		},
+		{
+			name: "later string keys win",
+			php:  `<?php $m = array_merge(array("a" => 1, "b" => 2), array("a" => 3)); echo $m["a"] . "," . $m["b"] . "," . count($m);`,
+			want: "3,2,2",
+		},
+		{
+			name: "string and int keys mix",
+			php:  `<?php $m = array_merge(array("a" => 1), array("x", "y")); echo $m["a"] . "," . $m[0] . "," . $m[1];`,
+			want: "1,x,y",
+		},
+		{
+			name: "string-keyed merge stays appendable",
+			php:  `<?php $m = array_merge(array("a" => 1), array("x")); $m[] = "z"; echo count($m) . "," . $m[1];`,
+			want: "3,z",
+		},
+		{
+			name: "merged list forwards to call_user_func_array",
+			php: `<?php
+$join3 = function ($a, $b, $c) { return $a . $b . $c; };
+echo call_user_func_array($join3, array_merge(array("x"), array("y", "z")));`,
+			want: "xyz",
+		},
+		{
+			name: "empty merge",
+			php:  `<?php $a = array_merge(); echo count($a) . (empty($a) ? ",empty" : ",set");`,
+			want: "0,empty",
+		},
+		{
+			name: "is_array holds for the merged list",
+			php:  `<?php echo is_array(array_merge(array(1), array(2))) ? "yes" : "no";`,
+			want: "yes",
+		},
+		{
+			name: "json_encode of a merged list is a JSON array",
+			php:  `<?php echo json_encode(array_merge(array("a"), array("b")));`,
+			want: `["a","b"]`,
+		},
+		{
+			name: "merged list element write",
+			php:  `<?php $a = array_merge(array("a"), array("b")); $a[0] = "z"; echo implode(",", $a);`,
+			want: "z,b",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runScript(t, tc.php); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringShimsScript(t *testing.T) {
+	cases := []struct {
+		name string
+		php  string
+		want string
+	}{
+		{
+			name: "htmlspecialchars escapes the five entities",
+			php:  `<?php echo htmlspecialchars("<a href=\"x\">a & b's</a>");`,
+			want: `&lt;a href=&quot;x&quot;&gt;a &amp; b&#039;s&lt;/a&gt;`,
+		},
+		{
+			name: "htmlspecialchars passes plain text through",
+			php:  `<?php echo htmlspecialchars("plain text");`,
+			want: "plain text",
+		},
+		{
+			name: "crc32",
+			php:  `<?php echo crc32("The quick brown fox jumped over the lazy dog.");`,
+			want: "2191738434",
+		},
+		{
+			name: "crc32 empty",
+			php:  `<?php echo crc32("");`,
+			want: "0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runScript(t, tc.php); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// BenchmarkScriptHTMLSpecialChars measures the shim the way a template does:
+// through the VM's reflection call path.
+func BenchmarkScriptHTMLSpecialChars(b *testing.B) {
+	prog, err := parser.Parse(`<?php echo htmlspecialchars("<a href=\"/x?a=1&b=2\">Tom & Jerry's</a>");`)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	stdlib.Register(rt)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out.Reset()
+		if err := rt.Run(prog); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+// BenchmarkScriptArrayMerge measures the call_user_func_array shape end to end.
+func BenchmarkScriptArrayMerge(b *testing.B) {
+	prog, err := parser.Parse(`<?php $a = array_merge(array("SELECT 1"), array("a", "b", "c", "d"));`)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	stdlib.Register(rt)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out.Reset()
+		if err := rt.Run(prog); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}

--- a/tests/fixtures/token_get_all.phpt
+++ b/tests/fixtures/token_get_all.phpt
@@ -1,0 +1,55 @@
+name: token_get_all
+description: >
+  Exercise token_get_all() from PHP the way minitpl's compiler does in
+  _split_exp(): foreach with keys, is_array() on the elements, $tok[0] compared
+  against the T_* constants, $tok[1] / $tok[2] reads, count(), and writing an
+  element back into both the token and the token list. The tokenizer returns
+  native Go slices ([]any of []any), so this fixture pins the PHP-visible
+  behaviour of that shape.
+---
+<?php
+$code = str_replace(".", "__1", "<" . "?php if (\$this->_vars.user) { ?" . ">");
+$tokens = token_get_all($code);
+
+echo "count:" . count($tokens) . "\n";
+
+$variables = array();
+$arrows = 0;
+foreach ($tokens as $k => $tok) {
+	if (is_array($tok)) {
+		echo "arr:" . count($tok) . ":" . token_name($tok[0]) . ":" . $tok[1] . ":" . $tok[2] . "\n";
+		if ($tok[0] == T_OBJECT_OPERATOR) {
+			$arrows = $arrows + 1;
+		}
+		if ($tok[0] == T_VARIABLE) {
+			$variables[] = str_replace("__1", ".", $tok[1]);
+		}
+		// minitpl rewrites the id in place and stores the token back.
+		$tok[0] = token_name($tok[0]);
+		$tokens[$k] = $tok;
+	} else {
+		echo "chr:" . $tok . "\n";
+	}
+}
+
+echo "arrows:" . $arrows . "\n";
+echo "vars:" . implode(",", $variables) . "\n";
+echo "rewritten:" . $tokens[0][0] . "\n";
+---
+count:13
+arr:3:T_OPEN_TAG:<?php:1
+arr:3:T_WHITESPACE: :1
+arr:3:T_IF:if:1
+arr:3:T_WHITESPACE: :1
+chr:(
+arr:3:T_VARIABLE:$this:1
+arr:3:T_OBJECT_OPERATOR:->:1
+arr:3:T_STRING:_vars__1user:1
+chr:)
+arr:3:T_WHITESPACE: :1
+chr:{
+arr:3:T_WHITESPACE: :1
+arr:3:T_CLOSE_TAG:?>:1
+arrows:1
+vars:$this
+rewritten:T_OPEN_TAG


### PR DESCRIPTION
Three measure → change → rebuild → re-measure rounds, driven by `phpscript test --profile ./tests/...`. Rounds started from the TODO list in `docs/allocation-performance.md`; once that was exhausted, targets came from `pprof -sample_index=alloc_objects`. Full write-up in [`docs/changelog/2026-08-16-performance-sprint.md`](docs/changelog/2026-08-16-performance-sprint.md).

**223,063 → 43,356 allocs/op (−80.6%) · 22.4 MiB → 5.1 MiB (−77.4%) · 10 → 2 GC runs.** No fixture regressed; the smallest gains were 56% on allocs and 27% on bytes.

**Throughput: interpreter 4.9x, CLI end-to-end 1.44x.** Measured by building the pre-sprint commit (`eba815c`) and running both binaries against the same 36 fixtures:

| | before | after | speedup |
|---|---:|---:|---:|
| Fixture execution, cold parse+compile, no process startup | 49/s | 242/s | **4.9x** |
| `phpscript test ./tests/...`, whole suite, end to end | 91 ms | 63 ms | **1.44x** |

The gap is the useful part: the interpreter is ~5x faster, but a CLI run now spends most of its 63 ms on fixed costs this PR does not touch (process startup, driver connections, fixture I/O).

## Where it came from

| Change | Effect |
|---|---|
| `runner`: pool eval environments behind a `scopeRef`, install only the functions an expression calls | `baseEnv` rebuilt one closure per registered function per `Eval`. Full-stdlib and single-binding scripts now both cost 24 allocs/op (were 649 and 145) |
| `runner`: cache expr's compile config per function-table generation; derive type-env nature once | `expr.Env(typeEnv)` made expr walk a ~95-entry map reflectively on **every compile** — 64% of all allocations |
| `parser`: operator table, presized token slice, chunked AST nodes | 3197 → 564 allocs per 10.8 KB parse |
| `parser`: `TokenGetAll` → `[]any` of `[]any`, pre-boxed id/line tables | 6003 → 1828 allocs on a 5.6 KB template |
| `model`: `Array` list mode — no `map[any]any` until a key breaks `0..n-1` | 5-elem 11 → 9 allocs, 50-elem 66 → 57, `Range` ~17x faster at 0 allocs |
| `stdlib`: hoist `htmlspecialchars`' `Replacer`, table-driven `crc32`, `Exception` → pointer, `toString`/`toInt` off `fmt` | 11 → 2 and 1 → 0 allocs; `$e->message = "x"` now works |

## Not done, deliberately

- **`array_merge` → `[]any`**: implemented, measured, reverted. Its premise (≈5 allocs saved) died when list-mode `Array` landed the same round — 8 allocs either way — and the slice breaks `$x = array_merge($a,$b); $x[] = "z"`.
- **Dropping `expr.Env`**: faster, but wrong. `expr/parser.parseCall` checks `predicates[name]` *before* the disabled-builtins list, so `count`/`map`/`filter`/`sum` would silently become expr predicates. Cached the config instead; `TestCompileMatchesExprEnv` guards it by diffing `Program.Disassemble()`.

## Fixtures

Allocs and KiB per run, with delta.

| Fixture | Allocs before | after | Δ | KiB before | after | Δ | GC before | after |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `include_minitpl` | 30427 | 4208 | -86% | 3093.1 | 310.7 | -90% | 2 | 0 |
| `operators_and_mutation` | 20791 | 2039 | -90% | 1880.3 | 200.0 | -89% | 1 | 0 |
| `ternary_conditions` | 20373 | 2973 | -85% | 1993.9 | 289.7 | -85% | 1 | 0 |
| `array_indexing` | 13895 | 3172 | -77% | 1356.3 | 294.5 | -78% | 0 | 0 |
| `object_nesting` | 11612 | 1775 | -85% | 1146.2 | 144.7 | -87% | 0 | 0 |
| `runtime_introspection` | 10631 | 2011 | -81% | 1122.3 | 166.1 | -85% | 0 | 0 |
| `session_manager` | 9109 | 1778 | -80% | 944.3 | 156.7 | -83% | 1 | 0 |
| `request_and_response_handling` | 8196 | 1351 | -84% | 902.7 | 135.3 | -85% | 1 | 0 |
| `compact` | 7911 | 1270 | -84% | 852.0 | 118.3 | -86% | 0 | 0 |
| `autoloading` | 7620 | 1203 | -84% | 843.7 | 127.7 | -85% | 0 | 0 |
| `get_included_files` | 7055 | 1318 | -81% | 946.3 | 434.2 | -54% | 0 | 1 |
| `php_array_splice` | 6995 | 2007 | -71% | 654.6 | 233.0 | -64% | 0 | 0 |
| `database_test` | 6428 | 1563 | -76% | 617.9 | 135.7 | -78% | 0 | 0 |
| `storage_lifecycle` | 6347 | 1354 | -79% | 675.7 | 154.5 | -77% | 1 | 0 |
| `storage_list` | 5696 | 1265 | -78% | 534.3 | 147.0 | -72% | 0 | 0 |
| `exception_response_code` | 4817 | 1187 | -75% | 498.9 | 138.6 | -72% | 0 | 0 |
| `database_migrate` | 4235 | 1368 | -68% | 509.9 | 135.9 | -73% | 1 | 0 |
| `condition_syntax` | 4113 | 781 | -81% | 470.5 | 119.4 | -75% | 0 | 0 |
| `php_foreach_syntax` | 4042 | 940 | -77% | 399.1 | 131.6 | -67% | 0 | 0 |
| `flatstack_destructuring_assignment` | 4041 | 774 | -81% | 446.4 | 132.9 | -70% | 1 | 0 |
| `flatstack_runner_compatible_fast_path` | 3523 | 1023 | -71% | 379.2 | 128.5 | -66% | 0 | 0 |
| `autoloading_default` | 3396 | 877 | -74% | 385.6 | 154.5 | -60% | 1 | 0 |
| `platform_database` | 2857 | 934 | -67% | 153.3 | 69.0 | -55% | 0 | 0 |
| `user_function_declaration_and_call` | 2048 | 596 | -71% | 238.2 | 104.3 | -56% | 0 | 0 |
| `include-return` | 1785 | 328 | -82% | 199.3 | 65.3 | -67% | 0 | 0 |
| `defer-usage` | 1716 | 372 | -78% | 196.8 | 66.2 | -66% | 0 | 0 |
| `storage_constructor_error_caught` | 1640 | 517 | -68% | 185.0 | 96.5 | -48% | 0 | 1 |
| `exception` | 1602 | 564 | -65% | 177.8 | 88.9 | -50% | 0 | 0 |
| `die_exit` | 1514 | 492 | -68% | 176.3 | 90.2 | -49% | 0 | 0 |
| `autoloading_missing` | 1496 | 475 | -68% | 183.7 | 86.8 | -53% | 0 | 0 |
| `stdin` | 1459 | 457 | -69% | 175.0 | 96.5 | -45% | 0 | 0 |
| `storage_context` | 1274 | 468 | -63% | 131.6 | 90.5 | -31% | 0 | 0 |
| `storage_method_error` | 1254 | 548 | -56% | 133.1 | 94.2 | -29% | 0 | 0 |
| `storage_method_error_caught` | 1141 | 495 | -57% | 94.9 | 69.0 | -27% | 0 | 0 |
| `storage_constructor_error` | 1034 | 455 | -56% | 120.4 | 87.1 | -28% | 0 | 0 |
| `flatstack_arithmetic` | 990 | 418 | -58% | 118.2 | 82.7 | -30% | 0 | 0 |
| `token_get_all` (new) | — | 2930 | — | — | 186.7 | — | — | 0 |
| **Total (36 common)** | **223063** | **43356** | **−80.6%** | **22936.8** | **5176.6** | **−77.4%** | **10** | **2** |

`token_get_all.phpt` is new — it pins the PHP-visible shape of `token_get_all` after it stopped returning `*model.Array` — so it is excluded from the total.

## What's left

`compileExpr` (~48% cum) is now expr's own parse/compile — a cold-start cost a long-lived runtime pays once per distinct expression — and `reflect.Value.Call` (~43%) is the reflection boundary the design accepts.

## Verification

`go build`, `go vet`, `gofmt -l` clean. `go test ./... -count=1` and `-race` pass. 37/37 fixtures pass. Tests added for every semantic change, including a differential test of `model.Array` against a replica of the old map-backed implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
