### PR TITLE
feat(info): phpscript info command

### DIFF
--- a/atkins.yml
+++ b/atkins.yml
@@ -51,7 +51,7 @@ tasks:
     passthru: true
     cmds:
       - ./scripts/list-apis.php > docs/reference/extensions/implemented-apis.md
-      - ./scripts/phpinfo.php
+      - phpscript info
       - cd docs/reference && php README.php > README.md
       - task: mdox:fmt
 

--- a/cmd/phpscript/info/run.go
+++ b/cmd/phpscript/info/run.go
@@ -1,0 +1,212 @@
+package info
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/titpetric/cli"
+
+	phplist "github.com/titpetric/phpscript/list"
+	"github.com/titpetric/phpscript/model"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+const Name = "Print runtime environment"
+
+type Options struct {
+	Verbose bool
+}
+
+func NewCommand() *cli.Command {
+	var opts Options
+	return &cli.Command{
+		Name:  "info",
+		Title: Name,
+		Bind: func(fs *cli.FlagSet) {
+			fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "List bound functions, classes and methods")
+		},
+		Run: func(ctx context.Context, args []string) error {
+			return Run(ctx, args, opts)
+		},
+	}
+}
+
+func Run(ctx context.Context, args []string, opts Options) error {
+	if len(args) > 0 {
+		return printSourceTree(args)
+	}
+	rt := runner.New(os.Stdout, runner.Options{SAPI: "cli", RootFS: os.DirFS(".")})
+	stdlib.Register(rt)
+	stdlib.RegisterFS(rt, ".")
+	fmt.Fprintln(os.Stdout, "# phpscript")
+	fmt.Fprintln(os.Stdout)
+	if err := rt.PHPInfo(); err != nil {
+		return err
+	}
+	if !opts.Verbose {
+		return nil
+	}
+	printBindings(rt)
+	return nil
+}
+
+func printBindings(rt *runner.Runtime) {
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "# Classes")
+	for _, name := range rt.DeclaredClasses() {
+		fmt.Fprintf(os.Stdout, "\n## %s\n\n", name)
+		if ctor, ok := rt.LookupConstructor(name); ok {
+			printHostClass(name, ctor)
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "Usage:\n\n- `new %s()`\n", name)
+	}
+	internal, _ := rt.DefinedFunctions()
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "## Functions")
+	fmt.Fprintln(os.Stdout)
+	for _, name := range internal {
+		fmt.Fprintf(os.Stdout, "- `%s()`\n", name)
+	}
+}
+
+func printHostClass(name string, ctor any) {
+	t := reflect.TypeOf(ctor)
+	if t.Kind() != reflect.Func {
+		fmt.Fprintf(os.Stdout, "Usage:\n\n- `new %s()`\n", name)
+		return
+	}
+	fmt.Fprintln(os.Stdout, "Usage:")
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintf(os.Stdout, "- `new %s(%s)`\n", name, ctorParams(t))
+	ret := ctorReturn(t)
+	if ret == nil {
+		return
+	}
+	for i := 0; i < ret.NumMethod(); i++ {
+		m := ret.Method(i)
+		if !m.IsExported() {
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "- `func (*%s) %s(%s)`\n", shortType(ret), phpMethod(m.Name), methodParams(m.Type))
+	}
+}
+
+func ctorParams(t reflect.Type) string {
+	var parts []string
+	for i := 0; i < t.NumIn(); i++ {
+		in := t.In(i)
+		if i == 0 && in == reflect.TypeOf((*context.Context)(nil)).Elem() {
+			continue
+		}
+		parts = append(parts, "$"+paramName(in, i))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func ctorReturn(t reflect.Type) reflect.Type {
+	for i := 0; i < t.NumOut(); i++ {
+		out := t.Out(i)
+		if out.Kind() == reflect.Interface && out.Name() == "error" {
+			continue
+		}
+		for out.Kind() == reflect.Pointer {
+			out = out.Elem()
+		}
+		return out
+	}
+	return nil
+}
+
+func methodParams(t reflect.Type) string {
+	var parts []string
+	start := 0
+	if t.NumIn() > 0 && t.In(0).Kind() == reflect.Pointer {
+		start = 1
+	}
+	for i := start; i < t.NumIn(); i++ {
+		in := t.In(i)
+		if in == reflect.TypeOf((*context.Context)(nil)).Elem() {
+			continue
+		}
+		parts = append(parts, "$"+paramName(in, i))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func paramName(t reflect.Type, i int) string {
+	if t.Kind() == reflect.String {
+		return "name"
+	}
+	return fmt.Sprintf("arg%d", i)
+}
+
+func phpMethod(name string) string {
+	if name == "" {
+		return name
+	}
+	return strings.ToLower(name[:1]) + name[1:]
+}
+
+func shortType(t reflect.Type) string {
+	n := t.Name()
+	if n == "" {
+		return t.String()
+	}
+	return n
+}
+
+func printSourceTree(paths []string) error {
+	files, err := phplist.ExpandFiles(paths)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, "# Source")
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		prog, err := parser.Parse(string(src))
+		if err != nil {
+			continue
+		}
+		var classes []*model.ClassDecl
+		var funcs []*model.FuncDecl
+		for _, s := range prog.Stmts {
+			switch n := s.(type) {
+			case *model.ClassDecl:
+				classes = append(classes, n)
+			case *model.FuncDecl:
+				funcs = append(funcs, n)
+			}
+		}
+		if len(classes) == 0 && len(funcs) == 0 {
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "\n## %s\n", file)
+		for _, c := range classes {
+			fmt.Fprintf(os.Stdout, "\n### %s\n\nUsage:\n\n- `new %s()`\n", c.Name, c.Name)
+			for _, m := range c.Methods {
+				fmt.Fprintf(os.Stdout, "- `function %s(%s)`\n", m.Name, paramList(m.Params))
+			}
+		}
+		for _, f := range funcs {
+			fmt.Fprintf(os.Stdout, "\n- `function %s(%s)`\n", f.Name, paramList(f.Params))
+		}
+	}
+	return nil
+}
+
+func paramList(params []model.Param) string {
+	parts := make([]string, len(params))
+	for i, p := range params {
+		parts[i] = "$" + p.Name
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cmd/phpscript/info/run_test.go
+++ b/cmd/phpscript/info/run_test.go
@@ -1,0 +1,74 @@
+package info
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunPrintsRuntime(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := Run(context.Background(), nil, Options{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "# phpscript") || !strings.Contains(out, "Runtime => phpscript") {
+		t.Fatalf("info output:\n%s", out)
+	}
+	if strings.Contains(out, "# Classes") {
+		t.Fatalf("verbose section without -v:\n%s", out)
+	}
+}
+
+func TestRunVerboseListsBindings(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := Run(context.Background(), nil, Options{Verbose: true}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, want := range []string{"# Classes", "## Database", "new Database", "## Functions", "`phpinfo()`"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSourceTree(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "sample.php")
+	if err := os.WriteFile(src, []byte("<?php\nclass Sample {\n\tfunction run($x) {}\n}\nfunction helper() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() {
+		if err := Run(context.Background(), []string{dir}, Options{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, want := range []string{"# Source", "### Sample", "function run($x)", "function helper()"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,21 @@ Use this command for normal script execution and shebang scripts:
 echo "Hello world\n";
 ```
 
+### `phpscript info [path...]`
+
+Print the runtime environment, the way `phpinfo()` does in a terminal.
+
+```bash
+phpscript info
+phpscript info -v
+phpscript info ./src
+```
+
+With no path, the command prints the built-in runtime. `-v` / `--verbose`
+adds bound classes (with constructors and methods) and internal functions.
+A path argument uses the same file expansion as `list` and prints markdown
+docs for classes and functions found in that tree.
+
 ### `phpscript lint <path>...`
 
 Lint one or more PHP files or directories.

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/titpetric/phpscript/cmd/phpscript/ast"
 	"github.com/titpetric/phpscript/cmd/phpscript/fmt"
+	"github.com/titpetric/phpscript/cmd/phpscript/info"
 	"github.com/titpetric/phpscript/cmd/phpscript/lint"
 	"github.com/titpetric/phpscript/cmd/phpscript/list"
 	"github.com/titpetric/phpscript/cmd/phpscript/run"
@@ -57,6 +58,7 @@ func start() error {
 	app := cli.NewApp("phpscript")
 	app.AddCommand("ast", ast.Name, ast.NewCommand)
 	app.AddCommand("fmt", fmt.Name, fmt.NewCommand)
+	app.AddCommand("info", info.Name, info.NewCommand)
 	app.AddCommand("lint", lint.Name, lint.NewCommand)
 	app.AddCommand("list", list.Name, list.NewCommand)
 	app.AddCommand("run", run.Name, func() *cli.Command {

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -390,6 +390,12 @@ func (rt *Runtime) RegisterConstructor(name string, ctor any) {
 	rt.constructors[name] = ctor
 }
 
+// LookupConstructor returns the host constructor registered for name.
+func (rt *Runtime) LookupConstructor(name string) (any, bool) {
+	fn, ok := rt.constructors[name]
+	return fn, ok
+}
+
 // SetIncludeCache installs a shared include cache. A cache must only be shared
 // by runtimes whose include paths resolve within the same source-root namespace.
 // Passing nil disables include caching.

--- a/scripts/phpinfo.php
+++ b/scripts/phpinfo.php
@@ -1,4 +1,0 @@
-#!/usr/bin/env phpscript
-<?php
-
-phpinfo();

--- a/stdlib/imports.go
+++ b/stdlib/imports.go
@@ -7,6 +7,7 @@ package stdlib
 // bindings to Register.
 import (
 	_ "github.com/titpetric/phpscript/stdlib/compat"
+	_ "github.com/titpetric/phpscript/stdlib/info"
 	_ "github.com/titpetric/phpscript/stdlib/ps"
 	_ "github.com/titpetric/phpscript/stdlib/smtp"
 	_ "github.com/titpetric/phpscript/stdlib/span"

--- a/stdlib/info/info.go
+++ b/stdlib/info/info.go
@@ -1,0 +1,16 @@
+package info
+
+import (
+	"github.com/titpetric/phpscript/runner"
+)
+
+func init() {
+	runner.RegisterBinding(Register)
+}
+
+// Register installs phpinfo().
+func Register(rt *runner.Runtime) {
+	rt.RegisterFunc("phpinfo", func(_ ...any) (bool, error) {
+		return true, rt.PHPInfo()
+	})
+}

--- a/stdlib/info/info.php
+++ b/stdlib/info/info.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env phpscript
+<?php
+phpinfo();
+
+if (getenv("PHPSCRIPT_INFO_VERBOSE") !== "1") {
+	return;
+}
+
+echo "\n# Classes\n\n";
+foreach (get_declared_classes() as $class) {
+	echo "## " . $class . "\n\n";
+}
+
+echo "## Functions\n\n";
+$functions = get_defined_functions();
+foreach ($functions["internal"] as $function) {
+	echo "- `" . $function . "`\n";
+}

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -1039,9 +1039,6 @@ func registerLang(rt *runner.Runtime) {
 	rt.RegisterFunc("get_declared_classes", func() []string {
 		return rt.DeclaredClasses()
 	})
-	rt.RegisterFunc("phpinfo", func(_ ...any) (bool, error) {
-		return true, rt.PHPInfo()
-	})
 	rt.RegisterFunc("php_sapi_name", func() string {
 		return rt.SAPI()
 	})


### PR DESCRIPTION
Closes #32.

- `phpscript info` prints the runtime (`phpinfo()` facts)
- `-v` / `--verbose` lists bound classes (constructors + methods) and internal functions
- path arguments scan a source tree the way `list` does
- `phpinfo()` registration lives in `stdlib/info` (blank import)
- `stdlib/info/info.php` is the PHP-side listing script
- `scripts/phpinfo.php` removed; `atkins.yml` calls `phpscript info`

`go test ./cmd/phpscript/info/ ./stdlib/ -count=1` passes.