### PR TITLE
feat(fmt): quotes, arrays, class member order (#8 #9 #10)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,9 +102,11 @@ phpscript fmt ./src        # PHP files directly in ./src
 phpscript fmt ./src/...    # PHP files in ./src and its subdirectories
 ```
 
-The formatter uses tabs for indentation, places class opening braces on the
-next line, keeps function and control-statement braces on the same line, and
-normalizes line endings to LF.
+The formatter uses tabs for indentation, keeps class, function, and
+control-statement braces on the same line, and normalizes line endings to LF.
+String quote style is preserved. Associative arrays with more than two keys
+are expanded one pair per line. Class members print as constants, then
+properties, then methods; blank lines between consecutive properties are kept.
 
 ### `phpscript list <path>...`
 

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -467,36 +467,57 @@ func (p *printer) printClass(n *model.ClassDecl) {
 	}
 	p.line(head + " {")
 	p.depth++
-	first := true
-	writeBlank := func() {
-		if !first {
+	prevLine := 0
+	for i, c := range n.Consts {
+		if i > 0 && fieldGap(prevLine, c.Line) {
 			p.blank()
 		}
-		first = false
-	}
-	for _, f := range n.Fields {
-		writeBlank()
-		p.line(p.field(f) + ";")
-	}
-	for _, f := range n.Statics {
-		writeBlank()
-		p.line(p.staticField(f) + ";")
-	}
-	for _, c := range n.Consts {
-		writeBlank()
 		vis := ""
 		if c.Visibility != "" {
 			vis = c.Visibility + " "
 		}
 		p.line(vis + "const " + c.Name + " = " + p.expr(c.Default) + ";")
+		prevLine = c.Line
 	}
-	for _, m := range n.Methods {
-		writeBlank()
+	vars := 0
+	printVar := func(f model.Field, static bool) {
+		if vars == 0 && len(n.Consts) > 0 {
+			p.blank()
+		} else if vars > 0 && fieldGap(prevLine, f.Line) {
+			p.blank()
+		}
+		if static {
+			p.line(p.staticField(f) + ";")
+		} else {
+			p.line(p.field(f) + ";")
+		}
+		prevLine = f.Line
+		vars++
+	}
+	for _, f := range n.Fields {
+		printVar(f, false)
+	}
+	for _, f := range n.Statics {
+		printVar(f, true)
+	}
+	for i, m := range n.Methods {
+		if i == 0 && (len(n.Consts) > 0 || vars > 0) {
+			p.blank()
+		} else if i > 0 {
+			p.blank()
+		}
 		p.printDeclarationComments(m)
 		p.printFunc(m, true)
 	}
 	p.depth--
 	p.line("}")
+}
+
+func fieldGap(prev, next int) bool {
+	if prev == 0 || next == 0 {
+		return false
+	}
+	return next > prev+1
 }
 
 // staticField renders a `static $name` property declaration. The modifier
@@ -586,7 +607,7 @@ func (p *printer) expr(e model.Expr) string {
 	case nil:
 		return ""
 	case *model.Lit:
-		return p.lit(n.Value)
+		return p.lit(n)
 	case *model.Var:
 		if n.Const {
 			return n.Name
@@ -714,19 +735,64 @@ func (p *printer) args(args []model.Expr) string {
 }
 
 func (p *printer) arrayLit(n *model.ArrayLit) string {
+	if shouldExpandArray(n) {
+		return p.arrayLitExpanded(n)
+	}
 	parts := make([]string, len(n.Items))
 	for i, it := range n.Items {
-		if it.Key != nil {
-			parts[i] = p.expr(it.Key) + " => " + p.expr(it.Val)
-		} else {
-			parts[i] = p.expr(it.Val)
-		}
+		parts[i] = p.arrayItem(it)
 	}
 	return "array(" + strings.Join(parts, ", ") + ")"
 }
 
-func (p *printer) lit(v any) string {
-	switch x := v.(type) {
+func arrayKeyCount(n *model.ArrayLit) int {
+	nKeys := 0
+	for _, it := range n.Items {
+		if it.Key != nil {
+			nKeys++
+		}
+	}
+	return nKeys
+}
+
+func shouldExpandArray(n *model.ArrayLit) bool {
+	if arrayKeyCount(n) > 2 {
+		return true
+	}
+	for _, it := range n.Items {
+		child, ok := it.Val.(*model.ArrayLit)
+		if ok && shouldExpandArray(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *printer) arrayItem(it model.ArrayItem) string {
+	if it.Key != nil {
+		return p.expr(it.Key) + " => " + p.expr(it.Val)
+	}
+	return p.expr(it.Val)
+}
+
+func (p *printer) arrayLitExpanded(n *model.ArrayLit) string {
+	var b strings.Builder
+	b.WriteString("array(\n")
+	p.depth++
+	pad := p.indent()
+	for _, it := range n.Items {
+		b.WriteString(pad)
+		b.WriteString(p.arrayItem(it))
+		b.WriteString(",\n")
+	}
+	p.depth--
+	b.WriteString(p.indent())
+	b.WriteString(")")
+	return b.String()
+}
+
+func (p *printer) lit(n *model.Lit) string {
+	switch x := n.Value.(type) {
 	case nil:
 		return "null"
 	case bool:
@@ -739,13 +805,16 @@ func (p *printer) lit(v any) string {
 	case float64:
 		return fmt.Sprintf("%v", x)
 	case string:
-		return phpQuote(x)
+		return phpQuote(x, n.Quote)
 	default:
 		return fmt.Sprintf("%v", x)
 	}
 }
 
-func phpQuote(s string) string {
+func phpQuote(s string, quote byte) string {
+	if quote == '\'' {
+		return phpSingleQuote(s)
+	}
 	var b strings.Builder
 	b.WriteByte('"')
 	for _, r := range s {
@@ -764,6 +833,22 @@ func phpQuote(s string) string {
 		}
 	}
 	b.WriteByte('"')
+	return b.String()
+}
+
+func phpSingleQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('\'')
+	for _, r := range s {
+		switch r {
+		case '\\', '\'':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('\'')
 	return b.String()
 }
 

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -462,6 +462,128 @@ func TestTerminalClosingTagAndWhitespaceTrimmedIdempotently(t *testing.T) {
 	}
 }
 
+func TestStringLiteralQuoteStylePreserved(t *testing.T) {
+	in := "<?php\n$exitCode = '<span class=\"badge badge-ok\">OK</span>';\n$name = \"Tit\";\n"
+	out, err := formatter.Source(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `$exitCode = '<span class="badge badge-ok">OK</span>';`) {
+		t.Fatalf("single quotes rewritten:\n%s", out)
+	}
+	if !strings.Contains(out, `$name = "Tit";`) {
+		t.Fatalf("double quotes lost:\n%s", out)
+	}
+	again, err := formatter.Source(out)
+	if err != nil || again != out {
+		t.Fatalf("not idempotent: %v\n%s", err, out)
+	}
+}
+
+func TestArrayKeyValuesExpandPastTwoKeys(t *testing.T) {
+	in := `<?php
+$arr = array("id" => 1, "name" => "Tit Petric", "active" => true);
+$pair = array("id" => 1, "name" => "Tit Petric");
+$one = array("name" => "Tit Petric");
+$monthly = array(
+	"labels" => array(),
+	"datasets" => array(
+		array("label" => "Minimum duration", "backgroundColor" => "#c7d2fe", "borderRadius" => 4, "data" => array()),
+	),
+);
+`
+	out, err := formatter.Source(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `"active" => true);`) {
+		t.Fatalf("3-key array stayed on one line:\n%s", out)
+	}
+	if !strings.Contains(out, "\t\"id\" => 1,\n\t\"name\" => \"Tit Petric\",\n\t\"active\" => true,\n)") {
+		t.Fatalf("3-key array not expanded:\n%s", out)
+	}
+	if !strings.Contains(out, `array("id" => 1, "name" => "Tit Petric")`) {
+		t.Fatalf("2-key array should stay one line:\n%s", out)
+	}
+	if !strings.Contains(out, `array("name" => "Tit Petric")`) {
+		t.Fatalf("1-key array should stay one line:\n%s", out)
+	}
+	if !strings.Contains(out, "\t\t\t\"label\" => \"Minimum duration\",\n") &&
+		!strings.Contains(out, "\t\t\"label\" => \"Minimum duration\",\n") {
+		t.Fatalf("nested 4-key array not expanded:\n%s", out)
+	}
+	again, err := formatter.Source(out)
+	if err != nil || again != out {
+		t.Fatalf("not idempotent: %v\n%s", err, out)
+	}
+}
+
+func TestClassConstVarMethodOrderAndSpacing(t *testing.T) {
+	in := `<?php
+class Compiler {
+	function __construct() {
+	}
+
+	const E_FILENAME_EMPTY = "Filename can't be empty, tried to render %q";
+
+	var $hooks;
+	var $_open_tag;
+	var $_close_tag;
+}
+`
+	want := `<?php
+
+class Compiler {
+	const E_FILENAME_EMPTY = "Filename can't be empty, tried to render %q";
+
+	var $hooks;
+	var $_open_tag;
+	var $_close_tag;
+
+	function __construct() {
+	}
+}
+`
+	out, err := formatter.Source(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != want {
+		t.Fatalf("class members:\n--- got ---\n%s--- want ---\n%s", out, want)
+	}
+
+	in2 := `<?php
+class Compiler {
+	var $hooks;
+
+	var $_open_tag;
+	var $_close_tag;
+
+	function __construct() {
+	}
+}
+`
+	want2 := `<?php
+
+class Compiler {
+	var $hooks;
+
+	var $_open_tag;
+	var $_close_tag;
+
+	function __construct() {
+	}
+}
+`
+	out2, err := formatter.Source(in2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out2 != want2 {
+		t.Fatalf("var spacing:\n--- got ---\n%s--- want ---\n%s", out2, want2)
+	}
+}
+
 func TestTrailingWhitespaceTrimmedFromMixedHTML(t *testing.T) {
 	in := "<?php\r\necho \"x\";\r\n?>\r\n<p>x</p>  \r\n"
 	want := "<?php\n\necho \"x\";\n\n?>\n<p>x</p>\n"

--- a/model/ast.go
+++ b/model/ast.go
@@ -211,6 +211,7 @@ type Field struct {
 	Name       string
 	Default    Expr   // nil if none
 	Visibility string // "public", "protected", "private", or ""
+	Line       int    // source line of the declaration (formatter spacing)
 }
 
 func (*InlineHTML) node() {}
@@ -286,8 +287,11 @@ func (*Unset) stmt() {}
 // ---------------------------------------------------------------------------
 
 // Lit is a literal scalar: nil, bool, int64, float64 or string.
+// Quote is the source delimiter for a string (' or "); zero means the
+// printer should pick double quotes.
 type Lit struct {
 	Value any
+	Quote byte
 }
 
 // Var is a `$name` reference (the `$` is stripped during parsing).

--- a/parser/alloc.go
+++ b/parser/alloc.go
@@ -110,6 +110,13 @@ func (p *parser) newLit(v any) *model.Lit {
 	return n
 }
 
+func (p *parser) newStringLit(v string, quote byte) *model.Lit {
+	n := p.litNodes.new()
+	n.Value = v
+	n.Quote = quote
+	return n
+}
+
 func (p *parser) newBinary(op string, left, right model.Expr) *model.Binary {
 	n := p.binaryNodes.new()
 	n.Op, n.Left, n.Right = op, left, right

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -242,7 +242,7 @@ func (p *parser) parsePrimary() (model.Expr, error) {
 
 	case tString:
 		p.next()
-		return p.newLit(t.val), nil
+		return p.newStringLit(t.val, t.quote), nil
 
 	case tIdent:
 		return p.parseIdentExpr()

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -25,10 +25,11 @@ const (
 
 // token is a single lexical unit with source position for diagnostics.
 type token struct {
-	kind tokKind
-	val  string
-	pos  int
-	line int
+	kind  tokKind
+	val   string
+	pos   int
+	line  int
+	quote byte // opening delimiter of a tString (' or ")
 }
 
 func (t token) String() string { return fmt.Sprintf("%v(%q)@%d", t.kind, t.val, t.line) }
@@ -124,6 +125,10 @@ func (l *lexer) skipShebang() {
 
 func (l *lexer) emit(k tokKind, v string) {
 	l.tokens = append(l.tokens, token{kind: k, val: v, pos: l.pos, line: l.line})
+}
+
+func (l *lexer) emitString(v string, quote byte) {
+	l.tokens = append(l.tokens, token{kind: tString, val: v, pos: l.pos, line: l.line, quote: quote})
 }
 
 // lexInlineHTML consumes raw text until the next <?php (or <?) open tag.
@@ -249,7 +254,7 @@ func (l *lexer) lexString(quote byte) error {
 			val := l.src[start:i]
 			l.advance(i - start) // keeps the line counter accurate
 			l.advanceRune()      // closing quote
-			l.emit(tString, val)
+			l.emitString(val, quote)
 			return nil
 		}
 	}
@@ -270,7 +275,7 @@ func (l *lexer) lexString(quote byte) error {
 		}
 		if c == quote {
 			l.advanceRune()
-			l.emit(tString, b.String())
+			l.emitString(b.String(), quote)
 			return nil
 		}
 		b.WriteByte(c)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -993,7 +993,7 @@ func (p *parser) parseConsts() ([]model.Field, error) {
 		if p.cur().kind != tIdent {
 			return nil, fmt.Errorf("line %d: expected constant name", p.cur().line)
 		}
-		c := model.Field{Name: p.next().val}
+		c := model.Field{Name: p.next().val, Line: p.toks[p.i-1].line}
 		if err := p.eatOp("="); err != nil {
 			return nil, err
 		}
@@ -1041,7 +1041,7 @@ func (p *parser) parseFields(visibility string) ([]model.Field, error) {
 		if p.cur().kind != tVar {
 			return nil, fmt.Errorf("line %d: expected $field", p.cur().line)
 		}
-		f := model.Field{Name: p.next().val, Visibility: visibility}
+		f := model.Field{Name: p.next().val, Visibility: visibility, Line: p.toks[p.i-1].line}
 		if p.isOp("=") {
 			p.next()
 			def, err := p.parseExpr()


### PR DESCRIPTION
Closes #8, #9, and #10.

- **#10** Single- and double-quoted string literals keep their delimiter; HTML in `'...'` is no longer rewritten with escaped double quotes.
- **#9** `array(...)` with more than two keys expands one pair per line, trailing comma, extra tab. One- and two-key arrays stay on one line with a space after each comma. A parent expands if a nested array must.
- **#8** Class members print as constants, then properties, then methods. Consecutive `var` lines stay packed unless the source already had a blank line. One blank line after the property block before methods.

`go test ./formatter/ ./parser/ -count=1` passes.