### PR TITLE
feat(server): @schedule annotation for cron-style jobs

### DIFF
--- a/annotations/annotations.go
+++ b/annotations/annotations.go
@@ -1,11 +1,12 @@
 // Package annotations discovers annotated PHP files in a source tree and gives
 // them a lifecycle: routed endpoints are served over HTTP, startup jobs run once
-// before the server listens.
+// before the server listens, and scheduled jobs run on an interval.
 //
 // Two annotations are recognised, both written as comments:
 //
 //   - `// @route GET /users/{id}` registers an HTTP endpoint.
 //   - `// @startup` marks a file the server executes before it listens.
+//   - `// @schedule daily -- prune` runs a file on a clock or interval.
 //
 // # Routes
 //
@@ -37,6 +38,15 @@
 // A file carrying `@startup` runs once, in path order, before the server
 // listens. It executes with the CLI SAPI, so it can migrate a schema or warm a
 // cache. An error aborts startup.
+//
+// # Scheduled jobs
+//
+// A file may repeat `@schedule` with an interval spec and optional `-- args`
+// passed as `$argv`. Specs: `every N seconds|minutes|hours`, `hourly`, `daily`,
+// `weekly`, `monthly`, `every weekday`, `every sunday` (any weekday name),
+// `N times per hour|day`. Calendar specs fire at local midnight. A tick is
+// skipped when the previous run is still going. Output is recorded on the
+// oida span as `output`.
 //
 // # Discovery
 //

--- a/annotations/schedule.go
+++ b/annotations/schedule.go
@@ -1,0 +1,126 @@
+package annotations
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"sync"
+	"time"
+
+	"github.com/titpetric/platform"
+
+	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/telemetry"
+)
+
+// Scheduler runs @schedule jobs for the life of the server. Start returns
+// immediately; each job waits until its next due time in its own goroutine.
+type Scheduler struct {
+	platform.UnimplementedModule
+	root   fs.FS
+	config config
+	now    func() time.Time
+}
+
+type scheduledJob struct {
+	file string
+	src  []byte
+	spec Schedule
+}
+
+// NewScheduler creates a schedule module reading jobs from root.
+func NewScheduler(root fs.FS, options ...Option) *Scheduler {
+	return &Scheduler{
+		UnimplementedModule: *platform.NewUnimplementedModule("phpschedule"),
+		root:                root,
+		config:              newConfig(options...),
+		now:                 time.Now,
+	}
+}
+
+// Start discovers jobs and runs them until ctx is cancelled.
+func (s *Scheduler) Start(ctx context.Context) error {
+	var jobs []scheduledJob
+	err := scanner{root: s.root, excluded: s.config.excludedDirs}.walk(func(file string, src []byte) error {
+		for _, spec := range ParseSchedules(src) {
+			jobs = append(jobs, scheduledJob{file: file, src: src, spec: spec})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		go s.loop(ctx, job)
+	}
+	return nil
+}
+
+func (s *Scheduler) loop(ctx context.Context, job scheduledJob) {
+	var running sync.Mutex
+	next := job.spec.Next(s.now())
+	for {
+		timer := time.NewTimer(next.Sub(s.now()))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		if running.TryLock() {
+			s.run(ctx, job)
+			running.Unlock()
+		}
+		next = job.spec.Next(s.now())
+	}
+}
+
+func (s *Scheduler) run(ctx context.Context, job scheduledJob) {
+	name := "@schedule " + job.spec.Raw
+	if len(job.spec.Args) > 0 {
+		name += " " + job.spec.Args[0]
+	}
+	name += " " + job.file
+	work := func(ctx context.Context) error {
+		return s.execute(ctx, job)
+	}
+	for _, observer := range s.config.observers {
+		if tracker, ok := observer.(interface {
+			TrackLifecycle(context.Context, string, string, func(context.Context) error) error
+		}); ok {
+			_ = tracker.TrackLifecycle(ctx, name, job.file, work)
+			return
+		}
+	}
+	_ = work(ctx)
+}
+
+func (s *Scheduler) execute(ctx context.Context, job scheduledJob) error {
+	var buf bytes.Buffer
+	out := io.Writer(&buf)
+	if s.config.output != nil {
+		out = io.MultiWriter(s.config.output, &buf)
+	}
+	req := runner.NewContext()
+	req.Argv = append([]string{job.file}, job.spec.Args...)
+	rt := s.config.newRuntime(ctx, s.root, out, "cli", func(rt *runner.Runtime) {
+		req.Register(rt)
+	})
+	rt.UpdateFilename(job.file)
+	program, err := rt.Load(string(job.src))
+	if err == nil {
+		err = rt.Run(program)
+	}
+	if span := telemetry.SpanFromContext(ctx); span != nil && buf.Len() > 0 {
+		span.SetAttribute("output", buf.String())
+	}
+	if exit, ok := runner.IsExit(err); ok && exit.Code == 0 {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("schedule %s: %w", job.file, err)
+	}
+	return nil
+}

--- a/annotations/schedule_parse.go
+++ b/annotations/schedule_parse.go
@@ -1,0 +1,189 @@
+package annotations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Schedule is one `@schedule` annotation: when to run, and argv after `--`.
+type Schedule struct {
+	Raw      string
+	Args     []string
+	Every    time.Duration
+	Weekdays []time.Weekday
+	MonthDay int
+	Align    align
+}
+
+type align int
+
+const (
+	alignInterval align = iota
+	alignDay
+)
+
+// ParseSchedules returns the @schedule declarations found in src. A line may
+// carry `-- args` after the interval spec; those become $argv[1:].
+func ParseSchedules(src []byte) []Schedule {
+	var out []Schedule
+	for line := range strings.SplitSeq(string(src), "\n") {
+		text, ok := comment(line)
+		if !ok {
+			continue
+		}
+		name, fields := tag(text)
+		if name != "@schedule" || len(fields) == 0 {
+			continue
+		}
+		spec, args := splitScheduleArgs(fields)
+		job, err := parseScheduleSpec(spec)
+		if err != nil {
+			continue
+		}
+		job.Raw = spec
+		job.Args = args
+		out = append(out, job)
+	}
+	return out
+}
+
+func splitScheduleArgs(fields []string) (string, []string) {
+	for i, field := range fields {
+		if field == "--" {
+			return strings.Join(fields[:i], " "), append([]string(nil), fields[i+1:]...)
+		}
+	}
+	return strings.Join(fields, " "), nil
+}
+
+func parseScheduleSpec(spec string) (Schedule, error) {
+	fields := strings.Fields(strings.ToLower(spec))
+	if len(fields) == 0 {
+		return Schedule{}, fmt.Errorf("empty schedule")
+	}
+	switch {
+	case eq(fields, "hourly"):
+		return Schedule{Every: time.Hour}, nil
+	case eq(fields, "daily"):
+		return Schedule{Align: alignDay}, nil
+	case eq(fields, "weekly"):
+		return Schedule{Align: alignDay, Weekdays: []time.Weekday{time.Sunday}}, nil
+	case eq(fields, "monthly"):
+		return Schedule{Align: alignDay, MonthDay: 1}, nil
+	case eq(fields, "every", "weekday"):
+		return Schedule{Align: alignDay, Weekdays: weekdays}, nil
+	case len(fields) == 2 && fields[0] == "every":
+		if day, ok := weekdayName(fields[1]); ok {
+			return Schedule{Align: alignDay, Weekdays: []time.Weekday{day}}, nil
+		}
+	case len(fields) == 3 && fields[0] == "every":
+		n, err := strconv.Atoi(fields[1])
+		if err != nil || n <= 0 {
+			return Schedule{}, fmt.Errorf("invalid interval count %q", fields[1])
+		}
+		unit, err := durationUnit(fields[2])
+		if err != nil {
+			return Schedule{}, err
+		}
+		return Schedule{Every: time.Duration(n) * unit}, nil
+	case len(fields) == 4 && fields[1] == "times" && fields[2] == "per":
+		n, err := strconv.Atoi(fields[0])
+		if err != nil || n <= 0 {
+			return Schedule{}, fmt.Errorf("invalid times count %q", fields[0])
+		}
+		switch fields[3] {
+		case "hour", "hours":
+			return Schedule{Every: time.Hour / time.Duration(n)}, nil
+		case "day", "days":
+			return Schedule{Every: 24 * time.Hour / time.Duration(n)}, nil
+		}
+	}
+	return Schedule{}, fmt.Errorf("unknown schedule %q", spec)
+}
+
+func eq(fields []string, want ...string) bool {
+	if len(fields) != len(want) {
+		return false
+	}
+	for i := range fields {
+		if fields[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func durationUnit(name string) (time.Duration, error) {
+	switch name {
+	case "second", "seconds":
+		return time.Second, nil
+	case "minute", "minutes":
+		return time.Minute, nil
+	case "hour", "hours":
+		return time.Hour, nil
+	default:
+		return 0, fmt.Errorf("unknown unit %q", name)
+	}
+}
+
+var weekdays = []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday}
+
+func weekdayName(name string) (time.Weekday, bool) {
+	switch name {
+	case "sunday", "sun":
+		return time.Sunday, true
+	case "monday", "mon":
+		return time.Monday, true
+	case "tuesday", "tue":
+		return time.Tuesday, true
+	case "wednesday", "wed":
+		return time.Wednesday, true
+	case "thursday", "thu":
+		return time.Thursday, true
+	case "friday", "fri":
+		return time.Friday, true
+	case "saturday", "sat":
+		return time.Saturday, true
+	}
+	return 0, false
+}
+
+// Next returns the first instant strictly after t at which the job should run.
+func (s Schedule) Next(t time.Time) time.Time {
+	if s.Every > 0 {
+		return t.Add(s.Every)
+	}
+	candidate := nextMidnight(t)
+	for i := 0; i < 62; i++ {
+		if s.matchDay(candidate) {
+			return candidate
+		}
+		candidate = candidate.Add(24 * time.Hour)
+	}
+	return t.Add(24 * time.Hour)
+}
+
+func nextMidnight(t time.Time) time.Time {
+	day := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	if !day.After(t) {
+		day = day.Add(24 * time.Hour)
+	}
+	return day
+}
+
+func (s Schedule) matchDay(t time.Time) bool {
+	if s.MonthDay > 0 && t.Day() != s.MonthDay {
+		return false
+	}
+	if len(s.Weekdays) == 0 {
+		return true
+	}
+	for _, day := range s.Weekdays {
+		if t.Weekday() == day {
+			return true
+		}
+	}
+	return false
+}

--- a/annotations/schedule_test.go
+++ b/annotations/schedule_test.go
@@ -1,0 +1,89 @@
+package annotations_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/titpetric/phpscript/annotations"
+)
+
+func TestParseSchedules(t *testing.T) {
+	src := []byte(`<?php
+// @schedule daily -- prune
+// @schedule every 5 minutes -- sync
+// @schedule every weekday
+// @schedule 2 times per hour -- tick
+// @schedule every sunday
+echo "// @schedule hourly";
+`)
+	got := annotations.ParseSchedules(src)
+	if len(got) != 5 {
+		t.Fatalf("schedules = %+v", got)
+	}
+	if got[0].Raw != "daily" || got[0].Args[0] != "prune" || got[0].Every != 0 {
+		t.Fatalf("daily = %+v", got[0])
+	}
+	if got[1].Every != 5*time.Minute || got[1].Args[0] != "sync" {
+		t.Fatalf("every 5 minutes = %+v", got[1])
+	}
+	if len(got[2].Weekdays) != 5 {
+		t.Fatalf("weekday = %+v", got[2])
+	}
+	if got[3].Every != 30*time.Minute {
+		t.Fatalf("2 times per hour = %v", got[3].Every)
+	}
+	if len(got[4].Weekdays) != 1 || got[4].Weekdays[0] != time.Sunday {
+		t.Fatalf("sunday = %+v", got[4])
+	}
+}
+
+func TestScheduleNext(t *testing.T) {
+	now := time.Date(2026, 8, 18, 15, 4, 5, 0, time.UTC)
+	interval := annotations.Schedule{Every: 5 * time.Minute}
+	if got := interval.Next(now); !got.Equal(now.Add(5 * time.Minute)) {
+		t.Fatalf("interval next = %v", got)
+	}
+	parsed := annotations.ParseSchedules([]byte("<?php\n// @schedule daily\n"))
+	if len(parsed) != 1 {
+		t.Fatal(parsed)
+	}
+	got := parsed[0].Next(now)
+	want := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("daily next = %v, want %v", got, want)
+	}
+}
+
+func TestSchedulerRunsWithArgv(t *testing.T) {
+	root := fstest.MapFS{
+		"job.php": {Data: []byte("<?php\n// @schedule every 1 seconds -- prune\necho $argv[1];\n")},
+	}
+	var buf bytes.Buffer
+	s := annotations.NewScheduler(root, annotations.WithOutput(&buf))
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Drive one execution through the same path Start uses by calling after a tick.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if buf.String() == "prune" {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("output = %q, want prune", buf.String())
+}
+
+func TestSchedulerStartScansFS(t *testing.T) {
+	root := fstest.MapFS{
+		"plain.php": {Data: []byte("<?php echo 1;")},
+		"cron.php":  {Data: []byte("<?php\n// @schedule daily\n")},
+	}
+	if err := annotations.NewScheduler(fs.FS(root)).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/phpscript/server/run.go
+++ b/cmd/phpscript/server/run.go
@@ -203,6 +203,7 @@ func Run(ctx context.Context, args []string, config config.Config) error {
 		annotations.WithObservers(observers...),
 	}
 	svc.Register(annotations.NewStartup(os.DirFS(root), annotationOptions...))
+	svc.Register(annotations.NewScheduler(os.DirFS(root), annotationOptions...))
 	if recorder != nil {
 		svc.Use(recorder.Middleware)
 		svc.Register(recorder)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,8 +121,9 @@ phpscript list index.php    # A specific PHP file
 ```
 
 The Route column names the entry point a file provides: a `METHOD /path`
-annotation, or `@startup` for a file the server runs before it listens. Files
-that are only included by others have neither.
+annotation, `@startup` for a file the server runs before it listens, or
+`@schedule …` for a clock or interval job. Files that are only included by
+others have neither.
 
 ### `phpscript ast <file.php>`
 
@@ -178,6 +179,30 @@ $migrate = new Database\Migrate("app");
 $migrate->load("./schema/*.up.sql");
 $migrate->run();
 ```
+
+`@schedule` annotations start after listen and keep running until shutdown:
+
+```php
+<?php
+// @schedule daily -- prune
+// @schedule every 5 minutes -- sync
+
+switch ($argv[1]) {
+case "prune":
+	break;
+case "sync":
+	break;
+default:
+	echo "Unknown/missing command";
+	exit(1);
+}
+```
+
+Specs: `every N seconds|minutes|hours`, `hourly`, `daily`, `weekly`,
+`monthly`, `every weekday`, `every sunday` (any weekday), `N times per hour|day`.
+Arguments after `--` become `$argv[1:]`. Calendar specs fire at local midnight.
+A tick is skipped if the previous run is still going. Output is stored on the
+oida span as `output`.
 
 Startup files run with the CLI SAPI and the application filesystem. If one
 fails, the server is not started. See

--- a/list/list.go
+++ b/list/list.go
@@ -50,9 +50,8 @@ func File(path string) ([]Row, error) {
 	}
 	classCol := strings.Join(classes, ", ")
 	anns := annotations.ParseRoutes(b)
-	if len(anns) == 0 {
-		// A startup file has no route but is still an entry point: the server
-		// runs it once before listening, so the inventory names it as one.
+	schedules := annotations.ParseSchedules(b)
+	if len(anns) == 0 && len(schedules) == 0 {
 		entry := ""
 		if annotations.HasStartup(b) {
 			entry = "@startup"
@@ -63,10 +62,21 @@ func File(path string) ([]Row, error) {
 			Classes:  classCol,
 		}}, nil
 	}
-	rows := make([]Row, 0, len(anns))
+	rows := make([]Row, 0, len(anns)+len(schedules))
 	for _, a := range anns {
 		rows = append(rows, Row{
 			Route:    a.Method + " " + a.Path,
+			Filename: rel,
+			Classes:  classCol,
+		})
+	}
+	for _, job := range schedules {
+		label := "@schedule " + job.Raw
+		if len(job.Args) > 0 {
+			label += " -- " + strings.Join(job.Args, " ")
+		}
+		rows = append(rows, Row{
+			Route:    label,
 			Filename: rel,
 			Classes:  classCol,
 		})


### PR DESCRIPTION
Closes #25.

```php
// @schedule daily -- prune
// @schedule every 5 minutes -- sync
```

- Specs: `every N seconds|minutes|hours`, `hourly`, `daily`, `weekly`, `monthly`, `every weekday`, `every sunday` (any weekday), `N times per hour|day`
- Args after `--` become `$argv[1:]`
- Calendar specs fire at local midnight
- Overlapping ticks are skipped
- Job output is stored on the oida lifecycle span as `output`
- `phpscript list` shows `@schedule …` rows
- Scheduler starts with the server (does not block listen)

`go test ./annotations/ ./list/ ./cmd/phpscript/server/ -count=1` passes.