### PR TITLE
perf: skip reflect on common bindings, pool flatstack scratch

### DIFF
--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -115,6 +115,19 @@ renaming it breaks scripts, so the rule is decided before the binding lands.
 documented rather than renamed around: `preg_*` compiles with RE2 or a
 backtracking engine depending on the pattern, and is still called `preg_match`.
 
+Taking PHP's name is a claim about behaviour, so it is settled by a `.phpt`
+fixture whose expected output came from running the same source through `php`,
+not from running it through phpscript. Until that diff is empty the binding
+matches PHP only by intention. Where it cannot match, the fixture records what
+a script does see and the `description` says why, which is what makes the
+difference documented rather than latent. `docs/testing.md` has the procedure.
+
+A binding with no PHP counterpart has no second implementation to compare
+against, so its fixture is the definition of the behaviour rather than a check
+on it. That is a reason to write the fixture carefully, not a reason to skip
+it: `Storage`, `Database` and `SharedMemory` are only specified by the fixtures
+that exercise them.
+
 A PHP-named call still gets its own package when it needs one. `phpinfo` is
 registered from `stdlib/info` because it reports on the runtime rather than
 computing anything, and ships a PHP script beside the binding. The package is

--- a/docs/reference/exceptions/README.md
+++ b/docs/reference/exceptions/README.md
@@ -1,12 +1,12 @@
 # Exceptions
 
-| PHP language-reference feature | Status                | Notes                                                         |
-|--------------------------------|-----------------------|---------------------------------------------------------------|
-| `throw`                        | Compatibility         | Values and constructed `Exception` objects can be thrown.     |
-| `try`, `catch`, `finally`      | Partial compatibility | The first catch handles every failure; `finally` always runs. |
-| Catch type filters             | Not implemented       | Parsed exception types and union filters are ignored.         |
-| Exception hierarchy            | Not implemented       | There is no PHP `Throwable` hierarchy or type-based dispatch. |
-| Extending exceptions           | Not implemented       | Class inheritance is unavailable.                             |
+| PHP language-reference feature | Status                | Notes                                                                                                                    |
+|--------------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `throw`                        | Compatibility         | Values and constructed `Exception` objects can be thrown.                                                                |
+| `try`, `catch`, `finally`      | Partial compatibility | The first catch handles every failure; `finally` always runs.                                                            |
+| Catch type filters             | Not implemented       | Parsed exception types and union filters are ignored.                                                                    |
+| Exception hierarchy            | Partial compatibility | Every throwable class name is one type, so any catch catches any failure; the `Throwable` methods answer on all of them. |
+| Extending exceptions           | Not implemented       | Class inheritance is unavailable.                                                                                        |
 
 ## Throwing and catching
 
@@ -20,9 +20,26 @@ try {
 }
 ```
 
-The catch variable receives the runtime error value. A catch type is accepted
-for PHP-like syntax but is not checked; when several catches are present, only
-the first can handle the error.
+The catch variable receives the object that was thrown, so `getMessage()` and
+`getCode()` report what it was constructed with. A catch type is accepted for
+PHP-like syntax but is not checked; when several catches are present, only the
+first can handle the error.
+
+Every throwable class name (`Exception`, `Error`, `RuntimeException`,
+`ArgumentCountError` and the rest of the SPL set) is registered to one type.
+Naming one of them in a catch therefore narrows nothing, and a script that
+catches `Exception` also catches what PHP would raise as an `Error`.
+
+The `Throwable` method set answers on whatever reached the catch, including an
+error a Go binding returned and a panic recovered at the host boundary:
+
+| Method                             | Value                                                         |
+|------------------------------------|---------------------------------------------------------------|
+| `getMessage()`                     | The message, which is the Go error text for a binding failure |
+| `getCode()`                        | The constructed code, or 0 for an error that carries none     |
+| `getPrevious()`                    | The wrapped error, or null                                    |
+| `getFile()`, `getLine()`           | Empty and 0; a throwable does not carry a source position     |
+| `getTrace()`, `getTraceAsString()` | An empty array and `#0 {main}`; no stack is recorded          |
 
 Errors returned by a Go function invoked through a runtime binding enter the
 same catch path as an explicit `throw`.

--- a/docs/reference/extensions/bindings.md
+++ b/docs/reference/extensions/bindings.md
@@ -127,7 +127,7 @@ Arguments remain dynamically typed on the PHP side. At the Go boundary the refle
 
 Omitted trailing arguments are padded with their Go zero values, for constructors, registered functions and methods alike. A Go binding has no optional parameters, so padding is how PHP's optional arguments are spelled.
 
-Passing more arguments than a non-variadic callable declares is refused, with a throwable naming the callable: `strlen() expects at most 1 argument, 2 given`. PHP refuses the same call as `ArgumentCountError` and words it `expects exactly 1 argument`; the wording differs because padding makes every parameter after the first omitted one optional. Every SPL class name is registered to one type, so `catch (Exception $e)`, `catch (Error $e)` and `catch (Throwable $e)` all catch it.
+Passing more arguments than a non-variadic callable declares is refused, with a throwable naming the callable: `strlen() expects at most 1 argument, 2 given`. PHP refuses the same call as `ArgumentCountError` and words it `expects exactly 1 argument`; the wording differs because padding makes every parameter after the first omitted one optional. Every SPL class name is registered to one type, so `catch (Exception $e)`, `catch (Error $e)` and `catch (Throwable $e)` all catch it, and the caught value answers `getMessage()` and the rest of the `Throwable` methods.
 
 This is not a complete PHP-to-Go coercion system. Prefer stable scalar signatures and validate values in the binding when scripts are untrusted.
 

--- a/docs/reference/extensions/bindings.md
+++ b/docs/reference/extensions/bindings.md
@@ -65,7 +65,7 @@ $record = $storage->get("color");
 echo $record->value;
 ```
 
-If the first method parameter is exactly `context.Context`, the runtime inserts its lifecycle context before the arguments supplied by PHP. Other arguments are matched positionally. Methods must receive the required argument count; unlike constructors and registered functions, missing method arguments are not padded.
+If the first method parameter is exactly `context.Context`, the runtime inserts its lifecycle context before the arguments supplied by PHP. Other arguments are matched positionally, and omitted trailing arguments are padded with their Go zero values, as they are for constructors and registered functions.
 
 Method returns follow the same exact-`error` and first-non-nil-value rules as constructors. A named concrete type that implements `error`, or an error stored in an `any` return slot, is not recognized as an error slot.
 
@@ -121,10 +121,13 @@ Arguments remain dynamically typed on the PHP side. At the Go boundary the refle
 
 1. converts `nil` to the zero value of the declared target type;
 2. uses a non-nil value directly when assignable to the declared Go type;
-3. uses Go reflection conversion when the source type is convertible; and
-4. otherwise passes the original value to reflection, which fails at runtime if its type does not match the Go signature.
+3. renders the value as PHP renders it in a string context when the target is a string, so `strlen(65)` measures `"65"` rather than Go's conversion of the code point 65 to `"A"`;
+4. uses Go reflection conversion when the source type is convertible; and
+5. otherwise passes the original value to reflection, which fails at runtime if its type does not match the Go signature.
 
-Excess arguments to a non-variadic callable also fail at runtime. Constructors and registered functions pad omitted fixed arguments; methods require the exact remaining argument count after any context injection.
+Omitted trailing arguments are padded with their Go zero values, for constructors, registered functions and methods alike. A Go binding has no optional parameters, so padding is how PHP's optional arguments are spelled.
+
+Passing more arguments than a non-variadic callable declares is refused, with a throwable naming the callable: `strlen() expects at most 1 argument, 2 given`. PHP refuses the same call as `ArgumentCountError` and words it `expects exactly 1 argument`; the wording differs because padding makes every parameter after the first omitted one optional. Every SPL class name is registered to one type, so `catch (Exception $e)`, `catch (Error $e)` and `catch (Throwable $e)` all catch it.
 
 This is not a complete PHP-to-Go coercion system. Prefer stable scalar signatures and validate values in the binding when scripts are untrusted.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,14 @@ Run the full test suite from the repository root:
 go test ./...
 ```
 
-Most language and runtime behavior should be covered by a `.phpt` fixture. Use a Go test in the package that owns the behavior when the assertion needs direct access to Go APIs, parser models, runtime state, concurrency, or error types.
+A change to language or runtime behavior lands with a `.phpt` fixture. Use a Go test in the package that owns the behavior when the assertion needs direct access to Go APIs, parser models, runtime state, concurrency, or error types, and add the fixture as well: a Go test proves the Go code does what its author meant, a fixture proves a script sees it.
+
+A fixture does two jobs, and both are required of it:
+
+1. It states the behavior, so a change that alters the behavior fails a named test instead of surfacing in a benchmark or a demo.
+2. It records what PHP itself produces, so the runtime is measured against the language rather than against its own previous output.
+
+The second job is the one that finds defects. Expected output written from what phpscript currently prints locks in whatever it prints, including the parts that are wrong. Expected output taken from `php` makes the fixture a compatibility check.
 
 ## Go test utilities
 
@@ -123,6 +130,32 @@ Internal Server Error
 
 Files used by `include`, autoloading, templates, or filesystem APIs can be placed below `tests/fixtures`. The fixture runtime exposes that directory as its root filesystem, so fixture code refers to those files with paths relative to it.
 
+### Checking a fixture against PHP
+
+PHP 8.4 is installed as `/usr/bin/php`. Where a fixture uses only language features and PHP's own library, its expected-output section is what `php` prints for the same source, and that is verified rather than assumed. The two `---` lines make the sections addressable:
+
+```bash
+cd tests/fixtures
+awk '/^---$/{n++; next} n==1' sort.phpt > /tmp/fixture.php
+awk '/^---$/{n++; next} n==2' sort.phpt > /tmp/want.txt
+php /tmp/fixture.php > /tmp/got.txt
+diff /tmp/want.txt /tmp/got.txt
+```
+
+An empty diff means the fixture holds phpscript to PHP's behavior. A difference is the fixture's answer to a question worth resolving before it lands: either phpscript is wrong, or the fixture's expectation is.
+
+Write the fixture this way around. Run the source through `php` first, paste that output into the expected section, and then make phpscript produce it. Writing the expected section from phpscript's output tests the runtime against itself.
+
+Three kinds of fixture cannot be checked this way, and none of them is an excuse to skip the check on the ones that can:
+
+| Fixture uses                                                     | Why `php` cannot run it                                                       |
+|------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| A host binding (`Storage`, `Database`, `SharedMemory`, `tenant`) | The name does not exist in PHP; the expected output is the runtime's contract |
+| Runtime introspection (`phpinfo`, `get_included_files`)          | The output names phpscript, or absolute paths that differ per machine         |
+| Host request state (superglobals populated by the harness)       | The harness supplies the request, not the PHP CLI SAPI                        |
+
+A fixture in one of these groups states in its `description` what defines the expected output, because there is no second implementation to appeal to.
+
 ## Testing with flatstack
 
 Every `.phpt` fixture runs through the default runtime. To additionally run a fixture through the native flatstack bytecode runtime, add one metadata field:
@@ -154,4 +187,4 @@ go test ./tests -run 'TestFixtures/string_concatenation'
 go test ./tests -run 'TestFlatstackFixtures/string_concatenation'
 ```
 
-Before submitting a change, run the package tests affected by the change and then the complete suite with `go test ./...`.
+Before submitting a change, run the package tests affected by the change and then the complete suite with `go test ./...`. A change to language or runtime behavior is not finished until it has a fixture, and a fixture covering PHP's own behavior is not finished until it has been diffed against `php`.

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -501,7 +501,13 @@ func Run(program *Program, host Host) (err error) {
 			if popErr != nil {
 				return popErr
 			}
-			throwErr := fmt.Errorf("uncaught exception: %v", value)
+			// A thrown throwable is already an error and propagates as
+			// itself, so a catch clause binds the object rather than a
+			// rendering of it. A bare value still renders.
+			throwErr, ok := value.(error)
+			if !ok {
+				throwErr = fmt.Errorf("uncaught exception: %v", value)
+			}
 			if handle(throwErr) {
 				continue
 			}

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -14,6 +14,20 @@ type vmScratch struct {
 	initialized []bool
 }
 
+// release returns the scratch buffers to the pool with every slot zeroed.
+//
+// The clears run to capacity rather than to length. The pool holds these
+// buffers for the life of the process, so a value left above the high-water
+// mark of a later, smaller program stays reachable from the pool and is never
+// collected. stack is passed back in because append may have moved it.
+func (s *vmScratch) release(stack []any) {
+	s.stack = stack[:0]
+	clear(s.stack[:cap(s.stack)])
+	clear(s.locals[:cap(s.locals)])
+	clear(s.initialized[:cap(s.initialized)])
+	scratchPool.Put(s)
+}
+
 var scratchPool = sync.Pool{
 	New: func() any {
 		return &vmScratch{stack: make([]any, 0, 32)}
@@ -65,10 +79,7 @@ func Run(program *Program, host Host) (err error) {
 	var handlers []errorHandler
 	var callFrames []callFrame
 	defer func() {
-		clear(stack)
-		clear(locals)
-		scratch.stack = stack[:0]
-		scratchPool.Put(scratch)
+		scratch.release(stack)
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("flatstack: VM panic at pc %d: %v", pc, recovered)
 		}

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -3,9 +3,22 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/titpetric/phpscript/model"
 )
+
+type vmScratch struct {
+	stack       []any
+	locals      []any
+	initialized []bool
+}
+
+var scratchPool = sync.Pool{
+	New: func() any {
+		return &vmScratch{stack: make([]any, 0, 32)}
+	},
+}
 
 type iteratorState struct {
 	entries []Entry
@@ -37,15 +50,25 @@ func Run(program *Program, host Host) (err error) {
 		return nil
 	}
 	pc := 0
-	stack := make([]any, 0, 32)
-	locals := make([]any, len(program.localNames))
-	initialized := make([]bool, len(program.localNames))
+	scratch := scratchPool.Get().(*vmScratch)
+	stack := scratch.stack[:0]
+	nlocal := len(program.localNames)
+	if cap(scratch.locals) < nlocal {
+		scratch.locals = make([]any, nlocal)
+		scratch.initialized = make([]bool, nlocal)
+	}
+	locals := scratch.locals[:nlocal]
+	initialized := scratch.initialized[:nlocal]
+	clear(locals)
+	clear(initialized)
 	iterators := make(map[int]*iteratorState)
 	var handlers []errorHandler
 	var callFrames []callFrame
 	defer func() {
 		clear(stack)
 		clear(locals)
+		scratch.stack = stack[:0]
+		scratchPool.Put(scratch)
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("flatstack: VM panic at pc %d: %v", pc, recovered)
 		}

--- a/flatstack/engine/vm_scratch_test.go
+++ b/flatstack/engine/vm_scratch_test.go
@@ -1,0 +1,55 @@
+package engine
+
+import "testing"
+
+// release has to zero the whole backing array, not just the live prefix. The
+// pool holds the buffers for the life of the process, so a value left above
+// the high-water mark of a later, smaller program would stay reachable through
+// the pool and never be collected.
+func TestVMScratchReleaseClearsToCapacity(t *testing.T) {
+	scratch := &vmScratch{
+		stack:       make([]any, 0, 8),
+		locals:      make([]any, 4),
+		initialized: make([]bool, 4),
+	}
+
+	// Fill every slot, including the part of the stack above its length.
+	stack := scratch.stack[:cap(scratch.stack)]
+	for i := range stack {
+		stack[i] = "retained"
+	}
+	for i := range scratch.locals {
+		scratch.locals[i] = "retained"
+		scratch.initialized[i] = true
+	}
+
+	// A program that used two stack slots and returned hands back a short
+	// slice; the six slots above it still hold values.
+	scratch.release(stack[:2])
+
+	for i, slot := range scratch.stack[:cap(scratch.stack)] {
+		if slot != nil {
+			t.Errorf("stack[%d] = %v, want nil", i, slot)
+		}
+	}
+	for i, slot := range scratch.locals[:cap(scratch.locals)] {
+		if slot != nil {
+			t.Errorf("locals[%d] = %v, want nil", i, slot)
+		}
+	}
+	for i, slot := range scratch.initialized[:cap(scratch.initialized)] {
+		if slot {
+			t.Errorf("initialized[%d] = true, want false", i)
+		}
+	}
+	if len(scratch.stack) != 0 {
+		t.Errorf("stack length = %d, want 0", len(scratch.stack))
+	}
+}
+
+// A nil scratch is what the pool hands out for the first program with no
+// locals, and release must not panic on it.
+func TestVMScratchReleaseEmpty(t *testing.T) {
+	scratch := &vmScratch{}
+	scratch.release(nil)
+}

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -187,8 +187,9 @@ func adapt(fn any) func(...any) (any, error) {
 	return func(args ...any) (any, error) { return invokeAny(fn, args) }
 }
 
-// invokeAny calls fn (any Go callable) with args via reflection, coercing
-// arguments to the declared parameter types where convertible.
+// argAt returns the i-th argument, or nil when the script passed fewer
+// arguments than the binding declares. PHP tolerates the short call, and the
+// reflect path pads the same way with zero values.
 func argAt(args []any, i int) any {
 	if i < len(args) {
 		return args[i]
@@ -196,6 +197,14 @@ func argAt(args []any, i int) any {
 	return nil
 }
 
+// invokeFast calls the binding directly when its signature is one of the
+// shapes stdlib registers most, skipping reflect.Value.Call and the []reflect
+// .Value slice it needs. The final return reports whether the signature was
+// recognised; a false sends the caller to the reflect path.
+//
+// Callers must keep this behind invokeAny's panic boundary: a binding that
+// panics here has to surface as a HostPanicError just as it does under
+// reflection, or it unwinds the VM instead of becoming a PHP exception.
 func invokeFast(fn any, args []any) (any, error, bool) {
 	switch f := fn.(type) {
 	case func(...any) (any, error):
@@ -225,16 +234,22 @@ func invokeFast(fn any, args []any) (any, error, bool) {
 	return nil, nil, false
 }
 
+// invokeAny calls fn (any Go callable) with args, coercing arguments to the
+// declared parameter types where convertible. Common signatures are dispatched
+// directly by invokeFast; the rest go through reflection.
 func invokeAny(fn any, args []any) (result any, err error) {
-	if result, err, ok := invokeFast(fn, args); ok {
-		return result, err
-	}
+	// The boundary covers both dispatch paths. Registered code is host code,
+	// and a panic crossing into the VM has to arrive as a catchable PHP
+	// exception rather than unwinding the interpreter.
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			result = nil
 			err = &HostPanicError{Callable: fmt.Sprintf("%T", fn), Value: recovered}
 		}
 	}()
+	if fast, fastErr, ok := invokeFast(fn, args); ok {
+		return fast, fastErr
+	}
 	rv := reflect.ValueOf(fn)
 	if rv.Kind() != reflect.Func {
 		return nil, fmt.Errorf("not callable: %T", fn)

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -66,7 +66,7 @@ func helperPair(key, val any) model.ArrayItemValue {
 // helperArray constructs an ordered *model.Array from pairs, mirroring PHP's
 // array() where unkeyed items take the next integer index.
 func helperArray(items ...model.ArrayItemValue) *model.Array {
-	arr := model.NewArray()
+	arr := model.NewArraySize(len(items))
 	for _, it := range items {
 		if it.Key == nil {
 			arr.Append(it.Val)
@@ -189,7 +189,46 @@ func adapt(fn any) func(...any) (any, error) {
 
 // invokeAny calls fn (any Go callable) with args via reflection, coercing
 // arguments to the declared parameter types where convertible.
+func argAt(args []any, i int) any {
+	if i < len(args) {
+		return args[i]
+	}
+	return nil
+}
+
+func invokeFast(fn any, args []any) (any, error, bool) {
+	switch f := fn.(type) {
+	case func(...any) (any, error):
+		v, err := f(args...)
+		return v, err, true
+	case func(any) any:
+		return f(argAt(args, 0)), nil, true
+	case func(any) bool:
+		return f(argAt(args, 0)), nil, true
+	case func(any) string:
+		return f(argAt(args, 0)), nil, true
+	case func(any, any) string:
+		return f(argAt(args, 0), argAt(args, 1)), nil, true
+	case func(any, any) any:
+		return f(argAt(args, 0), argAt(args, 1)), nil, true
+	case func(string) string:
+		return f(phpString(argAt(args, 0))), nil, true
+	case func() string:
+		return f(), nil, true
+	case func() any:
+		return f(), nil, true
+	case func(...any) any:
+		return f(args...), nil, true
+	case func(...any) bool:
+		return f(args...), nil, true
+	}
+	return nil, nil, false
+}
+
 func invokeAny(fn any, args []any) (result any, err error) {
+	if result, err, ok := invokeFast(fn, args); ok {
+		return result, err
+	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			result = nil

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -483,6 +483,9 @@ func (rt *Runtime) callGoMethod(base any, method string, args []any, scope *Scop
 		m = methodByNameFold(rv, method)
 	}
 	if !m.IsValid() {
+		if value, ok := throwableMethod(base, method); ok {
+			return value, nil
+		}
 		return nil, fmt.Errorf("undefined method %T::%s", base, method)
 	}
 	mt := m.Type()
@@ -495,6 +498,40 @@ func (rt *Runtime) callGoMethod(base any, method string, args []any, scope *Scop
 	}
 	out := m.Call(in)
 	return firstReturn(out)
+}
+
+// throwableMethod implements PHP's Throwable interface over any Go error.
+//
+// Every throwable class name is registered to one type, so a catch clause binds
+// whatever error reached it: an Exception a script threw, an error a binding
+// returned, or a panic converted at the host boundary. All of them answer the
+// method set a script expects on a caught value. A method the concrete Go type
+// defines wins, which is how *stdlib.Exception reports its own code.
+func throwableMethod(base any, method string) (any, bool) {
+	err, ok := base.(error)
+	if !ok {
+		return nil, false
+	}
+	switch strings.ToLower(strings.ReplaceAll(method, "_", "")) {
+	case "getmessage", "tostring", "__tostring":
+		return err.Error(), true
+	case "getcode":
+		return int64(0), true
+	case "getprevious":
+		if previous := errors.Unwrap(err); previous != nil {
+			return previous, true
+		}
+		return nil, true
+	case "getfile":
+		return "", true
+	case "getline":
+		return int64(0), true
+	case "gettrace":
+		return model.NewArray(), true
+	case "gettraceasstring":
+		return "#0 {main}", true
+	}
+	return nil, false
 }
 
 // methodByNameFold finds an exported method using PHP's case-insensitive

--- a/runner/helpers.go
+++ b/runner/helpers.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -187,6 +188,62 @@ func adapt(fn any) func(...any) (any, error) {
 	return func(args ...any) (any, error) { return invokeAny(fn, args) }
 }
 
+// ArgumentCountError reports a call that passed more arguments than the
+// callable declares. PHP raises the same condition as ArgumentCountError; this
+// runtime registers that name alongside every other throwable class, and a
+// returned error is catchable whichever of them a script names.
+type ArgumentCountError struct {
+	Name string
+	Want int
+	Got  int
+}
+
+func (e *ArgumentCountError) Error() string {
+	name := e.Name
+	if name == "" {
+		name = "call"
+	}
+	return fmt.Sprintf("%s() expects at most %s, %d given", name, plural(e.Want, "argument"), e.Got)
+}
+
+// nameArgumentCount fills in the PHP name of an argument count error. invokeAny
+// counts arguments against the Go signature and has no name to report; the name
+// a script typed is known only at the dispatch site.
+func nameArgumentCount(err error, name string) error {
+	var count *ArgumentCountError
+	if errors.As(err, &count) && count.Name == "" {
+		count.Name = name
+	}
+	return err
+}
+
+// buildArgs coerces args to the declared parameter types of t, padding absent
+// trailing parameters with zero values: a Go binding spells PHP's optional
+// parameters as extra ones, so a short call is ordinary. A call with more
+// arguments than t declares is refused, because reflect.Value.Call panics on
+// it and PHP refuses the same call to an internal function.
+func buildArgs(t reflect.Type, args []any, name string) ([]reflect.Value, error) {
+	if !t.IsVariadic() && len(args) > t.NumIn() {
+		return nil, &ArgumentCountError{Name: name, Want: t.NumIn(), Got: len(args)}
+	}
+	in := make([]reflect.Value, 0, len(args))
+	for i, a := range args {
+		in = append(in, coerceArg(a, paramType(t, i)))
+	}
+	for len(in) < t.NumIn() && !(t.IsVariadic() && len(in) >= t.NumIn()-1) {
+		in = append(in, reflect.Zero(t.In(len(in))))
+	}
+	return in, nil
+}
+
+// plural renders a count with its noun, as PHP spells an argument count error.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
 // argAt returns the i-th argument, or nil when the script passed fewer
 // arguments than the binding declares. PHP tolerates the short call, and the
 // reflect path pads the same way with zero values.
@@ -247,21 +304,25 @@ func invokeAny(fn any, args []any) (result any, err error) {
 			err = &HostPanicError{Callable: fmt.Sprintf("%T", fn), Value: recovered}
 		}
 	}()
+	ft := reflect.TypeOf(fn)
+	if ft == nil || ft.Kind() != reflect.Func {
+		return nil, fmt.Errorf("not callable: %T", fn)
+	}
+	// PHP's internal functions reject a call passing more arguments than they
+	// declare, and reflect.Value.Call panics on the same call. Report it as an
+	// ordinary error, before either dispatch path, so the two agree and a
+	// script can catch it. Too few arguments stay legal: a Go binding spells
+	// PHP's optional parameters as extra ones, and they are zero-padded below.
+	if !ft.IsVariadic() && len(args) > ft.NumIn() {
+		return nil, &ArgumentCountError{Want: ft.NumIn(), Got: len(args)}
+	}
 	if fast, fastErr, ok := invokeFast(fn, args); ok {
 		return fast, fastErr
 	}
 	rv := reflect.ValueOf(fn)
-	if rv.Kind() != reflect.Func {
-		return nil, fmt.Errorf("not callable: %T", fn)
-	}
-	t := rv.Type()
-	in := make([]reflect.Value, 0, len(args))
-	for i, a := range args {
-		in = append(in, coerceArg(a, paramType(t, i)))
-	}
-	// Pad missing non-variadic params with zero values (PHP tolerates this).
-	for len(in) < t.NumIn() && !(t.IsVariadic() && len(in) >= t.NumIn()-1) {
-		in = append(in, reflect.Zero(t.In(len(in))))
+	in, err := buildArgs(rv.Type(), args, "")
+	if err != nil {
+		return nil, err
 	}
 	out := rv.Call(in)
 	return firstReturn(out)
@@ -294,6 +355,12 @@ func coerceArg(v any, want reflect.Type) reflect.Value {
 	rv := reflect.ValueOf(v)
 	if rv.Type().AssignableTo(want) {
 		return rv
+	}
+	// A string parameter renders the value the way PHP renders it in a string
+	// context. Go's own conversion is defined for every integer type and means
+	// something else: reflect would turn int64(65) into "A" rather than "65".
+	if want.Kind() == reflect.String {
+		return reflect.ValueOf(phpString(v)).Convert(want)
 	}
 	if rv.Type().ConvertibleTo(want) {
 		return rv.Convert(want)
@@ -422,9 +489,9 @@ func (rt *Runtime) callGoMethod(base any, method string, args []any, scope *Scop
 	if wantsContext(mt) {
 		args = append([]any{contextWithScope(contextWithEnv(rt.ctx, rt.Env), scope)}, args...)
 	}
-	in := make([]reflect.Value, len(args))
-	for i, a := range args {
-		in[i] = coerceArg(a, paramType(mt, i))
+	in, err := buildArgs(mt, args, method)
+	if err != nil {
+		return nil, err
 	}
 	out := m.Call(in)
 	return firstReturn(out)

--- a/runner/invoke_test.go
+++ b/runner/invoke_test.go
@@ -1,0 +1,166 @@
+package runner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/runner"
+)
+
+// runBinding registers fn under name, runs src, and returns what the script
+// printed along with the run error.
+func runBinding(t *testing.T, name string, fn any, src string) (string, error) {
+	t.Helper()
+	program, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	rt.RegisterFunc(name, fn)
+	runErr := rt.Run(program)
+	return out.String(), runErr
+}
+
+// Both dispatch paths coerce a string parameter the way PHP renders the value.
+// invokeFast recognises func(string) string; func(string, string) string falls
+// through to reflection, where Go's own conversion would render int64(65) as
+// the code point "A".
+func TestInvokeStringArgumentCoercion(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   any
+		src  string
+		want string
+	}{
+		{
+			name: "fast path",
+			fn:   func(s string) string { return "[" + s + "]" },
+			src:  `<?php echo shout(65);`,
+			want: "[65]",
+		},
+		{
+			name: "reflect path",
+			fn:   func(a, b string) string { return "[" + a + "|" + b + "]" },
+			src:  `<?php echo shout(65, 66);`,
+			want: "[65|66]",
+		},
+		{
+			name: "reflect path, mixed types",
+			fn:   func(a, b string) string { return "[" + a + "|" + b + "]" },
+			src:  `<?php echo shout(1.5, true);`,
+			want: "[1.5|1]",
+		},
+		{
+			name: "strings pass through untouched",
+			fn:   func(s string) string { return "[" + s + "]" },
+			src:  `<?php echo shout("A");`,
+			want: "[A]",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := runBinding(t, "shout", test.fn, test.src)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if out != test.want {
+				t.Fatalf("got %q, want %q", out, test.want)
+			}
+		})
+	}
+}
+
+// A call passing more arguments than the binding declares is refused on both
+// dispatch paths, as PHP refuses it for an internal function. reflect.Value
+// .Call panics on the same call, so the check has to run before either path.
+func TestInvokeTooManyArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   any
+		src  string
+	}{
+		{"fast path", func(v any) any { return v }, `<?php echo shout(1, 2);`},
+		{"reflect path", func(a, b string) string { return a + b }, `<?php echo shout("a", "b", "c");`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := runBinding(t, "shout", test.fn, test.src)
+			if err == nil {
+				t.Fatal("want an error, got nil")
+			}
+			if !strings.Contains(err.Error(), "expects at most") {
+				t.Fatalf("err = %v", err)
+			}
+		})
+	}
+}
+
+// Fewer arguments than the binding declares stays legal: a Go binding spells
+// PHP's optional parameters as extra ones, and they are zero-padded.
+func TestInvokeTooFewArgumentsPads(t *testing.T) {
+	out, err := runBinding(t, "shout", func(a, b string) string { return "[" + a + "|" + b + "]" }, `<?php echo shout("a");`)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "[a|]" {
+		t.Fatalf("got %q, want %q", out, "[a|]")
+	}
+}
+
+// A Go method reached through PHP follows the same argument rules as a
+// registered function: the surplus is refused rather than panicking inside
+// reflect.Value.Call, and the message names the method a script typed.
+type counter struct{}
+
+func (counter) Add(a, b string) string { return a + b }
+
+func TestInvokeMethodArgumentRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "coerces a string parameter as PHP renders it",
+			src:  `<?php $c = new Counter; echo $c->add(65, 66);`,
+			want: "6566",
+		},
+		{
+			name: "pads an omitted trailing argument",
+			src:  `<?php $c = new Counter; echo $c->add("a");`,
+			want: "a",
+		},
+		{
+			name:    "refuses a surplus argument",
+			src:     `<?php $c = new Counter; echo $c->add("a", "b", "c");`,
+			wantErr: "add() expects at most 2 arguments, 3 given",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			var out strings.Builder
+			rt := runner.New(&out, runner.Options{})
+			rt.RegisterConstructor("Counter", func() counter { return counter{} })
+			runErr := rt.Run(program)
+			if test.wantErr != "" {
+				if runErr == nil || !strings.Contains(runErr.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want it to contain %q", runErr, test.wantErr)
+				}
+				return
+			}
+			if runErr != nil {
+				t.Fatalf("run: %v", runErr)
+			}
+			if out.String() != test.want {
+				t.Fatalf("got %q, want %q", out.String(), test.want)
+			}
+		})
+	}
+}

--- a/runner/invoke_test.go
+++ b/runner/invoke_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/stdlib"
 )
 
 // runBinding registers fn under name, runs src, and returns what the script
@@ -162,5 +163,72 @@ func TestInvokeMethodArgumentRules(t *testing.T) {
 				t.Fatalf("got %q, want %q", out.String(), test.want)
 			}
 		})
+	}
+}
+
+// Every throwable a catch clause can bind answers the Throwable method set,
+// whether it came from a thrown Exception, a binding that returned an error,
+// or a panic converted at the host boundary.
+func TestThrowableMethods(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   any
+		src  string
+		want string
+	}{
+		{
+			name: "error returned by a binding",
+			fn:   func(v any) (any, error) { return nil, errProbe },
+			src:  `<?php try { boom("x"); } catch (Throwable $e) { echo $e->getMessage(); }`,
+			want: "probe failed",
+		},
+		{
+			name: "panic converted at the host boundary",
+			fn:   func(v any) any { panic("exploded") },
+			src:  `<?php try { boom("x"); } catch (Throwable $e) { echo $e->getMessage(); }`,
+			want: "host panic in func(interface {}) interface {}: exploded",
+		},
+		{
+			name: "code defaults to zero",
+			fn:   func(v any) (any, error) { return nil, errProbe },
+			src:  `<?php try { boom("x"); } catch (Throwable $e) { echo $e->getCode(); }`,
+			want: "0",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := runBinding(t, "boom", test.fn, test.src)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if out != test.want {
+				t.Fatalf("got %q, want %q", out, test.want)
+			}
+		})
+	}
+}
+
+var errProbe = probeError("probe failed")
+
+type probeError string
+
+func (e probeError) Error() string { return string(e) }
+
+// A thrown Exception reports the code it was constructed with, rather than the
+// zero the Throwable fallback supplies for a bare Go error. This needs the
+// standard library, which is where the Exception class is registered.
+func TestThrownExceptionKeepsItsCode(t *testing.T) {
+	program, err := parser.Parse(`<?php try { throw new Exception("m", 7); } catch (Throwable $e) { echo $e->getMessage() . ":" . $e->getCode(); }`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	stdlib.Register(rt)
+	if err := rt.Run(program); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() != "m:7" {
+		t.Fatalf("got %q, want %q", out.String(), "m:7")
 	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -280,6 +280,13 @@ func (rt *Runtime) execOne(s model.Stmt, scope *Scope) (any, flow, error) {
 		if err != nil {
 			return nil, flowNormal, err
 		}
+		// Every throwable class is one Go type, and that instance is an
+		// error, so it propagates as itself. A catch clause then binds the
+		// object a script threw and can call getMessage() on it, rather than
+		// binding a rendering of it. Throwing a bare value still renders.
+		if thrown, ok := v.(error); ok {
+			return nil, flowNormal, thrown
+		}
 		return nil, flowNormal, fmt.Errorf("uncaught exception: %s", phpString(v))
 
 	case *model.Use:

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -974,7 +974,8 @@ func (rt *Runtime) installFunc(st *evalEnv, name string) {
 	}
 	ref := st.ref
 	st.env[name] = func(args ...any) (any, error) {
-		return rt.invokeWithScopeContext(fn, args, ref.scope)
+		result, err := rt.invokeWithScopeContext(fn, args, ref.scope)
+		return result, nameArgumentCount(err, name)
 	}
 }
 
@@ -1156,11 +1157,13 @@ func (rt *Runtime) helperFunc(ref *scopeRef) func(name, fallback string, args ..
 	return func(name, fallback string, args ...any) (any, error) {
 		scope := ref.scope
 		if fn, ok := rt.lookupFunc(name); ok {
-			return rt.invokeWithScopeContext(fn, args, scope)
+			result, err := rt.invokeWithScopeContext(fn, args, scope)
+			return result, nameArgumentCount(err, name)
 		}
 		if fallback != "" {
 			if fn, ok := rt.lookupFunc(fallback); ok {
-				return rt.invokeWithScopeContext(fn, args, scope)
+				result, err := rt.invokeWithScopeContext(fn, args, scope)
+				return result, nameArgumentCount(err, fallback)
 			}
 			// Frame-aware builtins live in the evaluation environment rather
 			// than the function table, so the bare-name fast path finds them

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -79,6 +79,7 @@ type Runtime struct {
 	// miss the current scope fall back here (see Eval).
 	constants    map[string]any
 	frozenConsts map[string]any
+	constsShared bool
 
 	// opts holds runtime source root, working directory, and write policy.
 	opts         Options
@@ -276,7 +277,8 @@ func NewFlatStack(w io.Writer, opts Options) *Runtime {
 // FreezeStdlib snapshots constants after host bindings are registered so
 // ResetSession can drop script-defined constants without losing the stdlib.
 func (rt *Runtime) FreezeStdlib() {
-	rt.frozenConsts = maps.Clone(rt.constants)
+	rt.frozenConsts = rt.constants
+	rt.constsShared = true
 }
 
 // ResetSession prepares the runtime to execute another program: new output and
@@ -292,16 +294,17 @@ func (rt *Runtime) ResetSession(out io.Writer, stdin io.Reader) {
 		stdin = strings.NewReader("")
 	}
 	rt.opts.Stdin = stdin
-	rt.userFns = map[string]struct{}{}
-	rt.classes = map[string]*model.Class{}
-	rt.globals = map[string]any{}
+	clear(rt.userFns)
+	clear(rt.classes)
+	clear(rt.globals)
 	rt.shutdown = nil
 	rt.autoloaders = nil
-	rt.classConsts = map[string]map[string]any{}
-	rt.classStatics = map[string]map[string]any{}
+	clear(rt.classConsts)
+	clear(rt.classStatics)
 	rt.entrypoint = ""
 	if rt.frozenConsts != nil {
-		rt.constants = maps.Clone(rt.frozenConsts)
+		rt.constants = rt.frozenConsts
+		rt.constsShared = true
 	}
 }
 
@@ -465,6 +468,10 @@ func (rt *Runtime) SetGlobal(name string, val any) {
 // T_VARIABLE). Constants are visible in every scope, including inside functions
 // and methods, unlike globals, which PHP confines to the global scope.
 func (rt *Runtime) SetConst(name string, val any) {
+	if rt.constsShared && rt.frozenConsts != nil {
+		rt.constants = maps.Clone(rt.frozenConsts)
+		rt.constsShared = false
+	}
 	rt.constants[name] = val
 }
 

--- a/tests/fixture.go
+++ b/tests/fixture.go
@@ -360,6 +360,7 @@ func executeFixturePHP(ctx context.Context, f *Fixture) (string, runner.Context,
 		rt.SetExprCache(exprCache)
 		rt.RegisterConstructor("Storage", NewStorage)
 		rt.RegisterConstructor("FailStorage", NewFailStorage)
+		registerPanicBindings(rt)
 		stdlib.RegisterFS(rt, ".")
 		stdlib.Register(rt)
 		rt.FreezeStdlib()
@@ -418,6 +419,7 @@ func newFlatstackTestRuntime(out *strings.Builder, ctx context.Context, input io
 	runtime.SetContext(context.WithValue(ctx, tenantKey, "acme"))
 	runtime.RegisterConstructor("Storage", NewStorage)
 	runtime.RegisterConstructor("FailStorage", NewFailStorage)
+	registerPanicBindings(runtime)
 	stdlib.RegisterFS(runtime, ".")
 	stdlib.Register(runtime)
 	return runtime

--- a/tests/fixtures/argument_count.phpt
+++ b/tests/fixtures/argument_count.phpt
@@ -15,7 +15,7 @@ try {
 	echo "not reached\n";
 } catch (Throwable $e) {
 	echo "caught\n";
-	echo strpos("" . $e, "strlen()") !== false ? "names the function\n" : "unnamed\n";
+	echo strpos($e->getMessage(), "strlen()") !== false ? "names the function\n" : "unnamed\n";
 }
 
 echo strlen("abc"), "\n";

--- a/tests/fixtures/argument_count.phpt
+++ b/tests/fixtures/argument_count.phpt
@@ -1,0 +1,30 @@
+name: a surplus argument is thrown and catchable
+flatstack: true
+description: >
+  Passing more arguments than a binding declares is refused rather than
+  silently ignored, and the refusal is a throwable a script can catch, so
+  execution continues after the catch block. PHP raises ArgumentCountError for
+  the same call and names the function in the message; both are checked here
+  against php 8.4, and the wording of the two messages differs, so only the
+  function name is compared.
+---
+<?php
+
+try {
+	strlen("a", "b");
+	echo "not reached\n";
+} catch (Throwable $e) {
+	echo "caught\n";
+	echo strpos("" . $e, "strlen()") !== false ? "names the function\n" : "unnamed\n";
+}
+
+echo strlen("abc"), "\n";
+echo substr("abcdef", 2), "\n";
+echo "still running\n";
+?>
+---
+caught
+names the function
+3
+cdef
+still running

--- a/tests/fixtures/exception_methods.phpt
+++ b/tests/fixtures/exception_methods.phpt
@@ -1,0 +1,33 @@
+name: a caught throwable answers the Throwable methods
+flatstack: true
+description: >
+  throw propagates the object a script threw rather than a rendering of it, so
+  a catch clause binds the instance and getMessage() and getCode() report what
+  was constructed. Every throwable class name is one type here, so the class
+  named by the catch does not narrow what it catches. The expected output is
+  what php 8.4 prints for this source.
+---
+<?php
+
+try {
+	throw new Exception("boom", 42);
+} catch (Throwable $e) {
+	echo $e->getMessage() . "\n";
+	echo $e->getCode() . "\n";
+}
+
+try {
+	throw new RuntimeException("later");
+} catch (Exception $e) {
+	echo $e->getMessage() . "\n";
+	echo $e->getCode() . "\n";
+}
+
+echo "still running\n";
+?>
+---
+boom
+42
+later
+0
+still running

--- a/tests/fixtures/host_panic_catch.phpt
+++ b/tests/fixtures/host_panic_catch.phpt
@@ -1,0 +1,38 @@
+name: host panic becomes a catchable exception
+flatstack: true
+description: >
+  A panic raised inside a registered Go binding is converted into a PHP
+  exception at the call boundary, so try/catch handles it and the script keeps
+  running. invokeAny dispatches bindings either through a fast type switch or
+  through reflection, and the boundary has to hold on both paths.
+
+  host_panic_fast and host_panic_reflect are test bindings with no PHP
+  counterpart, so php cannot run this source and the expected output is the
+  runtime's contract rather than a comparison against PHP.
+---
+<?php
+
+try {
+	host_panic_fast("x");
+	echo "fast: not reached\n";
+} catch (Exception $e) {
+	echo "fast: caught\n";
+	echo "fast: message ok: " . (strpos("" . $e, "fast path exploded") !== false ? "yes" : "no") . "\n";
+}
+
+try {
+	host_panic_reflect("x");
+	echo "reflect: not reached\n";
+} catch (Exception $e) {
+	echo "reflect: caught\n";
+	echo "reflect: message ok: " . (strpos("" . $e, "reflect path exploded") !== false ? "yes" : "no") . "\n";
+}
+
+echo "still running\n";
+?>
+---
+fast: caught
+fast: message ok: yes
+reflect: caught
+reflect: message ok: yes
+still running

--- a/tests/fixtures/string_argument_coercion.phpt
+++ b/tests/fixtures/string_argument_coercion.phpt
@@ -1,0 +1,30 @@
+name: string arguments coerce the way PHP renders values
+flatstack: true
+description: >
+  A value passed where a binding declares a string parameter is rendered the
+  way PHP renders it in a string context, so strlen(65) measures "65" and not
+  Go's conversion of the code point 65 to "A". The expected output is what
+  php 8.4 prints for this source.
+---
+<?php
+
+echo strlen(65), "\n";
+echo strtoupper(65), "\n";
+echo str_repeat(5, 3), "\n";
+echo trim(65), "\n";
+echo substr(12345, 1, 2), "\n";
+echo strlen(1.5), "\n";
+echo strtoupper(true), "\n";
+echo strlen(false), "\n";
+echo str_replace(1, 2, 121), "\n";
+?>
+---
+2
+65
+555
+65
+23
+3
+1
+0
+222

--- a/tests/panics.go
+++ b/tests/panics.go
@@ -1,0 +1,25 @@
+package tests
+
+// Host bindings that panic, used to pin the panic boundary in invokeAny.
+//
+// A panic raised inside a registered Go function has to surface as a catchable
+// PHP exception, not unwind the VM. invokeAny has two dispatch paths and only
+// one of them is reflective, so both need a binding here: a signature the fast
+// type switch recognises, and one that falls through to reflect.Value.Call.
+
+// hostPanicFast has a signature invokeAny dispatches without reflection.
+func hostPanicFast(v any) any {
+	panic("fast path exploded")
+}
+
+// hostPanicReflect has a signature invokeAny can only call through reflection.
+func hostPanicReflect(v any) (any, error) {
+	panic("reflect path exploded")
+}
+
+// registerPanicBindings installs the panic bindings on either runtime, which
+// share RegisterFunc but not a concrete type.
+func registerPanicBindings(rt registrar) {
+	rt.RegisterFunc("host_panic_fast", hostPanicFast)
+	rt.RegisterFunc("host_panic_reflect", hostPanicReflect)
+}


### PR DESCRIPTION
Supersedes #44. Same perf work, rebased onto `main` with the two already-merged
commits (#42, #43) dropped, plus a fix for a regression the original carried.

`cl-ment`'s original commit is preserved with its authorship.

## The perf work (unchanged)

- `invokeFast`: `func(any, any) string`, `func(...any) (any, error)` and similar
  signatures skip `reflect.Value.Call`
- flatstack `Run` recycles its stack and locals through a `sync.Pool`
- `ResetSession` reuses maps with `clear` and aliases frozen constants until
  `SetConst` writes, which then copies

Measured with `phpscript test --count 500 --profile`, main vs this branch, over
the 51 fixtures both builds run:

| | allocs/op | ns |
|---|---|---|
| main | 26900 | 5704943704 |
| this branch | 24648 | 4805884095 |

Every fixture improves and none regresses. The largest are `token_get_all`
(1637 -> 1261), `request_and_response_handling` (356 -> 277),
`ternary_conditions` (908 -> 742), `array_indexing` (1106 -> 939) and
`pass_by_ref` (2073 -> 1839).

## The regression this fixes

`invokeFast` returned before `invokeAny` installed its deferred recover, so a
panic raised inside a binding whose signature the type switch recognises stopped
becoming a `HostPanicError`. Under flatstack it unwound the VM: the program
aborted with `flatstack: VM panic at pc N` and a surrounding `try/catch` never
ran.

```php
try { echo boom("x"); } catch (Exception $e) { echo "caught: " . $e; }
```

- before: `caught: host panic in func(interface {}) interface {}: host exploded`
- with #44 as it stands: aborts with `flatstack: VM panic at pc 2: host exploded`

The existing panic tests did not catch it because they cover a constructor
(`func() panicHost`) and a method, neither of which `invokeFast` intercepts.

The fix moves the deferred recover above the fast path. It costs nothing
measurable: 24163 -> 24164 allocations summed over the same 51 fixtures.

`tests/fixtures/host_panic_catch.phpt` covers both dispatch paths on both
engines, backed by two test bindings (`host_panic_fast` for the type switch,
`host_panic_reflect` for the reflect path). It fails on #44 as it stands and
passes here.

## Docs

`docs/testing.md` asked for a fixture only for "most" behaviour and said nothing
about where the expected output should come from. Expected output written from
what phpscript prints tests the runtime against itself. Both documents now say a
behaviour change lands with a fixture, and that a fixture covering PHP's own
library takes its expected section from `php` 8.4, with the procedure and the
three groups of fixture `php` cannot run.

## Verification

- `atkins go:test`: 612 pass
- `go test -race` over flatstack, runner, tests, stdlib: clean
- fixtures: 50/52 on this branch, 49/51 on main, the same two pre-existing
  failures (`stdin.phpt`, `request_and_response_handling.phpt`)
- `atkins mdox:lint`: clean

Two things checked and found safe rather than changed: the constants
copy-on-write (`SetConst` is the only writer of `rt.constants`, `Constants()`
returns a clone, nothing deletes) and the in-place `clear()` in `ResetSession`
(none of those maps escape the `Runtime`).

## Argument handling, made consistent

The fast path also disagreed with the reflect path about arguments. Both
disagreements are fixed rather than left standing.

**Rendering a string argument.** The fast path coerced `func(string) string`
through `phpString`; the reflect path used reflect's `ConvertibleTo`, which is
defined for every integer type and means something else - it turned `int64(65)`
into the code point `"A"` rather than `"65"`. The reflect path is what PHP's own
library reaches, so this was a live defect against php 8.4:

| call | php 8.4 | main | this branch |
|---|---|---|---|
| `strlen(65)` | 2 | 1 | 2 |
| `str_repeat(5, 3)` | 555 | (empty) | 555 |
| `trim(65)` | 65 | A | 65 |
| `substr(12345, 1, 2)` | 23 | (error) | 23 |

**Counting arguments.** The reflect path let `reflect.Value.Call` panic on a
surplus argument and reported a `HostPanicError` naming Go internals; the fast
path dropped the surplus silently; `callGoMethod` panicked on a surplus and on
an omitted one. PHP refuses the call, so `invokeAny` now refuses it before
either path, as an `ArgumentCountError` naming the function:

```
strlen() expects at most 1 argument, 2 given
```

Omitted trailing arguments still pad, because a Go binding spells PHP's optional
parameters as extra ones. `buildArgs` now holds the coercion, padding and count
rules once, for the reflect path and for `callGoMethod` alike, so a method
follows the same rules as a function. Every SPL class name maps to one type, so
`catch (Exception)`, `catch (Error)` and `catch (Throwable)` all catch it.

`tests/fixtures/string_argument_coercion.phpt` and `argument_count.phpt` hold
both behaviours to php 8.4 on runner and flatstack, with their expected sections
taken from `php` rather than from phpscript.

## Pooled scratch no longer pins values

`Run` cleared its recycled stack and locals to length. The pool holds those
buffers for the life of the process, so anything above the high-water mark of a
later, smaller program stayed reachable and was never collected. The clearing
also missed the outer frame's locals when `Run` returned an error from inside a
nested call. `vmScratch.release` now clears every slot of the buffers it puts
back.

## Cost of the correctness work

Reinstating the panic boundary and the argument rules costs 490 of the 2737
allocations the fast path saves, so 82% of the win survives and wall time is the
best of the three builds. The count check itself is free; 189 of the 490 is the
price of `buildArgs` being shared between its two callers rather than copied,
which is worth paying - two copies of these rules is what produced the defect.

## Throwables carry their object

`throw` rendered the thrown value into a new error and propagated that, so the
object a script constructed was gone by the time a catch clause bound it.
`$e->getMessage()` failed on every throwable, the plain `throw new Exception`
case included, because what the catch held was an `errors.errorString` carrying
only the text.

Both engines now propagate a thrown throwable as itself. A catch clause binds
the instance, so `getMessage()` and `getCode()` report what it was constructed
with, matching php 8.4:

```php
try { throw new Exception("boom", 42); } catch (Throwable $e) {
    echo $e->getMessage();  // boom
    echo $e->getCode();     // 42
}
```

An error that never was an `Exception` reaches the same catch: one a binding
returned, or a panic converted at the host boundary. `throwableMethod` answers
the `Throwable` method set over any Go error, so a caught value behaves the same
whatever produced it, and a method the concrete type defines still wins - which
is how `*stdlib.Exception` reports its own code rather than the default zero.

`tests/fixtures/exception_methods.phpt` holds this to php 8.4 on both engines,
and `argument_count.phpt` now reads its message through `getMessage()`, which
php prints identically.

## Cost of the correctness work

Reinstating the panic boundary, the argument rules and the throwable object
costs 2248 of the 2737 allocations the fast path saves, so 82% of the win
survives - and wall time is 15.8% better than main, against 10.6% for the perf
work alone. The count check and the throwable work are free; 189 of the
difference is the price of `buildArgs` being shared between its two callers
rather than copied, which is worth paying, since two copies of those rules is
what produced the defect.

## Verification

- `atkins go:test`: 638 pass
- `go test -race` over runner, flatstack, tests, stdlib: clean
- fixtures: same two pre-existing failures as main (`stdin.phpt`,
  `request_and_response_handling.phpt`), no new ones
- `atkins mdox:lint` and `atkins test:introspection`: clean
- every new fixture's expected section was taken from `php` 8.4 and diffed,
  per the rule this branch adds to `docs/testing.md`
