### PR TITLE
feat(telemetry): durable disk storage for oida traces

### DIFF
--- a/cmd/phpscript/server/run.go
+++ b/cmd/phpscript/server/run.go
@@ -187,7 +187,11 @@ func Run(ctx context.Context, args []string, config config.Config) error {
 	var recorder *telemetry.Module
 	if config.Telemetry.Enabled {
 		var err error
-		recorder, err = telemetry.NewModule(config.Telemetry)
+		opts, err := config.Telemetry.Resolved()
+		if err != nil {
+			return err
+		}
+		recorder, err = telemetry.NewModule(opts)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,8 @@ package config
 
 import (
 	_ "embed"
+	"fmt"
+	"strings"
 
 	"github.com/titpetric/phpscript/runner"
 	"github.com/titpetric/phpscript/telemetry"
@@ -13,11 +15,44 @@ var DefaultRuntimeConfig []byte
 
 // Config configures phpscript runtimes and HTTP modules.
 type Config struct {
-	Runner    runner.Options    `yaml:"runner"`
-	Flatstack Flatstack         `yaml:"flatstack"`
-	Routes    Routes            `yaml:"routes"`
-	Telemetry telemetry.Options `yaml:"telemetry"`
-	Env       []string          `yaml:"env"`
+	Runner    runner.Options `yaml:"runner"`
+	Flatstack Flatstack      `yaml:"flatstack"`
+	Routes    Routes         `yaml:"routes"`
+	Telemetry Telemetry      `yaml:"telemetry"`
+	Env       []string       `yaml:"env"`
+}
+
+// Telemetry is oida options plus optional durable storage.
+type Telemetry struct {
+	telemetry.Options `yaml:",inline"`
+	Driver            string `yaml:"driver"`
+	StoragePath       string `yaml:"storage_path"`
+}
+
+// Resolved returns oida options with storage applied.
+func (t Telemetry) Resolved() (telemetry.Options, error) {
+	opts := t.Options
+	switch strings.ToLower(strings.TrimSpace(t.Driver)) {
+	case "", "memory":
+		return opts, nil
+	case "disk":
+		path := t.StoragePath
+		if path == "" {
+			path = "/dev/shm/phpscript-trace-detail"
+		}
+		limit := opts.RingBufferSize
+		if limit <= 0 {
+			limit = 200
+		}
+		store, err := telemetry.NewStorageDisk(limit, path)
+		if err != nil {
+			return opts, fmt.Errorf("telemetry disk storage: %w", err)
+		}
+		opts.Storage = store
+		return opts, nil
+	default:
+		return opts, fmt.Errorf("telemetry driver %q: want memory or disk", t.Driver)
+	}
 }
 
 // Flatstack selects the flat bytecode runtime when enabled.
@@ -39,6 +74,6 @@ func New() Config {
 		Routes: Routes{
 			Enabled: true,
 		},
-		Telemetry: options,
+		Telemetry: Telemetry{Options: options},
 	}
 }

--- a/config/config.yml
+++ b/config/config.yml
@@ -17,6 +17,7 @@ telemetry:
   sample_rate: 100
   track_memory_use: true
   live_stream: true
+  driver: memory
 
 env:
   - "PLATFORM_DB_SQLITE_TEST=sqlite://:memory:"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,8 @@ matter for a phpscript service are:
 | `track_memory_use`    |           `true` | Record process-wide allocation and garbage-collection changes per trace. |
 | `live_stream`         |           `true` | Serve the live view over server sent events instead of a refresh timer.  |
 | `ignore_paths`        | health endpoints | Paths never traced. Entries ending in `/*` match by prefix.              |
+| `driver`              |         `memory` | Trace store: `memory` (ring buffer) or `disk` (JSON files, restart-safe). |
+| `storage_path`        | `/dev/shm/phpscript-trace-detail` | Folder for `driver: disk`. One `{id}.json` per retained trace. |
 
 Memory tracking has process-wide sampling overhead and concurrent requests can
 overlap in those measurements. See [Telemetry](./telemetry.md) for the views,

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,7 +12,10 @@ types bound there, so the provider is named in one place.
 
 The bundled server enables telemetry by default. Set `telemetry.enabled` to
 `false` in a file passed with `-f` to turn it off; retention, sampling, the
-mount path and memory sampling are configurable in the same section. See
+mount path and memory sampling are configurable in the same section. Set
+`telemetry.driver` to `disk` and `telemetry.storage_path` to a folder (tmpfs
+is fine) so completed traces survive a restart as `{id}.json`. Sampling still
+decides what is recorded; the disk driver only persists what was sampled. See
 [Configuration](./configuration.md#http-modules).
 
 ## Views

--- a/main_test.go
+++ b/main_test.go
@@ -63,6 +63,33 @@ env:
 	}
 }
 
+func TestLoadConfigTelemetryDisk(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(filename, []byte(`
+telemetry:
+  enabled: true
+  driver: disk
+  storage_path: `+dir+`
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Telemetry.Driver != "disk" || cfg.Telemetry.StoragePath != dir {
+		t.Fatalf("telemetry storage = %+v", cfg.Telemetry)
+	}
+	opts, err := cfg.Telemetry.Resolved()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Storage == nil {
+		t.Fatal("disk storage not applied")
+	}
+}
+
 func TestParseConfigFile(t *testing.T) {
 	filename, args, err := parseConfigFile([]string{"server", "-f", "config.yml", "app"})
 	if err != nil {


### PR DESCRIPTION
Closes #23.

oida already ships `NewStorageDisk`. This wires it from config:

```yaml
telemetry:
  driver: disk
  storage_path: /dev/shm/phpscript-trace-detail
  sample_rate: 100
```

`driver` defaults to `memory`. Sampling still decides what is recorded; the disk store only persists sampled traces (`{id}.json`). Permalink / restart survival is oida's disk backend, not a second store in this repo.