### PR TITLE
perf(test): reuse runtime and AST across -count reruns

### DIFF
--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -77,7 +77,8 @@ type Runtime struct {
 	// constants are visible in every scope, including inside functions and
 	// methods, matching PHP's constant semantics. Bare-identifier lookups that
 	// miss the current scope fall back here (see Eval).
-	constants map[string]any
+	constants    map[string]any
+	frozenConsts map[string]any
 
 	// opts holds runtime source root, working directory, and write policy.
 	opts         Options
@@ -270,6 +271,38 @@ func NewFlatStack(w io.Writer, opts Options) *Runtime {
 	rt := New(w, opts)
 	rt.flat = true
 	return rt
+}
+
+// FreezeStdlib snapshots constants after host bindings are registered so
+// ResetSession can drop script-defined constants without losing the stdlib.
+func (rt *Runtime) FreezeStdlib() {
+	rt.frozenConsts = maps.Clone(rt.constants)
+}
+
+// ResetSession prepares the runtime to execute another program: new output and
+// stdin, empty globals and user declarations. Host functions, constructors and
+// the expression/bytecode caches stay.
+func (rt *Runtime) ResetSession(out io.Writer, stdin io.Reader) {
+	if out == nil {
+		out = os.Stdout
+	}
+	rt.out = out
+	rt.outStack = nil
+	if stdin == nil {
+		stdin = strings.NewReader("")
+	}
+	rt.opts.Stdin = stdin
+	rt.userFns = map[string]struct{}{}
+	rt.classes = map[string]*model.Class{}
+	rt.globals = map[string]any{}
+	rt.shutdown = nil
+	rt.autoloaders = nil
+	rt.classConsts = map[string]map[string]any{}
+	rt.classStatics = map[string]map[string]any{}
+	rt.entrypoint = ""
+	if rt.frozenConsts != nil {
+		rt.constants = maps.Clone(rt.frozenConsts)
+	}
 }
 
 // SetContext installs the lifecycle context auto-injected into registered Go

--- a/tests/fixture.go
+++ b/tests/fixture.go
@@ -20,6 +20,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/runner"
 	"github.com/titpetric/phpscript/stdlib"
@@ -99,6 +100,12 @@ type Fixture struct {
 	PHP      string `yaml:"-"`
 	Expected string `yaml:"-"`
 	Path     string `yaml:"-"`
+
+	mu        sync.Mutex
+	parsed    *model.Program
+	parsedErr error
+	interp    *runner.Runtime
+	flatRT    *flatstack.Runtime
 }
 
 // TestResult carries execution outcome for a single fixture.
@@ -316,80 +323,95 @@ func RunFixture(ctx context.Context, f *Fixture) *TestResult {
 	return res
 }
 
+func (f *Fixture) program() (*model.Program, error) {
+	if f.parsed != nil || f.parsedErr != nil {
+		return f.parsed, f.parsedErr
+	}
+	f.parsed, f.parsedErr = parser.Parse(f.PHP)
+	return f.parsed, f.parsedErr
+}
+
+func (f *Fixture) stdin() io.Reader {
+	content := f.Request.Stdin
+	if content == "" {
+		content = f.Stdin
+	}
+	if content == "" {
+		return strings.NewReader("")
+	}
+	return strings.NewReader(content)
+}
+
 func executeFixturePHP(ctx context.Context, f *Fixture) (string, runner.Context, error) {
-	prog, err := parser.Parse(f.PHP)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	prog, err := f.program()
 	if err != nil {
 		return "Internal Server Error", runner.Context{}, err
 	}
 
 	var out strings.Builder
 	reqCtx := buildFixtureRequestContext(f)
-
-	stdinContent := f.Request.Stdin
-	if stdinContent == "" {
-		stdinContent = f.Stdin
+	if f.interp == nil {
+		options := runner.Options{RootFS: testPHPFS(), Stdin: f.stdin()}
+		rt := runner.New(&out, options)
+		rt.SetIncludeCache(includeCache)
+		rt.SetExprCache(exprCache)
+		rt.RegisterConstructor("Storage", NewStorage)
+		rt.RegisterConstructor("FailStorage", NewFailStorage)
+		stdlib.RegisterFS(rt, ".")
+		stdlib.Register(rt)
+		rt.FreezeStdlib()
+		f.interp = rt
+	} else {
+		f.interp.ResetSession(&out, f.stdin())
 	}
+	f.interp.SetContext(ctx)
+	reqCtx.Register(f.interp)
 
-	options := runner.Options{
-		RootFS: testPHPFS(),
-	}
-	if stdinContent != "" {
-		options.Stdin = strings.NewReader(stdinContent)
-	}
-
-	rt := runner.New(&out, options)
-	rt.SetIncludeCache(includeCache)
-	rt.SetExprCache(exprCache)
-	rt.SetContext(ctx)
-
-	rt.RegisterConstructor("Storage", NewStorage)
-	rt.RegisterConstructor("FailStorage", NewFailStorage)
-	stdlib.RegisterFS(rt, ".")
-	stdlib.Register(rt)
-
-	reqCtx.Register(rt)
-
-	if err := rt.Run(prog); err != nil {
+	if err := f.interp.Run(prog); err != nil {
 		if _, ok := runner.IsExit(err); ok {
 			return out.String(), reqCtx, nil
 		}
 		return "Internal Server Error", reqCtx, err
 	}
-
 	return out.String(), reqCtx, nil
 }
 
 func executeFlatstack(ctx context.Context, f *Fixture) (string, error) {
-	prog, err := parser.Parse(f.PHP)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	prog, err := f.program()
 	if err != nil {
 		return "", err
 	}
-	if err := flatstack.Supports(prog); err != nil {
-		return "", fmt.Errorf("flatstack unsupported: %w", err)
+	if f.flatRT == nil {
+		if err := flatstack.Supports(prog); err != nil {
+			return "", fmt.Errorf("flatstack unsupported: %w", err)
+		}
 	}
 
 	var out strings.Builder
-	stdinContent := f.Request.Stdin
-	if stdinContent == "" {
-		stdinContent = f.Stdin
+	if f.flatRT == nil {
+		f.flatRT = newFlatstackTestRuntime(&out, ctx, f.stdin())
+		f.flatRT.FreezeStdlib()
+	} else {
+		f.flatRT.ResetSession(&out, f.stdin())
+		f.flatRT.SetContext(context.WithValue(ctx, tenantKey, "acme"))
 	}
-
-	runtime := newFlatstackTestRuntime(&out, ctx, strings.NewReader(stdinContent))
-	if err := runtime.Run(prog); err != nil {
+	if err := f.flatRT.Run(prog); err != nil {
 		if _, ok := flatstack.IsExit(err); ok {
 			return out.String(), nil
 		}
 		return out.String(), err
 	}
-
 	return out.String(), nil
 }
 
-func newFlatstackTestRuntime(out *strings.Builder, ctx context.Context, input ...*strings.Reader) *flatstack.Runtime {
-	options := flatstack.Options{RootFS: testPHPFS()}
-	if len(input) > 0 {
-		options.Stdin = input[0]
-	}
+func newFlatstackTestRuntime(out *strings.Builder, ctx context.Context, input io.Reader) *flatstack.Runtime {
+	options := flatstack.Options{RootFS: testPHPFS(), Stdin: input}
 	runtime := flatstack.New(out, options)
 	runtime.SetIncludeCache(flatIncludeCache)
 	runtime.SetExprCache(flatExprCache)


### PR DESCRIPTION
`--count N` was measuring harness setup: a new Runtime, env snapshot, stdlib Register, parse and flatstack Compile on every iteration.

- parse the fixture PHP once
- keep the runner / flatstack Runtime after the first `stdlib.Register`
- `ResetSession` clears globals, user funcs/classes and script constants; host bindings and the expr/bytecode cache stay

`--count 500 --profile` before → after (allocs/op, B/op):

| fixture | before | after |
|---|---|---|
| pass_by_ref | 4231 / 634k | 2073 / 84k |
| database_readonly | 3666 / 386k | 2418 / 114k |
| sort | 2438 / 306k | 1306 / 51k |
| array_indexing | 2016 / 256k | 1106 / 45k |
| include-return | 252 / 56k | 99 / 8k |
| flatstack_arithmetic | 394 / 98k | 112 / 11k |

Heap after reuse: `compiler.emit` / `RegisterFunc` gone from the top; remaining cost is `expr/vm.Run`, `reflect.Value.call`, `model.Array`.