### PR TITLE
feat(test): --json, pprof, P50/P95/P99, short -c/-t

### DIFF
--- a/cmd/phpscript/test/loop_test.go
+++ b/cmd/phpscript/test/loop_test.go
@@ -96,6 +96,7 @@ func TestTerminalTableColumnsAndSpacing(t *testing.T) {
 		{Options{Count: 2}, "| Test | Filename | Duration (ms) | Count | GC Runs |"},
 		{Options{Count: 2, Profile: true}, "| Test | Filename | Duration (ms) | Count | Allocs/op | Bytes/op | GC Runs |"},
 		{Options{Profile: true}, "| Test | Filename | Duration (ms) | Allocs/op | Bytes/op | GC Runs |"},
+		{Options{Time: time.Millisecond}, "| Test | Filename | Duration (ms) | Count | P50 (µs) | P95 (µs) | P99 (µs) | GC Runs |"},
 	}
 	for _, c := range cases {
 		var buf bytes.Buffer
@@ -165,5 +166,18 @@ func TestTerminalSummaryUsesWorktreeStyle(t *testing.T) {
 func TestFormatGCRuns(t *testing.T) {
 	if got, want := formatGCRuns(2, 8), "2 (25.00%)"; got != want {
 		t.Fatalf("formatGCRuns(2, 8) = %q, want %q", got, want)
+	}
+}
+
+func TestPercentileNs(t *testing.T) {
+	samples := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	if got, want := percentileNs(samples, 50), int64(50); got != want {
+		t.Fatalf("p50 = %d, want %d", got, want)
+	}
+	if got, want := percentileNs(samples, 95), int64(100); got != want {
+		t.Fatalf("p95 = %d, want %d", got, want)
+	}
+	if got := percentileNs(nil, 50); got != 0 {
+		t.Fatalf("empty = %d, want 0", got)
 	}
 }

--- a/cmd/phpscript/test/run.go
+++ b/cmd/phpscript/test/run.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
+	"runtime/pprof"
+	"sort"
 	"time"
 
 	"github.com/titpetric/cli"
@@ -18,25 +20,48 @@ const Name = "Run .phpt test fixtures"
 
 // Options holds CLI flag options for the test command.
 type Options struct {
-	Report     string
-	ReportHTML string
+	JSON       bool
 	Count      int
 	Time       time.Duration
 	Profile    bool
+	CPUProfile string
+	MemProfile string
 }
 
-// NewCommand creates a new test command.
+type jsonFixture struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Passed      bool   `json:"passed"`
+	Runs        int    `json:"runs"`
+	DurationNs  int64  `json:"duration_ns"`
+	P50Ns       int64  `json:"p50_ns,omitempty"`
+	P95Ns       int64  `json:"p95_ns,omitempty"`
+	P99Ns       int64  `json:"p99_ns,omitempty"`
+	AllocsPerOp uint64 `json:"allocs_per_op,omitempty"`
+	BytesPerOp  uint64 `json:"bytes_per_op,omitempty"`
+	GCRuns      uint32 `json:"gc_runs"`
+	Failure     string `json:"failure_reason,omitempty"`
+}
+
+type jsonReport struct {
+	Total   int           `json:"total"`
+	Passed  int           `json:"passed"`
+	Failed  int           `json:"failed"`
+	Results []jsonFixture `json:"results"`
+}
+
 func NewCommand() *cli.Command {
 	var opts Options
 	return &cli.Command{
 		Name:  "test",
 		Title: Name,
 		Bind: func(fs *cli.FlagSet) {
-			fs.StringVar(&opts.Report, "report", "", "Write JSON test report to specified file")
-			fs.StringVar(&opts.ReportHTML, "report-html", "", "Write HTML test report to specified file")
-			fs.IntVar(&opts.Count, "count", 0, "Run each test N times; with --time, produce N benchmark samples")
-			fs.DurationVar(&opts.Time, "time", 0, "Run each test for this duration per benchmark sample (e.g. 10s)")
+			fs.BoolVar(&opts.JSON, "json", false, "Write machine-readable JSON to stdout")
+			fs.IntVarP(&opts.Count, "count", "c", 0, "Run each test N times; with --time, produce N benchmark samples")
+			fs.DurationVarP(&opts.Time, "time", "t", 0, "Run each test for this duration per benchmark sample (e.g. 10s)")
 			fs.BoolVar(&opts.Profile, "profile", false, "Report memory usage per run (allocs/op, B/op)")
+			fs.StringVar(&opts.CPUProfile, "cpuprofile", "", "Write CPU profile to file")
+			fs.StringVar(&opts.MemProfile, "memprofile", "", "Write memory profile to file")
 		},
 		Run: func(ctx context.Context, args []string) error {
 			return Run(ctx, args, opts)
@@ -50,21 +75,29 @@ type fixtureRun struct {
 	DisplayPath string
 	Runs        int
 	Total       time.Duration
+	P50         time.Duration
+	P95         time.Duration
+	P99         time.Duration
 	AllocsPerOp uint64
 	BytesPerOp  uint64
 	GCRuns      uint32
 }
 
-// runFixtureLoop reruns one fixture until the count and time requirements are
-// both met (a single run when neither flag is set). The reported result is the
-// first failing run if any, else the last run.
 func runFixtureLoop(ctx context.Context, fx *tests.Fixture, opts Options) *fixtureRun {
 	out := &fixtureRun{}
+	hint := opts.Count
+	if hint <= 0 {
+		hint = 64
+	}
+	samples := make([]int64, 0, hint)
+
 	var before, after runtime.MemStats
 	runtime.ReadMemStats(&before)
 	start := time.Now()
 	for {
+		opStart := time.Now()
 		res := tests.RunFixture(ctx, fx)
+		samples = append(samples, time.Since(opStart).Nanoseconds())
 		out.Runs++
 		if out.Result == nil || (out.Result.Passed && !res.Passed) {
 			out.Result = res
@@ -88,12 +121,29 @@ func runFixtureLoop(ctx context.Context, fx *tests.Fixture, opts Options) *fixtu
 		out.AllocsPerOp = (after.Mallocs - before.Mallocs) / n
 		out.BytesPerOp = (after.TotalAlloc - before.TotalAlloc) / n
 	}
+	if opts.Time > 0 && len(samples) > 0 {
+		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+		out.P50 = time.Duration(percentileNs(samples, 50))
+		out.P95 = time.Duration(percentileNs(samples, 95))
+		out.P99 = time.Duration(percentileNs(samples, 99))
+	}
 	return out
 }
 
-// runFixtureSamples returns one aggregate run normally. When count and time
-// are both set, count selects the number of benchmark samples and each sample
-// runs independently for the requested time.
+func percentileNs(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (p*len(sorted) + 99) / 100
+	if idx < 1 {
+		idx = 1
+	}
+	if idx > len(sorted) {
+		idx = len(sorted)
+	}
+	return sorted[idx-1]
+}
+
 func runFixtureSamples(ctx context.Context, fx *tests.Fixture, opts Options) []*fixtureRun {
 	if opts.Count <= 0 || opts.Time <= 0 {
 		return []*fixtureRun{runFixtureLoop(ctx, fx, opts)}
@@ -113,6 +163,21 @@ func runFixtureSamples(ctx context.Context, fx *tests.Fixture, opts Options) []*
 
 // Run executes .phpt test fixtures matching the provided paths or patterns.
 func Run(ctx context.Context, args []string, opts Options) error {
+	if opts.CPUProfile != "" {
+		f, err := os.Create(opts.CPUProfile)
+		if err != nil {
+			return fmt.Errorf("create cpuprofile: %w", err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			f.Close()
+			return fmt.Errorf("start cpuprofile: %w", err)
+		}
+		defer func() {
+			pprof.StopCPUProfile()
+			f.Close()
+		}()
+	}
+
 	paths := args
 	if len(paths) == 0 {
 		paths = []string{"."}
@@ -124,7 +189,11 @@ func Run(ctx context.Context, args []string, opts Options) error {
 	}
 
 	if len(fixtures) == 0 {
-		fmt.Println("No .phpt test fixtures found.")
+		if !opts.JSON {
+			fmt.Println("No .phpt test fixtures found.")
+		} else {
+			_ = json.NewEncoder(os.Stdout).Encode(jsonReport{Results: []jsonFixture{}})
+		}
 		return nil
 	}
 
@@ -135,10 +204,14 @@ func Run(ctx context.Context, args []string, opts Options) error {
 			displayPaths[i] = fx.Name
 		}
 	}
-	table := newResultTable(os.Stdout, displayPaths, opts)
-	table.writeHeader()
 
-	var results []*tests.TestResult
+	var table resultTable
+	if !opts.JSON {
+		table = newResultTable(os.Stdout, displayPaths, opts)
+		table.writeHeader()
+	}
+
+	var jsonRows []jsonFixture
 	var failedRuns []*fixtureRun
 	var passedCount, failedCount int
 	startAll := time.Now()
@@ -148,7 +221,23 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		var firstFailedRun *fixtureRun
 		for _, fr := range runFixtureSamples(ctx, fx, opts) {
 			fr.DisplayPath = displayPaths[i]
-			table.writeResult(fr)
+			if table != nil {
+				table.writeResult(fr)
+			}
+			jsonRows = append(jsonRows, jsonFixture{
+				Name:        fx.Name,
+				Path:        fr.DisplayPath,
+				Passed:      fr.Result.Passed,
+				Runs:        fr.Runs,
+				DurationNs:  fr.Total.Nanoseconds(),
+				P50Ns:       fr.P50.Nanoseconds(),
+				P95Ns:       fr.P95.Nanoseconds(),
+				P99Ns:       fr.P99.Nanoseconds(),
+				AllocsPerOp: fr.AllocsPerOp,
+				BytesPerOp:  fr.BytesPerOp,
+				GCRuns:      fr.GCRuns,
+				Failure:     fr.Result.FailureReason,
+			})
 
 			if fixtureResult == nil || fixtureResult.Passed {
 				fixtureResult = fr.Result
@@ -157,7 +246,6 @@ func Run(ctx context.Context, args []string, opts Options) error {
 				firstFailedRun = fr
 			}
 		}
-		results = append(results, fixtureResult)
 
 		if fixtureResult.Passed {
 			passedCount++
@@ -166,33 +254,42 @@ func Run(ctx context.Context, args []string, opts Options) error {
 			failedRuns = append(failedRuns, firstFailedRun)
 		}
 	}
-	table.close()
-	table.writeSummary(passedCount, failedCount, len(fixtures), time.Since(startAll))
 
-	for _, fr := range failedRuns {
-		fmt.Printf("FAIL %s (%dms)\n", fr.DisplayPath, fr.Result.DurationMs)
-		if fr.Result.FailureReason != "" {
-			fmt.Printf("  Reason: %s\n", fr.Result.FailureReason)
+	if table != nil {
+		table.close()
+		table.writeSummary(passedCount, failedCount, len(fixtures), time.Since(startAll))
+	}
+
+	if opts.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		if err := enc.Encode(jsonReport{
+			Total:   len(fixtures),
+			Passed:  passedCount,
+			Failed:  failedCount,
+			Results: jsonRows,
+		}); err != nil {
+			return fmt.Errorf("write json: %w", err)
 		}
 	}
 
-	if opts.Report != "" {
-		if err := writeReportFile(opts.Report, func(f *os.File) error {
-			return tests.WriteJSONReport(f, results)
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing JSON report: %v\n", err)
-		} else {
-			fmt.Printf("Wrote JSON report to %s\n", opts.Report)
+	if !opts.JSON {
+		for _, fr := range failedRuns {
+			fmt.Printf("FAIL %s (%dms)\n", fr.DisplayPath, fr.Result.DurationMs)
+			if fr.Result.FailureReason != "" {
+				fmt.Printf("  Reason: %s\n", fr.Result.FailureReason)
+			}
 		}
 	}
 
-	if opts.ReportHTML != "" {
-		if err := writeReportFile(opts.ReportHTML, func(f *os.File) error {
-			return tests.WriteHTMLReport(f, results)
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing HTML report: %v\n", err)
-		} else {
-			fmt.Printf("Wrote HTML report to %s\n", opts.ReportHTML)
+	if opts.MemProfile != "" {
+		f, err := os.Create(opts.MemProfile)
+		if err != nil {
+			return fmt.Errorf("create memprofile: %w", err)
+		}
+		defer f.Close()
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			return fmt.Errorf("write memprofile: %w", err)
 		}
 	}
 
@@ -201,19 +298,4 @@ func Run(ctx context.Context, args []string, opts Options) error {
 	}
 
 	return nil
-}
-
-func writeReportFile(path string, writeFn func(*os.File) error) error {
-	dir := filepath.Dir(path)
-	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
-		}
-	}
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return writeFn(f)
 }

--- a/cmd/phpscript/test/run_test.go
+++ b/cmd/phpscript/test/run_test.go
@@ -1,7 +1,9 @@
 package test_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,33 +16,48 @@ func TestMain(m *testing.M) {
 	tests.TestMain(m)
 }
 
-func TestRunCommand(t *testing.T) {
+func TestRunCommandJSON(t *testing.T) {
 	ctx := context.Background()
+	tmpDir := t.TempDir()
+	cpuPath := filepath.Join(tmpDir, "cpu.pprof")
+	memPath := filepath.Join(tmpDir, "mem.pprof")
 
-	tmpDir, err := os.MkdirTemp("", "phpscript-test-*")
+	old := os.Stdout
+	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
-
-	jsonReport := filepath.Join(tmpDir, "report.json")
-	htmlReport := filepath.Join(tmpDir, "report.html")
-
-	opts := test.Options{
-		Report:     jsonReport,
-		ReportHTML: htmlReport,
+	os.Stdout = w
+	errRun := test.Run(ctx, []string{"../../../tests/fixtures/die_exit.phpt"}, test.Options{
+		JSON:       true,
+		CPUProfile: cpuPath,
+		MemProfile: memPath,
+	})
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if errRun != nil {
+		t.Fatalf("unexpected error running test command: %v", errRun)
 	}
 
-	err = test.Run(ctx, []string{"../../../tests/fixtures"}, opts)
-	if err != nil {
-		t.Fatalf("unexpected error running test command: %v", err)
+	var report struct {
+		Total   int `json:"total"`
+		Passed  int `json:"passed"`
+		Results []struct {
+			Passed bool `json:"passed"`
+		} `json:"results"`
 	}
-
-	if _, err := os.Stat(jsonReport); os.IsNotExist(err) {
-		t.Fatalf("expected JSON report file at %s", jsonReport)
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("json: %v\n%s", err, buf.String())
 	}
-
-	if _, err := os.Stat(htmlReport); os.IsNotExist(err) {
-		t.Fatalf("expected HTML report file at %s", htmlReport)
+	if report.Total < 1 || report.Passed < 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	if _, err := os.Stat(cpuPath); err != nil {
+		t.Fatalf("cpuprofile: %v", err)
+	}
+	if _, err := os.Stat(memPath); err != nil {
+		t.Fatalf("memprofile: %v", err)
 	}
 }

--- a/cmd/phpscript/test/table.go
+++ b/cmd/phpscript/test/table.go
@@ -42,6 +42,7 @@ type terminalTable struct {
 	widths  []int
 	loop    bool
 	profile bool
+	lat     bool
 }
 
 type resultTable interface {
@@ -64,9 +65,13 @@ func newTerminalTable(w io.Writer, filenames []string, opts Options) *terminalTa
 		headers: []string{"Test", "Filename", "Duration (ms)"},
 		loop:    opts.Count > 0 || opts.Time > 0,
 		profile: opts.Profile,
+		lat:     opts.Time > 0,
 	}
 	if t.loop {
 		t.headers = append(t.headers, "Count")
+	}
+	if t.lat {
+		t.headers = append(t.headers, "P50 (µs)", "P95 (µs)", "P99 (µs)")
 	}
 	if t.profile {
 		t.headers = append(t.headers, "Allocs/op", "Bytes/op")
@@ -107,6 +112,13 @@ func (t *terminalTable) writeResult(r *fixtureRun) {
 	}
 	if t.loop {
 		row = append(row, colorWhite+strconv.Itoa(r.Runs)+colorReset)
+	}
+	if t.lat {
+		row = append(row,
+			colorWhite+formatMicros(r.P50)+colorReset,
+			colorWhite+formatMicros(r.P95)+colorReset,
+			colorWhite+formatMicros(r.P99)+colorReset,
+		)
 	}
 	if t.profile {
 		row = append(row,
@@ -175,6 +187,9 @@ func (t *markdownTable) writeResult(r *fixtureRun) {
 	if t.loop {
 		row = append(row, strconv.Itoa(r.Runs))
 	}
+	if t.lat {
+		row = append(row, formatMicros(r.P50), formatMicros(r.P95), formatMicros(r.P99))
+	}
 	if t.profile {
 		row = append(row, strconv.FormatUint(r.AllocsPerOp, 10), strconv.FormatUint(r.BytesPerOp, 10))
 	}
@@ -196,6 +211,10 @@ func (t *markdownTable) writeMarkdownRow(values []string) {
 
 func formatDuration(duration time.Duration) string {
 	return strconv.FormatInt(duration.Milliseconds(), 10)
+}
+
+func formatMicros(d time.Duration) string {
+	return strconv.FormatInt(d.Microseconds(), 10)
 }
 
 func formatGCRuns(gcRuns uint32, runs int) string {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,24 +71,26 @@ phpscript test tests/fixtures
 phpscript test tests/fixtures/array_indexing.phpt
 ```
 
-Use `--count N` to run each fixture N times in one aggregate row, or `--time D`
-to repeatedly run each fixture for at least duration D. When both flags are
-provided, they select benchmark sampling: each fixture prints N rows, and each
-row is an independent sample that runs for at least D. The `Count` column is
-the number of fixture executions completed during that sample. `GC Runs`
-reports completed Go garbage-collection cycles as `N (M%)`, where M is their
-share of the fixture execution count for that row, shown to two decimal places.
+Use `--count N` (`-c`) to run each fixture N times in one aggregate row, or
+`--time D` (`-t`) to repeatedly run each fixture for at least duration D.
+When both flags are provided, they select benchmark sampling: each fixture
+prints N rows, and each row is an independent sample that runs for at least D.
+The `Count` column is the number of fixture executions completed during that
+sample. With `--time`, `P50`/`P95`/`P99` report per-operation latency in
+microseconds so the wall-clock sample window is not mistaken for a single-run
+duration. `GC Runs` reports completed Go garbage-collection cycles as
+`N (M%)`, where M is their share of the fixture execution count for that row,
+shown to two decimal places.
 
 ```bash
-phpscript test --count 5 tests/fixtures
-phpscript test --time 1s tests/fixtures
+phpscript test -c 5 tests/fixtures
+phpscript test -t 1s tests/fixtures
 phpscript test --count 5 --time 1s tests/fixtures
 ```
 
-Use `--profile` to add per-operation allocation and byte counts. `--report`
-and `--report-html` write JSON and HTML reports respectively; reports continue
-to contain one result per fixture even when benchmark sampling prints multiple
-rows.
+Use `--profile` to add per-operation allocation and byte counts. `--json`
+writes a machine-readable report to stdout (no table). `--cpuprofile` and
+`--memprofile` write pprof files for the whole `test` invocation.
 
 ### `phpscript fmt <path>...`
 


### PR DESCRIPTION
Closes #29.

- Remove `--report` and `--report-html`
- `--json` writes a machine-readable report to stdout (no table mix)
- `--cpuprofile` / `--memprofile` write pprof files for the whole `test` run
- Short flags `-c` / `-t` for `--count` / `--time`
- With `--time`, table adds P50/P95/P99 per-op latency in microseconds (the wall-clock sample window stays in Duration)

`go test ./cmd/phpscript/test/ -count=1` passes.