### PR TITLE
feat(test): --matrix runs every fixture against all three runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # phpscript - A custom PHP-flavoured runtime written in Go
 
-This is an experimental PHP interpreter. It supports the basic php expression syntax and some parts of the standard library. It's currently very rudimentary and only enables limited functionality.
+This is a PHP interpreter written in Go. It supports the basic php expression syntax and some parts of the standard library. It's currently rudimentary and only enables limited functionality.
 
 - [About phpscript](./docs/README.md)
 - [Language reference and PHP compatibility](./docs/reference/README.md)

--- a/atkins.yml
+++ b/atkins.yml
@@ -20,6 +20,7 @@ tasks:
       - task: up
       - task: test:introspection
       - task: test:phpscript:run
+      - task: test:phpscript:matrix
       - task: test:demos:dbadmin
       - task: test:demos:example
 
@@ -54,6 +55,16 @@ tasks:
       - phpscript info
       - cd docs/reference && php README.php > README.md
       - task: mdox:fmt
+
+  # Every fixture runs on all three runtimes, so a divergence between the two
+  # Go runtimes, or between phpscript and php itself, fails the pipeline.
+  test:phpscript:matrix:
+    dir: tests/fixtures
+    passthru: true
+    env:
+      include: .env.testing
+    cmds:
+      - phpscript test --matrix -v
 
   test:phpscript:run:
     dir: tests/fixtures

--- a/cmd/phpscript/test/loop_test.go
+++ b/cmd/phpscript/test/loop_test.go
@@ -23,7 +23,7 @@ func loopFixture(t *testing.T) *tests.Fixture {
 }
 
 func TestRunFixtureLoopCount(t *testing.T) {
-	fr := runFixtureLoop(context.Background(), loopFixture(t), Options{Count: 5})
+	fr := runFixtureLoop(context.Background(), loopFixture(t), tests.RunnerRuntime, Options{Count: 5})
 	if fr.Runs != 5 {
 		t.Fatalf("Runs = %d, want 5", fr.Runs)
 	}
@@ -33,7 +33,7 @@ func TestRunFixtureLoopCount(t *testing.T) {
 }
 
 func TestRunFixtureLoopTime(t *testing.T) {
-	fr := runFixtureLoop(context.Background(), loopFixture(t), Options{Time: 50 * time.Millisecond})
+	fr := runFixtureLoop(context.Background(), loopFixture(t), tests.RunnerRuntime, Options{Time: 50 * time.Millisecond})
 	if fr.Runs < 2 {
 		t.Fatalf("Runs = %d, want at least 2 within 50ms", fr.Runs)
 	}
@@ -43,14 +43,14 @@ func TestRunFixtureLoopTime(t *testing.T) {
 }
 
 func TestRunFixtureLoopSingleByDefault(t *testing.T) {
-	fr := runFixtureLoop(context.Background(), loopFixture(t), Options{})
+	fr := runFixtureLoop(context.Background(), loopFixture(t), tests.RunnerRuntime, Options{})
 	if fr.Runs != 1 {
 		t.Fatalf("Runs = %d, want 1", fr.Runs)
 	}
 }
 
 func TestRunFixtureLoopProfile(t *testing.T) {
-	fr := runFixtureLoop(context.Background(), loopFixture(t), Options{Count: 3, Profile: true})
+	fr := runFixtureLoop(context.Background(), loopFixture(t), tests.RunnerRuntime, Options{Count: 3, Profile: true})
 	if fr.AllocsPerOp == 0 || fr.BytesPerOp == 0 {
 		t.Fatalf("profile counters empty: allocs=%d bytes=%d", fr.AllocsPerOp, fr.BytesPerOp)
 	}
@@ -61,7 +61,7 @@ func TestRunFixtureSamplesCountAndTime(t *testing.T) {
 		count     = 3
 		benchTime = 10 * time.Millisecond
 	)
-	runs := runFixtureSamples(context.Background(), loopFixture(t), Options{
+	runs := runFixtureSamples(context.Background(), loopFixture(t), tests.RunnerRuntime, Options{
 		Count: count,
 		Time:  benchTime,
 	})

--- a/cmd/phpscript/test/matrix.go
+++ b/cmd/phpscript/test/matrix.go
@@ -1,0 +1,135 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/titpetric/phpscript/tests"
+)
+
+// matrixStatus is the outcome of one runner for one fixture.
+type matrixStatus int
+
+const (
+	matrixPass matrixStatus = iota
+	matrixFail
+	matrixSkip
+)
+
+// matrixCell holds one runner's outcome and the detail printed under the row
+// when the run is verbose.
+type matrixCell struct {
+	Runner tests.Runner
+	Status matrixStatus
+	Reason string
+}
+
+// matrixRow is a fixture and its cell per runner, in tests.Runners order.
+type matrixRow struct {
+	DisplayPath string
+	Cells       []matrixCell
+}
+
+// Failed reports whether any runner failed the fixture.
+func (r matrixRow) Failed() bool {
+	for _, cell := range r.Cells {
+		if cell.Status == matrixFail {
+			return true
+		}
+	}
+	return false
+}
+
+// runMatrix runs every fixture through every runner and reports the number of
+// failed fixtures. A fixture opted out of a runner, or a runner missing from
+// the machine, is skipped rather than failed.
+func runMatrix(ctx context.Context, fixtures []*tests.Fixture, displayPaths []string, opts Options) int {
+	var table matrixTable
+	if !opts.JSON {
+		table = newMatrixTable(os.Stdout, displayPaths, opts)
+		table.writeHeader()
+	}
+
+	var jsonRows []jsonFixture
+	var passedCount, failedCount int
+	startAll := time.Now()
+
+	for i, fx := range fixtures {
+		row := matrixRow{DisplayPath: displayPaths[i]}
+		for _, name := range tests.Runners {
+			cell := matrixCell{Runner: name}
+			if !fx.Runs(name) {
+				cell.Status = matrixSkip
+				cell.Reason = fmt.Sprintf("opted out by runner.%s: false", name)
+				row.Cells = append(row.Cells, cell)
+				jsonRows = append(jsonRows, jsonFixture{
+					Name:    fx.Name,
+					Path:    row.DisplayPath,
+					Runner:  string(name),
+					Skipped: true,
+					Failure: cell.Reason,
+				})
+				continue
+			}
+
+			for _, fr := range runFixtureSamples(ctx, fx, name, opts) {
+				fr.DisplayPath = row.DisplayPath
+				jsonRows = append(jsonRows, jsonFixture{
+					Name:        fx.Name,
+					Path:        fr.DisplayPath,
+					Runner:      string(name),
+					Passed:      fr.Result.Passed,
+					Skipped:     fr.Result.Skipped,
+					Runs:        fr.Runs,
+					DurationNs:  fr.Total.Nanoseconds(),
+					P50Ns:       fr.P50.Nanoseconds(),
+					P95Ns:       fr.P95.Nanoseconds(),
+					P99Ns:       fr.P99.Nanoseconds(),
+					AllocsPerOp: fr.AllocsPerOp,
+					BytesPerOp:  fr.BytesPerOp,
+					GCRuns:      fr.GCRuns,
+					Failure:     fr.Result.FailureReason,
+				})
+
+				// A failing sample decides the cell; samples of one fixture
+				// only differ when the runtime is not deterministic.
+				if cell.Status == matrixPass && !fr.Result.Passed {
+					cell.Status = matrixFail
+					cell.Reason = fr.Result.FailureReason
+					if fr.Result.Skipped {
+						cell.Status = matrixSkip
+					}
+				}
+			}
+			row.Cells = append(row.Cells, cell)
+		}
+
+		if row.Failed() {
+			failedCount++
+		} else {
+			passedCount++
+		}
+		if table != nil {
+			table.writeRow(row)
+		}
+	}
+
+	if table != nil {
+		table.close()
+		table.writeSummary(passedCount, failedCount, len(fixtures), time.Since(startAll))
+	}
+
+	if opts.JSON {
+		_ = json.NewEncoder(os.Stdout).Encode(jsonReport{
+			Total:   len(fixtures),
+			Passed:  passedCount,
+			Failed:  failedCount,
+			Results: jsonRows,
+		})
+	}
+
+	return failedCount
+}

--- a/cmd/phpscript/test/matrix_table.go
+++ b/cmd/phpscript/test/matrix_table.go
@@ -1,0 +1,254 @@
+package test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
+
+	"github.com/titpetric/phpscript/tests"
+)
+
+const colorDim = "\033[38;5;244m"
+
+// maxTableWidth bounds how far a verbose table is widened to fill a terminal.
+const maxTableWidth = 120
+
+// matrixHeaders labels each runner column of the matrix report.
+var matrixHeaders = map[tests.Runner]string{
+	tests.RunnerFlatstack: "Flat stack",
+	tests.RunnerRuntime:   "Runtime",
+	tests.RunnerPHP:       "PHP",
+}
+
+// matrixTable renders one fixture per row with a cell per runner.
+type matrixTable interface {
+	writeHeader()
+	writeRow(matrixRow)
+	close()
+	writeSummary(passed, failed, total int, duration time.Duration)
+}
+
+// terminalMatrix writes the ansi table. Column widths are established before
+// the run so a fixture can be printed as soon as it completes.
+type terminalMatrix struct {
+	w       io.Writer
+	headers []string
+	widths  []int
+	verbose bool
+}
+
+func newMatrixTable(w io.Writer, filenames []string, opts Options) matrixTable {
+	table := newTerminalMatrix(w, filenames, opts)
+	file, ok := w.(*os.File)
+	if !ok || !term.IsTerminal(int(file.Fd())) {
+		return &markdownMatrix{terminalMatrix: table}
+	}
+	if width, _, err := term.GetSize(int(file.Fd())); err == nil {
+		table.fit(width)
+	}
+	return table
+}
+
+// fit widens the last column so a verbose table fills the terminal. The failure
+// detail below a row is wrapped into the runner columns, and the natural width
+// of three status columns leaves too little of a reason to read.
+func (t *terminalMatrix) fit(width int) {
+	if !t.verbose {
+		return
+	}
+	natural := 1
+	for _, w := range t.widths {
+		natural += w + 3
+	}
+	if grow := min(width, maxTableWidth) - natural; grow > 0 {
+		t.widths[len(t.widths)-1] += grow
+	}
+}
+
+func newTerminalMatrix(w io.Writer, filenames []string, opts Options) *terminalMatrix {
+	t := &terminalMatrix{w: w, verbose: opts.Verbose}
+	t.headers = []string{"Fixture"}
+	for _, runner := range tests.Runners {
+		t.headers = append(t.headers, matrixHeaders[runner])
+	}
+
+	t.widths = make([]int, len(t.headers))
+	for i, header := range t.headers {
+		t.widths[i] = ansi.StringWidth(header)
+	}
+	for _, filename := range filenames {
+		if width := ansi.StringWidth(filename); width > t.widths[0] {
+			t.widths[0] = width
+		}
+	}
+	for i := 1; i < len(t.widths); i++ {
+		t.widths[i] = max(t.widths[i], len("PASS"))
+	}
+	return t
+}
+
+func (t *terminalMatrix) writeHeader() {
+	t.writeBorder(boxTopLeft, boxTeeDown, boxTopRight)
+	t.writeRowValues(t.headers, colorHeader)
+	t.writeBorder(boxTeeRight, boxCross, boxTeeLeft)
+}
+
+func (t *terminalMatrix) writeRow(row matrixRow) {
+	values := []string{colorAmber + row.DisplayPath + colorReset}
+	for _, cell := range row.Cells {
+		values = append(values, statusColor(cell.Status)+statusLabel(cell.Status)+colorReset)
+	}
+	t.writeRowValues(values, "")
+
+	if !t.verbose {
+		return
+	}
+	for _, cell := range row.Cells {
+		if cell.Status != matrixFail || cell.Reason == "" {
+			continue
+		}
+		for _, line := range wrapDetail(string(cell.Runner)+": "+cell.Reason, t.detailWidth()) {
+			t.writeDetail(line)
+		}
+	}
+}
+
+func (t *terminalMatrix) close() {
+	t.writeBorder(boxBottomLeft, boxTeeUp, boxBottomRight)
+}
+
+func (t *terminalMatrix) writeSummary(passed, failed, total int, duration time.Duration) {
+	fmt.Fprintf(t.w, "%sMatrix summary: %d passed, %d failed out of %d fixtures (%dms)%s\n",
+		colorHeader, passed, failed, total, duration.Milliseconds(), colorReset)
+}
+
+// detailWidth is the width of the runner columns merged into one cell, which
+// is what a continuation row prints its failure detail in.
+func (t *terminalMatrix) detailWidth() int {
+	width := 0
+	for _, w := range t.widths[1:] {
+		width += w
+	}
+	return width + 3*(len(t.widths)-2)
+}
+
+func (t *terminalMatrix) writeDetail(line string) {
+	separator := colorSeparator + boxVertical + colorReset
+	fixture := strings.Repeat(" ", t.widths[0])
+	padding := strings.Repeat(" ", max(0, t.detailWidth()-ansi.StringWidth(line)))
+	fmt.Fprintln(t.w, separator+" "+fixture+" "+separator+" "+colorWhite+line+colorReset+padding+" "+separator)
+}
+
+func (t *terminalMatrix) writeBorder(left, middle, right string) {
+	segments := make([]string, len(t.widths))
+	for i, width := range t.widths {
+		segments[i] = strings.Repeat(boxHorizontal, width+2)
+	}
+	fmt.Fprintln(t.w, colorSeparator+left+strings.Join(segments, middle)+right+colorReset)
+}
+
+func (t *terminalMatrix) writeRowValues(values []string, color string) {
+	cells := make([]string, len(values))
+	reset := ""
+	if color != "" {
+		reset = colorReset
+	}
+	for i, value := range values {
+		padding := strings.Repeat(" ", max(0, t.widths[i]-ansi.StringWidth(value)))
+		cells[i] = " " + color + value + padding + reset + " "
+	}
+	separator := colorSeparator + boxVertical + colorReset
+	fmt.Fprintln(t.w, separator+strings.Join(cells, separator)+separator)
+}
+
+// markdownMatrix renders the same matrix for a piped stdout.
+type markdownMatrix struct {
+	*terminalMatrix
+}
+
+func (t *markdownMatrix) writeHeader() {
+	t.writeMarkdownRow(t.headers)
+	separators := make([]string, len(t.widths))
+	for i, width := range t.widths {
+		separators[i] = strings.Repeat("-", width)
+	}
+	t.writeMarkdownRow(separators)
+}
+
+func (t *markdownMatrix) writeRow(row matrixRow) {
+	values := []string{row.DisplayPath}
+	for _, cell := range row.Cells {
+		values = append(values, statusLabel(cell.Status))
+	}
+	t.writeMarkdownRow(values)
+
+	if !t.verbose {
+		return
+	}
+	// Markdown has no fixed width to wrap into, so a reason only breaks where
+	// it already carries a newline.
+	for _, cell := range row.Cells {
+		if cell.Status != matrixFail || cell.Reason == "" {
+			continue
+		}
+		for _, line := range strings.Split(string(cell.Runner)+": "+cell.Reason, "\n") {
+			detail := make([]string, len(t.widths))
+			detail[1] = strings.ReplaceAll(strings.TrimRight(line, " "), "|", "\\|")
+			t.writeMarkdownRow(detail)
+		}
+	}
+}
+
+func (t *markdownMatrix) close() {}
+
+func (t *markdownMatrix) writeSummary(int, int, int, time.Duration) {}
+
+func (t *markdownMatrix) writeMarkdownRow(values []string) {
+	cells := make([]string, len(values))
+	for i, value := range values {
+		cells[i] = value + strings.Repeat(" ", max(0, t.widths[i]-ansi.StringWidth(value)))
+	}
+	fmt.Fprintln(t.w, "| "+strings.Join(cells, " | ")+" |")
+}
+
+func statusLabel(status matrixStatus) string {
+	switch status {
+	case matrixFail:
+		return "FAIL"
+	case matrixSkip:
+		return "SKIP"
+	default:
+		return "PASS"
+	}
+}
+
+func statusColor(status matrixStatus) string {
+	switch status {
+	case matrixFail:
+		return colorRed
+	case matrixSkip:
+		return colorDim
+	default:
+		return colorGreen
+	}
+}
+
+// wrapDetail splits a failure reason into lines that fit the detail column.
+// Reasons embed newlines to separate the got and want output.
+func wrapDetail(reason string, width int) []string {
+	var lines []string
+	for _, line := range strings.Split(reason, "\n") {
+		line = strings.TrimRight(line, " ")
+		for ansi.StringWidth(line) > width && width > 0 {
+			lines = append(lines, ansi.Truncate(line, width, ""))
+			line = strings.TrimPrefix(line, ansi.Truncate(line, width, ""))
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}

--- a/cmd/phpscript/test/matrix_test.go
+++ b/cmd/phpscript/test/matrix_test.go
@@ -1,0 +1,142 @@
+package test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/titpetric/phpscript/tests"
+)
+
+func matrixSample() matrixRow {
+	return matrixRow{
+		DisplayPath: "a.phpt",
+		Cells: []matrixCell{
+			{Runner: tests.RunnerFlatstack, Status: matrixPass},
+			{Runner: tests.RunnerRuntime, Status: matrixFail, Reason: "output mismatch:\n  got:  \"x\"\n  want: \"y\""},
+			{Runner: tests.RunnerPHP, Status: matrixSkip, Reason: "opted out by runner.php: false"},
+		},
+	}
+}
+
+func TestTerminalMatrixColumnsAndSpacing(t *testing.T) {
+	var buf bytes.Buffer
+	table := newTerminalMatrix(&buf, []string{"a-much-longer-name.phpt"}, Options{})
+	table.writeHeader()
+	table.writeRow(matrixSample())
+	table.close()
+
+	output := ansi.Strip(buf.String())
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	header := strings.Join(strings.Fields(strings.ReplaceAll(lines[1], "│", "|")), " ")
+	if want := "| Fixture | Flat stack | Runtime | PHP |"; header != want {
+		t.Errorf("header = %q, want %q", header, want)
+	}
+	for i, line := range lines {
+		if ansi.StringWidth(line) != ansi.StringWidth(lines[0]) {
+			t.Errorf("line %d has width %d, want %d:\n%s", i, ansi.StringWidth(line), ansi.StringWidth(lines[0]), output)
+		}
+	}
+	if !strings.Contains(buf.String(), colorGreen+"PASS") ||
+		!strings.Contains(buf.String(), colorRed+"FAIL") ||
+		!strings.Contains(buf.String(), colorDim+"SKIP") {
+		t.Errorf("table is missing expected ANSI colors: %q", buf.String())
+	}
+	// Without --verbose a failure reason stays out of the table.
+	if strings.Contains(output, "output mismatch") {
+		t.Errorf("non-verbose table printed a failure reason:\n%s", output)
+	}
+}
+
+func TestTerminalMatrixVerboseContinuationRows(t *testing.T) {
+	var buf bytes.Buffer
+	table := newTerminalMatrix(&buf, []string{"a.phpt"}, Options{Verbose: true})
+	table.writeHeader()
+	table.writeRow(matrixSample())
+	table.close()
+
+	output := ansi.Strip(buf.String())
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for i, line := range lines {
+		if ansi.StringWidth(line) != ansi.StringWidth(lines[0]) {
+			t.Errorf("line %d has width %d, want %d:\n%s", i, ansi.StringWidth(line), ansi.StringWidth(lines[0]), output)
+		}
+	}
+
+	var details []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "│") && strings.HasPrefix(strings.TrimSpace(strings.Split(line, "│")[1]), "") &&
+			strings.Contains(line, "runtime: ") {
+			details = append(details, line)
+		}
+	}
+	if len(details) != 1 {
+		t.Fatalf("want one continuation row naming the failed runner:\n%s", output)
+	}
+	// The fixture column of a continuation row is empty, so the row reads as
+	// part of the fixture above it.
+	if fixture := strings.Split(details[0], "│")[1]; strings.TrimSpace(fixture) != "" {
+		t.Errorf("continuation row fixture column = %q, want empty", fixture)
+	}
+	if !strings.Contains(output, "want: \"y\"") {
+		t.Errorf("continuation rows dropped part of the reason:\n%s", output)
+	}
+	// A skipped runner is not a failure, so it contributes no detail.
+	if strings.Contains(output, "opted out") {
+		t.Errorf("skip reason printed as a failure:\n%s", output)
+	}
+}
+
+func TestMatrixTableFallsBackToMarkdown(t *testing.T) {
+	var buf bytes.Buffer
+	table := newMatrixTable(&buf, []string{"a.phpt"}, Options{Verbose: true})
+	table.writeHeader()
+	table.writeRow(matrixSample())
+	table.close()
+	table.writeSummary(0, 1, 1, time.Millisecond)
+
+	got := buf.String()
+	if strings.Contains(got, boxVertical) || strings.Contains(got, colorGreen) {
+		t.Errorf("piped output is not markdown: %q", got)
+	}
+	for _, want := range []string{
+		"| Fixture | Flat stack | Runtime | PHP  |",
+		"| a.phpt  | PASS       | FAIL    | SKIP |",
+		"runtime: output mismatch:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("markdown table is missing %q:\n%s", want, got)
+		}
+	}
+	// Every markdown row has one cell per column, continuation rows included.
+	for _, line := range strings.Split(strings.TrimSpace(got), "\n") {
+		if columns := strings.Count(line, "|"); columns != 5 {
+			t.Errorf("row %q has %d separators, want 5", line, columns)
+		}
+	}
+}
+
+func TestMatrixTableFitWidensLastColumn(t *testing.T) {
+	var buf bytes.Buffer
+	table := newTerminalMatrix(&buf, []string{"a.phpt"}, Options{Verbose: true})
+	natural := table.detailWidth()
+	table.fit(maxTableWidth)
+	if table.detailWidth() <= natural {
+		t.Errorf("detail width = %d, want more than the natural %d", table.detailWidth(), natural)
+	}
+	table.writeHeader()
+	table.close()
+	lines := strings.Split(strings.TrimSpace(ansi.Strip(buf.String())), "\n")
+	if width := ansi.StringWidth(lines[0]); width != maxTableWidth {
+		t.Errorf("table width = %d, want %d", width, maxTableWidth)
+	}
+	// A table already wider than the terminal is left alone.
+	before := table.detailWidth()
+	table.fit(10)
+	if table.detailWidth() != before {
+		t.Errorf("detail width = %d, want it unchanged at %d", table.detailWidth(), before)
+	}
+}

--- a/cmd/phpscript/test/run.go
+++ b/cmd/phpscript/test/run.go
@@ -21,6 +21,8 @@ const Name = "Run .phpt test fixtures"
 // Options holds CLI flag options for the test command.
 type Options struct {
 	JSON       bool
+	Matrix     bool
+	Verbose    bool
 	Count      int
 	Time       time.Duration
 	Profile    bool
@@ -31,7 +33,9 @@ type Options struct {
 type jsonFixture struct {
 	Name        string `json:"name"`
 	Path        string `json:"path"`
+	Runner      string `json:"runner,omitempty"`
 	Passed      bool   `json:"passed"`
+	Skipped     bool   `json:"skipped,omitempty"`
 	Runs        int    `json:"runs"`
 	DurationNs  int64  `json:"duration_ns"`
 	P50Ns       int64  `json:"p50_ns,omitempty"`
@@ -57,6 +61,8 @@ func NewCommand() *cli.Command {
 		Title: Name,
 		Bind: func(fs *cli.FlagSet) {
 			fs.BoolVar(&opts.JSON, "json", false, "Write machine-readable JSON to stdout")
+			fs.BoolVar(&opts.Matrix, "matrix", false, "Run every fixture through all runtimes and report a matrix")
+			fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "Report the failure of each runtime below its fixture")
 			fs.IntVarP(&opts.Count, "count", "c", 0, "Run each test N times; with --time, produce N benchmark samples")
 			fs.DurationVarP(&opts.Time, "time", "t", 0, "Run each test for this duration per benchmark sample (e.g. 10s)")
 			fs.BoolVar(&opts.Profile, "profile", false, "Report memory usage per run (allocs/op, B/op)")
@@ -83,7 +89,7 @@ type fixtureRun struct {
 	GCRuns      uint32
 }
 
-func runFixtureLoop(ctx context.Context, fx *tests.Fixture, opts Options) *fixtureRun {
+func runFixtureLoop(ctx context.Context, fx *tests.Fixture, r tests.Runner, opts Options) *fixtureRun {
 	out := &fixtureRun{}
 	hint := opts.Count
 	if hint <= 0 {
@@ -96,7 +102,7 @@ func runFixtureLoop(ctx context.Context, fx *tests.Fixture, opts Options) *fixtu
 	start := time.Now()
 	for {
 		opStart := time.Now()
-		res := tests.RunFixture(ctx, fx)
+		res := tests.RunFixtureOn(ctx, fx, r)
 		samples = append(samples, time.Since(opStart).Nanoseconds())
 		out.Runs++
 		if out.Result == nil || (out.Result.Passed && !res.Passed) {
@@ -144,16 +150,16 @@ func percentileNs(sorted []int64, p int) int64 {
 	return sorted[idx-1]
 }
 
-func runFixtureSamples(ctx context.Context, fx *tests.Fixture, opts Options) []*fixtureRun {
+func runFixtureSamples(ctx context.Context, fx *tests.Fixture, r tests.Runner, opts Options) []*fixtureRun {
 	if opts.Count <= 0 || opts.Time <= 0 {
-		return []*fixtureRun{runFixtureLoop(ctx, fx, opts)}
+		return []*fixtureRun{runFixtureLoop(ctx, fx, r, opts)}
 	}
 
 	sampleOpts := opts
 	sampleOpts.Count = 0
 	runs := make([]*fixtureRun, 0, opts.Count)
 	for range opts.Count {
-		runs = append(runs, runFixtureLoop(ctx, fx, sampleOpts))
+		runs = append(runs, runFixtureLoop(ctx, fx, r, sampleOpts))
 		if ctx.Err() != nil {
 			break
 		}
@@ -205,6 +211,17 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		}
 	}
 
+	if opts.Matrix {
+		failed := runMatrix(ctx, fixtures, displayPaths, opts)
+		if err := writeMemProfile(opts); err != nil {
+			return err
+		}
+		if failed > 0 {
+			return fmt.Errorf("%d fixture(s) failed", failed)
+		}
+		return nil
+	}
+
 	var table resultTable
 	if !opts.JSON {
 		table = newResultTable(os.Stdout, displayPaths, opts)
@@ -219,7 +236,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 	for i, fx := range fixtures {
 		var fixtureResult *tests.TestResult
 		var firstFailedRun *fixtureRun
-		for _, fr := range runFixtureSamples(ctx, fx, opts) {
+		for _, fr := range runFixtureSamples(ctx, fx, tests.RunnerRuntime, opts) {
 			fr.DisplayPath = displayPaths[i]
 			if table != nil {
 				table.writeResult(fr)
@@ -227,6 +244,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 			jsonRows = append(jsonRows, jsonFixture{
 				Name:        fx.Name,
 				Path:        fr.DisplayPath,
+				Runner:      string(fr.Result.Runner),
 				Passed:      fr.Result.Passed,
 				Runs:        fr.Runs,
 				DurationNs:  fr.Total.Nanoseconds(),
@@ -281,21 +299,30 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		}
 	}
 
-	if opts.MemProfile != "" {
-		f, err := os.Create(opts.MemProfile)
-		if err != nil {
-			return fmt.Errorf("create memprofile: %w", err)
-		}
-		defer f.Close()
-		runtime.GC()
-		if err := pprof.WriteHeapProfile(f); err != nil {
-			return fmt.Errorf("write memprofile: %w", err)
-		}
+	if err := writeMemProfile(opts); err != nil {
+		return err
 	}
 
 	if failedCount > 0 {
 		return fmt.Errorf("%d fixture(s) failed", failedCount)
 	}
 
+	return nil
+}
+
+// writeMemProfile dumps a heap profile when one was requested.
+func writeMemProfile(opts Options) error {
+	if opts.MemProfile == "" {
+		return nil
+	}
+	f, err := os.Create(opts.MemProfile)
+	if err != nil {
+		return fmt.Errorf("create memprofile: %w", err)
+	}
+	defer f.Close()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("write memprofile: %w", err)
+	}
 	return nil
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,7 +78,7 @@ PHP accesses this constructor as `SharedMemory`. The binding exposes `set` and `
 
 ## `.phpt` fixtures
 
-Fixtures live directly in [`tests/fixtures`](../tests/fixtures). The test harness discovers every file with a `.phpt` extension and runs it through the default `runner` runtime.
+Fixtures live directly in [`tests/fixtures`](../tests/fixtures). The test harness discovers every file with a `.phpt` extension and runs it through the default `runner` runtime, and through the other runtimes the fixture has not opted out of.
 
 Each fixture has three sections separated by a line containing only `---`:
 
@@ -106,13 +106,13 @@ hello world
 
 The YAML metadata supports these fields:
 
-| Field         | Required | Purpose                                                              |
-|---------------|---------:|----------------------------------------------------------------------|
-| `name`        |      yes | Human-readable subtest name.                                         |
-| `description` |      yes | Behavior and intent covered by the fixture.                          |
-| `error`       |       no | Substring that must occur in the chain of an uncaught runtime error. |
-| `stdin`       |       no | String exposed to the script through `STDIN`.                        |
-| `flatstack`   |       no | Set to `true` to run the fixture through flatstack as well.          |
+| Field         | Required | Purpose                                                                    |
+|---------------|---------:|----------------------------------------------------------------------------|
+| `name`        |      yes | Human-readable subtest name.                                               |
+| `description` |      yes | Behavior and intent covered by the fixture.                                |
+| `error`       |       no | Substring that must occur in the chain of an uncaught runtime error.       |
+| `stdin`       |       no | String exposed to the script through `STDIN`.                              |
+| `runner`      |       no | Runtimes the fixture opts out of; see [Runner metadata](#runner-metadata). |
 
 The expected-output section is always checked. Trailing newline differences are ignored, but all other output must match exactly. For an uncaught error, set `error` to a stable identifying substring and normally expect the host response body `Internal Server Error`:
 
@@ -132,7 +132,7 @@ Files used by `include`, autoloading, templates, or filesystem APIs can be place
 
 ### Checking a fixture against PHP
 
-PHP 8.4 is installed as `/usr/bin/php`. Where a fixture uses only language features and PHP's own library, its expected-output section is what `php` prints for the same source, and that is verified rather than assumed. The two `---` lines make the sections addressable:
+PHP 8.4 is installed as `/usr/bin/php`. Where a fixture uses only language features and PHP's own library, its expected-output section is what `php` prints for the same source, and that is verified rather than assumed. `phpscript test --matrix` runs that check for every fixture at once; to see the whole difference for one of them, run the two sides by hand. The two `---` lines make the sections addressable:
 
 ```bash
 cd tests/fixtures
@@ -154,17 +154,36 @@ Three kinds of fixture cannot be checked this way, and none of them is an excuse
 | Runtime introspection (`phpinfo`, `get_included_files`)          | The output names phpscript, or absolute paths that differ per machine         |
 | Host request state (superglobals populated by the harness)       | The harness supplies the request, not the PHP CLI SAPI                        |
 
-A fixture in one of these groups states in its `description` what defines the expected output, because there is no second implementation to appeal to.
+A fixture in one of these groups states in its `description` what defines the expected output, because there is no second implementation to appeal to, and opts the php runtime out with `runner`.
 
-## Testing with flatstack
+## Runner metadata
 
-Every `.phpt` fixture runs through the default runtime. To additionally run a fixture through the native flatstack bytecode runtime, add one metadata field:
+Every fixture runs through every runtime. A fixture that one runtime cannot execute opts that runtime out:
 
 ```yaml
-flatstack: true
+runner:
+  php: false
 ```
 
-No Go-side fixture list needs updating. The flatstack harness discovers the flag automatically. It also calls `flatstack.Supports` before execution, so the test fails if the program would use the compatibility interpreter instead of native flat bytecode. Only add the flag after all syntax and runtime operations used by the fixture are supported by flatstack.
+Both `flatstack` and `php` are accepted, and an omitted key means the runtime is used. The default runtime cannot be opted out of, because its output is what the expected-output section states.
+
+Opt out only where the runtime has nothing to say about the fixture: `php: false` for the three groups above, `flatstack: false` where the bytecode engine cannot execute the program at all. Syntax the bytecode engine does not compile is not a reason on its own, because it falls back to the compatibility interpreter and produces the same output.
+
+## Testing across runtimes
+
+`phpscript test --matrix` runs every fixture through all three runtimes and prints one row per fixture:
+
+```bash
+phpscript test --matrix tests/fixtures
+phpscript test --matrix -v tests/fixtures   # with the failures of each runtime
+```
+
+| Fixture             | Flat stack | Runtime | PHP  |
+|---------------------|------------|---------|------|
+| array_indexing.phpt | PASS       | PASS    | PASS |
+| storage_list.phpt   | PASS       | PASS    | SKIP |
+
+A `SKIP` is a fixture that opted the runtime out, or a `php` binary that is not installed. Any other non-pass fails the run. This is the check that finds a divergence between the two Go runtimes, and between phpscript and PHP itself.
 
 ## Running fixture tests
 
@@ -174,7 +193,7 @@ Run all default-runtime fixtures:
 go test ./tests -run '^TestFixtures$'
 ```
 
-Run all flatstack-enabled fixtures:
+Run every fixture through the flat bytecode runtime:
 
 ```bash
 go test ./tests -run '^TestFlatstackFixtures$'
@@ -187,4 +206,4 @@ go test ./tests -run 'TestFixtures/string_concatenation'
 go test ./tests -run 'TestFlatstackFixtures/string_concatenation'
 ```
 
-Before submitting a change, run the package tests affected by the change and then the complete suite with `go test ./...`. A change to language or runtime behavior is not finished until it has a fixture, and a fixture covering PHP's own behavior is not finished until it has been diffed against `php`.
+Before submitting a change, run the package tests affected by the change, then the complete suite with `go test ./...`, and then `phpscript test --matrix tests/fixtures`. A change to language or runtime behavior is not finished until it has a fixture, and a fixture covering PHP's own behavior is not finished until it passes the php column of the matrix.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,6 +107,27 @@ Use `--profile` to add per-operation allocation and byte counts. `--json`
 writes a machine-readable report to stdout (no table). `--cpuprofile` and
 `--memprofile` write pprof files for the whole `test` invocation.
 
+Use `--matrix` to run every fixture through all three runtimes (the flat
+bytecode engine, the default interpreter, and the `php` binary), reporting one
+row per fixture with a cell per runtime. Every other `test` flag is honored. A
+fixture that opts out of a runtime, and a runtime that is not installed, are
+reported as `SKIP`; anything else that is not a pass fails the run, and the
+command exits non-zero.
+
+```bash
+phpscript test --matrix tests/fixtures
+phpscript test --matrix -v tests/fixtures
+```
+
+| Fixture             | Flat stack | Runtime | PHP  |
+|---------------------|------------|---------|------|
+| array_indexing.phpt | PASS       | PASS    | PASS |
+| storage_list.phpt   | PASS       | PASS    | SKIP |
+
+Add `--verbose` (`-v`) to print the failure of each runtime in continuation
+rows below its fixture. A continuation row leaves the fixture column empty, so
+it reads as part of the row above it.
+
 ### `phpscript fmt <path>...`
 
 Format one or more PHP files or directories in place. A directory path formats

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -617,6 +617,13 @@ func (c *compiler) expr(expr model.Expr, path string) error {
 			return unsupported(path, "compact() requires scope reflection")
 		}
 		for i, argument := range node.Args {
+			// An output parameter is handed to the binding as a setter for the
+			// caller's variable, the way the interpreter emits __ref.
+			if variable, ok := model.UnwrapParenthesized(argument).(*model.Var); ok &&
+				model.ByRefArg(node.Name, node.Fallback, i) {
+				c.emit(instruction{op: opRef, a: c.slot(variable.Name)})
+				continue
+			}
 			if err := c.expr(argument, fmt.Sprintf("%s.arg[%d]", path, i)); err != nil {
 				return err
 			}

--- a/flatstack/engine/program.go
+++ b/flatstack/engine/program.go
@@ -24,6 +24,7 @@ const (
 	opJumpFalse
 	opJumpTrue
 	opCall
+	opRef
 	opConstruct
 	opCallMethod
 	opGetProperty

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -329,6 +329,14 @@ func Run(program *Program, host Host) (err error) {
 				pc = inst.target
 				continue
 			}
+		case opRef:
+			// The setter writes the frame the call was made from; a user
+			// function called in between installs its own locals, and this one
+			// keeps pointing at the caller's.
+			frame, frameInitialized, slot := locals, initialized, inst.a
+			stack = append(stack, func(value any) {
+				frame[slot], frameInitialized[slot] = value, true
+			})
 		case opCall, opConstruct:
 			arguments, argErr := args(inst.a)
 			if argErr != nil {

--- a/model/byref.go
+++ b/model/byref.go
@@ -1,0 +1,20 @@
+package model
+
+// byRefArgs lists, per builtin, the argument positions PHP passes by reference.
+// They are output parameters: the binding receives a setter that writes the
+// caller's variable instead of a value. minitpl only needs preg_match_all's
+// $matches, and preg_match's for the same reason.
+var byRefArgs = map[string]map[int]bool{
+	"preg_match_all": {2: true},
+	"preg_match":     {2: true},
+}
+
+// ByRefArg reports whether the argument at index is an output parameter of the
+// named call. Inside a namespaced file the call carries a qualified name and
+// the global name it falls back to, and either may match.
+func ByRefArg(name, fallback string, index int) bool {
+	if refs, ok := byRefArgs[name]; ok {
+		return refs[index]
+	}
+	return byRefArgs[fallback][index]
+}

--- a/parser/tokenizer.go
+++ b/parser/tokenizer.go
@@ -302,7 +302,14 @@ func (t *phpTokenizer) scanInlineHTML() {
 		startLine = t.line
 		if strings.HasPrefix(t.src[t.pos:], "<?php") {
 			t.consume(5)
-			t.emitArr(T_OPEN_TAG, "<?php", startLine)
+			// PHP folds the one whitespace character that ends the open tag
+			// into the token, so `<?php\n` is a six byte T_OPEN_TAG.
+			text := "<?php"
+			if t.pos < len(t.src) && isOpenTagSpace(t.src[t.pos]) {
+				text += string(t.src[t.pos])
+				t.advance()
+			}
+			t.emitArr(T_OPEN_TAG, text, startLine)
 		} else {
 			t.consume(2)
 			t.emitArr(T_OPEN_TAG, "<?", startLine)
@@ -470,6 +477,11 @@ func (t *phpTokenizer) scanOperator() bool {
 		return true
 	}
 	return false
+}
+
+// isOpenTagSpace reports the whitespace PHP absorbs into T_OPEN_TAG.
+func isOpenTagSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
 func (t *phpTokenizer) advance() {

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -58,8 +58,10 @@ func (h flatHost) SetProperty(receiver any, name string, value any, op string) e
 	})
 }
 
+// Echo writes through the runtime output stack rather than to the base writer,
+// so ob_start captures bytecode output the way it captures interpreted output.
 func (h flatHost) Echo(value any) error {
-	_, err := io.WriteString(h.runtime.out, phpString(value))
+	_, err := io.WriteString(h.runtime.Output(), phpString(value))
 	return err
 }
 
@@ -102,7 +104,15 @@ func (h flatHost) UnsetIndex(container, key any) error {
 func (h flatHost) SetIndex(base, key, value any, appendValue bool, op string) error {
 	array, ok := base.(*model.Array)
 	if !ok {
-		return fmt.Errorf("assign: target is not an array")
+		// Native Go collections are writable where Go itself allows it, the
+		// same as in the interpreter: only `$a[] =` needs an *Array, since a
+		// slice cannot grow through the interface holding it.
+		if appendValue {
+			return fmt.Errorf("assign: cannot append to %T; a binding whose result is appended to must return *model.Array", base)
+		}
+		return assignGoIndex(base, key, func(current any) any {
+			return applyAssignOp(op, current, value)
+		})
 	}
 	if appendValue {
 		array.Append(value)

--- a/runner/transpile.go
+++ b/runner/transpile.go
@@ -308,28 +308,17 @@ func (t *Transpiler) emit(e model.Expr) (string, error) {
 	}
 }
 
-// byRefArgs lists, per function, the argument positions that are passed by
-// reference (output parameters). minitpl only needs preg_match_all's $matches.
-var byRefArgs = map[string]map[int]bool{
-	"preg_match_all": {2: true},
-	"preg_match":     {2: true},
-}
-
 // emitCall emits a free-function call. Free functions resolve from the env by
 // name (forwarded Go symbols or user-registered/PHP functions); expr-lang
 // builtins are disabled at compile time so PHP names like `count` never collide.
 // By-reference output arguments that are plain variables are emitted as __ref
 // setters so the shim can write the result back into scope.
 func (t *Transpiler) emitCall(n *model.Call) (string, error) {
-	// Inside a namespaced file Name is qualified ("MiniTPL\preg_match_all") and
-	// only Fallback carries the global name the by-reference table is keyed by.
-	refs := byRefArgs[n.Name]
-	if refs == nil && n.Fallback != "" {
-		refs = byRefArgs[n.Fallback]
-	}
 	args := make([]string, 0, len(n.Args))
 	for i, a := range n.Args {
-		if refs[i] {
+		// Inside a namespaced file Name is qualified ("MiniTPL\preg_match_all")
+		// and only Fallback carries the global name the table is keyed by.
+		if model.ByRefArg(n.Name, n.Fallback, i) {
 			if v, ok := model.UnwrapParenthesized(a).(*model.Var); ok {
 				t.addVar(v.Name)
 				args = append(args, "__ref("+strconv.Quote(v.Name)+")")

--- a/tests/fixture.go
+++ b/tests/fixture.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -91,9 +92,9 @@ type FixtureResponse struct {
 type Fixture struct {
 	Name        string          `yaml:"name"`
 	Description string          `yaml:"description"`
-	Error       string          `yaml:"error"`     // optional: expected uncaught error substring
-	Stdin       string          `yaml:"stdin"`     // optional: top-level stdin contents
-	Flatstack   bool            `yaml:"flatstack"` // optional: also test on flatstack bytecode
+	Error       string          `yaml:"error"`  // optional: expected uncaught error substring
+	Stdin       string          `yaml:"stdin"`  // optional: top-level stdin contents
+	Runner      FixtureRunners  `yaml:"runner"` // optional: runners the fixture opts out of
 	Request     FixtureRequest  `yaml:"request"`
 	Response    FixtureResponse `yaml:"response"`
 
@@ -119,7 +120,8 @@ type TestResult struct {
 	GotOutput     string `json:"got_output,omitempty"`
 	WantOutput    string `json:"want_output,omitempty"`
 	Error         string `json:"error,omitempty"`
-	FlatstackUsed bool   `json:"flatstack_used,omitempty"`
+	Runner        Runner `json:"runner,omitempty"`
+	Skipped       bool   `json:"skipped,omitempty"`
 }
 
 // ParseFixture splits a .phpt file into its three sections and parses the YAML metadata.
@@ -233,13 +235,21 @@ func loadFixtureFile(path string) (*Fixture, error) {
 	return fx, nil
 }
 
-// RunFixture executes a single fixture against the runner (and flatstack if requested).
+// RunFixture executes a single fixture against the default runtime.
 func RunFixture(ctx context.Context, f *Fixture) *TestResult {
+	return RunFixtureOn(ctx, f, RunnerRuntime)
+}
+
+// RunFixtureOn executes a single fixture against one runner. Every runner is
+// held to the same expected output; the runner only decides how the source is
+// executed.
+func RunFixtureOn(ctx context.Context, f *Fixture, r Runner) *TestResult {
 	start := time.Now()
 	res := &TestResult{
 		Name:        f.Name,
 		Description: f.Description,
 		Path:        f.Path,
+		Runner:      r,
 	}
 
 	if os.Getenv("DB_DSN_SQLITE_TEST") == "" {
@@ -250,73 +260,75 @@ func RunFixture(ctx context.Context, f *Fixture) *TestResult {
 		ctx = context.WithValue(ctx, tenantKey, "acme")
 	}
 
-	out, reqCtx, runErr := executeFixturePHP(ctx, f)
+	var (
+		out      string
+		runErr   error
+		headers  http.Header
+		hostFail string
+	)
+
+	switch r {
+	case RunnerFlatstack:
+		var reqCtx runner.Context
+		out, reqCtx, runErr = executeFlatstack(ctx, f)
+		headers = reqCtx.ResponseHeaders()
+	case RunnerPHP:
+		php, hostErr := executePHP(ctx, f)
+		if hostErr != nil {
+			res.Skipped = errors.Is(hostErr, ErrRunnerUnavailable)
+			res.FailureReason = hostErr.Error()
+			res.Error = hostErr.Error()
+			res.DurationMs = time.Since(start).Milliseconds()
+			return res
+		}
+		out = php.Stdout
+		runErr = phpFatal(php.Stderr)
+		hostFail = php.diagnostics()
+	default:
+		var reqCtx runner.Context
+		out, reqCtx, runErr = executeFixturePHP(ctx, f)
+		headers = reqCtx.ResponseHeaders()
+	}
+
 	res.GotOutput = out
 	res.WantOutput = strings.TrimSuffix(f.Expected, "\n")
 	res.DurationMs = time.Since(start).Milliseconds()
 
 	if f.Error != "" {
 		if runErr == nil {
-			res.Passed = false
 			res.FailureReason = fmt.Sprintf("expected uncaught error containing %q, but execution succeeded with output %q", f.Error, out)
 			return res
 		}
 		if !errorChainContains(runErr, f.Error) {
-			res.Passed = false
 			res.FailureReason = fmt.Sprintf("uncaught error %q does not contain expected substring %q", runErr.Error(), f.Error)
 			res.Error = runErr.Error()
 			return res
 		}
 	} else if runErr != nil {
-		res.Passed = false
 		res.FailureReason = fmt.Sprintf("unexpected uncaught error: %v", runErr)
 		res.Error = runErr.Error()
 		return res
 	}
 
-	// Verify response.headers if specified
-	if len(f.Response.Headers) > 0 {
-		stagedHeaders := reqCtx.ResponseHeaders()
+	// Response headers are staged by the host, so only an in-process runner can
+	// be held to them.
+	if headers != nil {
 		for k, wantVal := range f.Response.Headers {
-			gotVal := stagedHeaders.Get(k)
+			gotVal := headers.Get(k)
 			if gotVal != wantVal {
-				res.Passed = false
 				res.FailureReason = fmt.Sprintf("header mismatch for %s: got %q, want %q", k, gotVal, wantVal)
 				return res
 			}
 		}
 	}
 
-	// Compare stdout
 	gotTrim := strings.TrimSuffix(out, "\n")
 	if gotTrim != res.WantOutput {
-		res.Passed = false
 		res.FailureReason = fmt.Sprintf("output mismatch:\n  got:  %q\n  want: %q", gotTrim, res.WantOutput)
-		return res
-	}
-
-	// If flatstack execution is requested, also run via Flatstack
-	if f.Flatstack {
-		res.FlatstackUsed = true
-		flatOut, flatErr := executeFlatstack(ctx, f)
-		if f.Error != "" {
-			if flatErr == nil {
-				res.Passed = false
-				res.FailureReason = fmt.Sprintf("[flatstack] expected error containing %q, but succeeded", f.Error)
-				return res
-			}
-		} else if flatErr != nil {
-			res.Passed = false
-			res.FailureReason = fmt.Sprintf("[flatstack] unexpected error: %v", flatErr)
-			return res
-		} else {
-			flatTrim := strings.TrimSuffix(flatOut, "\n")
-			if flatTrim != res.WantOutput {
-				res.Passed = false
-				res.FailureReason = fmt.Sprintf("[flatstack] output mismatch:\n  got:  %q\n  want: %q", flatTrim, res.WantOutput)
-				return res
-			}
+		if hostFail != "" {
+			res.FailureReason += "\n  " + hostFail
 		}
+		return res
 	}
 
 	res.Passed = true
@@ -380,43 +392,43 @@ func executeFixturePHP(ctx context.Context, f *Fixture) (string, runner.Context,
 	return out.String(), reqCtx, nil
 }
 
-func executeFlatstack(ctx context.Context, f *Fixture) (string, error) {
+// executeFlatstack mirrors executeFixturePHP on the flat bytecode runtime, so
+// both in-process runners are held to the same host behavior: an uncaught
+// error produces the host error body, and the fixture request is registered.
+func executeFlatstack(ctx context.Context, f *Fixture) (string, runner.Context, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	prog, err := f.program()
 	if err != nil {
-		return "", err
-	}
-	if f.flatRT == nil {
-		if err := flatstack.Supports(prog); err != nil {
-			return "", fmt.Errorf("flatstack unsupported: %w", err)
-		}
+		return "Internal Server Error", runner.Context{}, err
 	}
 
 	var out strings.Builder
+	reqCtx := buildFixtureRequestContext(f)
 	if f.flatRT == nil {
-		f.flatRT = newFlatstackTestRuntime(&out, ctx, f.stdin())
+		f.flatRT = newFlatstackTestRuntime(&out, f.stdin())
 		f.flatRT.FreezeStdlib()
 	} else {
 		f.flatRT.ResetSession(&out, f.stdin())
-		f.flatRT.SetContext(context.WithValue(ctx, tenantKey, "acme"))
 	}
+	f.flatRT.SetContext(ctx)
+	reqCtx.Register(f.flatRT)
+
 	if err := f.flatRT.Run(prog); err != nil {
 		if _, ok := flatstack.IsExit(err); ok {
-			return out.String(), nil
+			return out.String(), reqCtx, nil
 		}
-		return out.String(), err
+		return "Internal Server Error", reqCtx, err
 	}
-	return out.String(), nil
+	return out.String(), reqCtx, nil
 }
 
-func newFlatstackTestRuntime(out *strings.Builder, ctx context.Context, input io.Reader) *flatstack.Runtime {
+func newFlatstackTestRuntime(out *strings.Builder, input io.Reader) *flatstack.Runtime {
 	options := flatstack.Options{RootFS: testPHPFS(), Stdin: input}
 	runtime := flatstack.New(out, options)
 	runtime.SetIncludeCache(flatIncludeCache)
 	runtime.SetExprCache(flatExprCache)
-	runtime.SetContext(context.WithValue(ctx, tenantKey, "acme"))
 	runtime.RegisterConstructor("Storage", NewStorage)
 	runtime.RegisterConstructor("FailStorage", NewFailStorage)
 	registerPanicBindings(runtime)

--- a/tests/fixture_test.go
+++ b/tests/fixture_test.go
@@ -40,9 +40,8 @@ import (
 type fixture struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
-	Error       string `yaml:"error"`     // optional: expected error substring
-	Stdin       string `yaml:"stdin"`     // optional: runtime STDIN contents
-	Flatstack   bool   `yaml:"flatstack"` // optional: run through flat bytecode fixtures
+	Error       string `yaml:"error"` // optional: expected error substring
+	Stdin       string `yaml:"stdin"` // optional: runtime STDIN contents
 
 	PHP      string `yaml:"-"`
 	Expected string `yaml:"-"`

--- a/tests/fixtures/argument_count.phpt
+++ b/tests/fixtures/argument_count.phpt
@@ -1,5 +1,4 @@
 name: a surplus argument is thrown and catchable
-flatstack: true
 description: >
   Passing more arguments than a binding declares is refused rather than
   silently ignored, and the refusal is a throwable a script can catch, so

--- a/tests/fixtures/array_indexing.phpt
+++ b/tests/fixtures/array_indexing.phpt
@@ -1,5 +1,4 @@
 name: array indexing
-flatstack: true
 description: >
   Test nested array reads and minitpl-style foreach targets.
 ---

--- a/tests/fixtures/autoloading_default.phpt
+++ b/tests/fixtures/autoloading_default.phpt
@@ -1,5 +1,4 @@
 name: default spl autoloading
-flatstack: true
 description: >
   Registering spl_autoload without a callback searches the configured include
   path for the lowercased namespaced class name with PHP file extensions.

--- a/tests/fixtures/autoloading_missing.phpt
+++ b/tests/fixtures/autoloading_missing.phpt
@@ -1,5 +1,4 @@
 name: undefined class without autoloader
-flatstack: true
 description: >
   No class autoloader exists unless spl_autoload_register is invoked, so an
   undefined class construction throws an error that PHP code can catch.

--- a/tests/fixtures/condition_syntax.phpt
+++ b/tests/fixtures/condition_syntax.phpt
@@ -1,9 +1,11 @@
 name: condition syntax
-flatstack: true
+runner:
+  php: false
 description: >
   Covers parenthesized PHP-style if conditions, phpscript's unwrapped short-if
   condition, and runtime compatibility for assignment expressions inside if
   conditions. Use `phpscript lint` to report assignment-in-condition syntax.
+  The short-if form is a phpscript extension that PHP rejects at parse time.
 ---
 <?php
 $foo = false;

--- a/tests/fixtures/database_migrate.phpt
+++ b/tests/fixtures/database_migrate.phpt
@@ -1,4 +1,6 @@
 name: database migrations
+runner:
+  php: false
 description: Database\Migrate loads and runs SQL migrations against a named sqlite database.
 ---
 <?php

--- a/tests/fixtures/database_property_access.phpt
+++ b/tests/fixtures/database_property_access.phpt
@@ -1,5 +1,6 @@
 name: database binding property access
-flatstack: true
+runner:
+  php: false
 description: >
   A property of a Go binding resolves the way its methods do: $db->is_readonly
   reads and writes the field IsReadonly, folding case and underscores the same

--- a/tests/fixtures/database_property_unwritable.phpt
+++ b/tests/fixtures/database_property_unwritable.phpt
@@ -1,5 +1,6 @@
 name: database binding property is not writable
-flatstack: true
+runner:
+  php: false
 description: >
   Only an exported field is a writable property. Assigning anything else throws
   rather than quietly doing nothing: an assignment that looks like it took

--- a/tests/fixtures/database_readonly.phpt
+++ b/tests/fixtures/database_readonly.phpt
@@ -1,5 +1,6 @@
 name: database read-only client
-flatstack: true
+runner:
+  php: false
 description: >
   $db->is_readonly restricts a client to statements that only read, and refuses
   everything else. The CRUD helpers are refused before a statement is built;

--- a/tests/fixtures/database_test.phpt
+++ b/tests/fixtures/database_test.phpt
@@ -1,4 +1,6 @@
 name: database bridge
+runner:
+  php: false
 description: Database.php can use the Go-backed Database with sqlite.
 ---
 <?php

--- a/tests/fixtures/defer-usage.phpt
+++ b/tests/fixtures/defer-usage.phpt
@@ -1,7 +1,10 @@
 name: deferred function usage
+runner:
+  php: false
 description: >
   A deferred function runs when the current file finishes, after the rest of
-  the file has produced its output.
+  the file has produced its output. defer() is a phpscript extension, so there
+  is no PHP behavior to compare against.
 ---
 <?php
 

--- a/tests/fixtures/die_exit.phpt
+++ b/tests/fixtures/die_exit.phpt
@@ -1,5 +1,4 @@
 name: die_exit
-flatstack: true
 description: >
   die interrupts execution without producing an HTTP-style host error. A string
   argument is a message and is printed; an integer argument is an exit status.

--- a/tests/fixtures/die_message.phpt
+++ b/tests/fixtures/die_message.phpt
@@ -1,5 +1,4 @@
 name: die_message
-flatstack: true
 description: >
   A string passed to die/exit is a message: it is printed before execution
   stops, and it is not read as an exit status.

--- a/tests/fixtures/exception.phpt
+++ b/tests/fixtures/exception.phpt
@@ -1,8 +1,10 @@
 name: exception (uncaught)
-flatstack: true
+runner:
+  php: false
 description: >
   An exception has to be thrown to cause an error.
-  An uncaught exception results in an internal server error.
+  An uncaught exception results in an internal server error. The host error
+  body is the runtime's contract, not something the PHP CLI produces.
 error: boom
 ---
 <?php

--- a/tests/fixtures/exception_methods.phpt
+++ b/tests/fixtures/exception_methods.phpt
@@ -1,5 +1,4 @@
 name: a caught throwable answers the Throwable methods
-flatstack: true
 description: >
   throw propagates the object a script threw rather than a rendering of it, so
   a catch clause binds the instance and getMessage() and getCode() report what

--- a/tests/fixtures/exception_response_code.phpt
+++ b/tests/fixtures/exception_response_code.phpt
@@ -1,5 +1,4 @@
 name: exception (caught)
-flatstack: true
 description: >
   A caught exception can be handled with it's `getCode` and `getMessage`
   methods. If you use the variable `$e` itself, it only prints the message.

--- a/tests/fixtures/flatstack_arithmetic.phpt
+++ b/tests/fixtures/flatstack_arithmetic.phpt
@@ -1,6 +1,5 @@
 name: flatstack arithmetic
 description: Arithmetic expressions execute through native flat bytecode.
-flatstack: true
 ---
 <?php echo 20 + 22; ?>
 ---

--- a/tests/fixtures/flatstack_destructuring_assignment.phpt
+++ b/tests/fixtures/flatstack_destructuring_assignment.phpt
@@ -1,6 +1,5 @@
 name: flatstack destructuring assignment
 description: List destructuring assignments execute through native flat bytecode.
-flatstack: true
 ---
 <?php
 $arr = [10, 20, 30];

--- a/tests/fixtures/flatstack_runner_compatible_fast_path.phpt
+++ b/tests/fixtures/flatstack_runner_compatible_fast_path.phpt
@@ -1,8 +1,9 @@
 name: flatstack runner-compatible fast path
+runner:
+  php: false
 description: >
   A Go-backed constructor, context injection, method calls, and returned struct
   property access all execute through native flat bytecode.
-flatstack: true
 ---
 <?php
 $storage = new Storage;

--- a/tests/fixtures/get_included_files.phpt
+++ b/tests/fixtures/get_included_files.phpt
@@ -1,5 +1,9 @@
 name: get_included_files
-description: get_included_files returns included dirFS filenames.
+runner:
+  php: false
+description: >
+  get_included_files returns included dirFS filenames. The list names the
+  runtime root filesystem, so only phpscript defines the expected output.
 ---
 <?php
 include("modules/menu.php");

--- a/tests/fixtures/host_panic_catch.phpt
+++ b/tests/fixtures/host_panic_catch.phpt
@@ -1,5 +1,6 @@
 name: host panic becomes a catchable exception
-flatstack: true
+runner:
+  php: false
 description: >
   A panic raised inside a registered Go binding is converted into a PHP
   exception at the call boundary, so try/catch handles it and the script keeps

--- a/tests/fixtures/object_nesting.phpt
+++ b/tests/fixtures/object_nesting.phpt
@@ -1,6 +1,10 @@
 name: object and value nesting
+runner:
+  php: false
 description: >
   Test chained property, method, and array access in reads and foreach sources.
+  The classes declare PHP 4 style constructors, which minitpl relies on and
+  PHP 8 removed, so the expected output is phpscript's contract.
 ---
 <?php
 class Leaf {

--- a/tests/fixtures/pass_by_ref.phpt
+++ b/tests/fixtures/pass_by_ref.phpt
@@ -1,5 +1,4 @@
 name: foreach by value and by reference
-flatstack: true
 description: >
   `foreach ($a as $v)` binds a copy of the element, so writing through the loop
   variable leaves the source alone; `foreach ($a as &$v)` binds the element, so

--- a/tests/fixtures/php_array_splice.phpt
+++ b/tests/fixtures/php_array_splice.phpt
@@ -1,5 +1,4 @@
 name: Array splice tests
-flatstack: true
 description: Mainly tests array_splice.
 ---
 <?php

--- a/tests/fixtures/php_foreach_syntax.phpt
+++ b/tests/fixtures/php_foreach_syntax.phpt
@@ -1,5 +1,4 @@
 name: if + foreach + else syntax usage
-flatstack: true
 description: >
   Conditions in php allow to skip braces making the following example a common
   pattern to manage output in case no array data is available to foreach over.

--- a/tests/fixtures/platform_database.phpt
+++ b/tests/fixtures/platform_database.phpt
@@ -1,4 +1,6 @@
 name: database bridge
+runner:
+  php: false
 description: Database.php can use the Go-backed Database with sqlite.
 ---
 <?php

--- a/tests/fixtures/request_and_response_handling.phpt
+++ b/tests/fixtures/request_and_response_handling.phpt
@@ -1,6 +1,11 @@
 ---
 name: request and response handling
-description: Reads GET, POST, cookie, command-line, and stdin request data and sets response headers.
+runner:
+  php: false
+description: >
+  Reads GET, POST, cookie, command-line, and stdin request data and sets
+  response headers. The harness supplies the request, which the PHP CLI SAPI
+  has no equivalent of.
 
 request:
   args:

--- a/tests/fixtures/runtime_introspection.phpt
+++ b/tests/fixtures/runtime_introspection.phpt
@@ -1,7 +1,10 @@
 name: runtime introspection functions
+runner:
+  php: false
 description: >
   Runtime symbol APIs expose constants, internal and user functions, local
-  variables, and both PHP and host-backed classes.
+  variables, and both PHP and host-backed classes. The symbols named are
+  phpscript's, so PHP has no comparable output.
 ---
 <?php
 

--- a/tests/fixtures/session_manager.phpt
+++ b/tests/fixtures/session_manager.phpt
@@ -1,4 +1,6 @@
 name: session manager and storage bindings
+runner:
+  php: false
 description: Session storage constructors are available to PHP and the manager validates, starts, and reads HTTP-only cookie-backed sessions.
 request:
   cookie:

--- a/tests/fixtures/sort.phpt
+++ b/tests/fixtures/sort.phpt
@@ -1,5 +1,4 @@
 name: sort
-flatstack: true
 description: >
   sort and rsort order a list in place with PHP's comparison operator,
   reindexing the keys from zero: numbers and numeric strings compare as

--- a/tests/fixtures/stdin.phpt
+++ b/tests/fixtures/stdin.phpt
@@ -1,5 +1,4 @@
 name: stdin
-flatstack: true
 description: >
   STDIN is a readable stream backed by the runtime input reader.
 stdin: "name=catalogue&column_count=6"

--- a/tests/fixtures/storage_constructor_error.phpt
+++ b/tests/fixtures/storage_constructor_error.phpt
@@ -1,5 +1,6 @@
 name: storage constructor error (uncaught)
-flatstack: true
+runner:
+  php: false
 description: >
   A constructor returning an error surfaces as a thrown error: `new FailStorage`
   fails. Uncaught, execution aborts and the host renders an "Internal Server

--- a/tests/fixtures/storage_constructor_error_caught.phpt
+++ b/tests/fixtures/storage_constructor_error_caught.phpt
@@ -1,5 +1,6 @@
 name: storage constructor error (caught)
-flatstack: true
+runner:
+  php: false
 description: >
   A failing constructor can be caught with try/catch. `new FailStorage` raises,
   the error is bound to $e, and `echo $e` prints its message; execution then

--- a/tests/fixtures/storage_context.phpt
+++ b/tests/fixtures/storage_context.phpt
@@ -1,5 +1,6 @@
 name: storage context injection
-flatstack: true
+runner:
+  php: false
 description: >
   The runtime's context.Context is auto-injected into the constructor (mirroring
   vuego's wrapContextFunc). A value placed on the context — the tenant — is

--- a/tests/fixtures/storage_lifecycle.phpt
+++ b/tests/fixtures/storage_lifecycle.phpt
@@ -1,5 +1,6 @@
 name: storage lifecycle
-flatstack: true
+runner:
+  php: false
 description: >
   `new Storage` constructs a Go-backed value via the registered constructor
   (with the context auto-injected). get() returns a rich Record struct; its

--- a/tests/fixtures/storage_list.phpt
+++ b/tests/fixtures/storage_list.phpt
@@ -1,5 +1,6 @@
 name: storage list of rich types
-flatstack: true
+runner:
+  php: false
 description: >
   all() returns a Go slice of rich Record structs. PHP foreach iterates the Go
   slice directly, and each element's struct fields are read with `->`. This

--- a/tests/fixtures/storage_method_error.phpt
+++ b/tests/fixtures/storage_method_error.phpt
@@ -1,5 +1,6 @@
 name: storage method error (uncaught)
-flatstack: true
+runner:
+  php: false
 description: >
   A method's trailing Go error (omitted from the PHP assignment) is surfaced as
   a thrown error. Uncaught, it aborts execution and the host renders an

--- a/tests/fixtures/storage_method_error_caught.phpt
+++ b/tests/fixtures/storage_method_error_caught.phpt
@@ -1,5 +1,6 @@
 name: storage method error (caught)
-flatstack: true
+runner:
+  php: false
 description: >
   A method's error can be caught with try/catch. The caught exception is bound
   to $e, and `echo $e` prints its message — so execution continues normally and

--- a/tests/fixtures/string_argument_coercion.phpt
+++ b/tests/fixtures/string_argument_coercion.phpt
@@ -1,5 +1,4 @@
 name: string arguments coerce the way PHP renders values
-flatstack: true
 description: >
   A value passed where a binding declares a string parameter is rendered the
   way PHP renders it in a string context, so strlen(65) measures "65" and not

--- a/tests/fixtures/token_get_all.phpt
+++ b/tests/fixtures/token_get_all.phpt
@@ -36,9 +36,8 @@ echo "arrows:" . $arrows . "\n";
 echo "vars:" . implode(",", $variables) . "\n";
 echo "rewritten:" . $tokens[0][0] . "\n";
 ---
-count:13
-arr:3:T_OPEN_TAG:<?php:1
-arr:3:T_WHITESPACE: :1
+count:12
+arr:3:T_OPEN_TAG:<?php :1
 arr:3:T_IF:if:1
 arr:3:T_WHITESPACE: :1
 chr:(

--- a/tests/fixtures/user_function_declaration_and_call.phpt
+++ b/tests/fixtures/user_function_declaration_and_call.phpt
@@ -1,5 +1,4 @@
 name: user function declaration and call
-flatstack: true
 description: >
   Test that user function declarations, argument binding, return values, and
   calls compile to and execute with flat bytecode.

--- a/tests/flatstack_fixture_test.go
+++ b/tests/flatstack_fixture_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 )
 
-// TestFlatstackFixtures runs opted-in fixtures through flat bytecode.
+// TestFlatstackFixtures runs every fixture through the flat bytecode runtime,
+// which falls back to the compatibility interpreter for syntax it does not
+// compile yet.
 func TestFlatstackFixtures(t *testing.T) {
 	entries, err := fs.ReadDir(fixturesFS, "fixtures")
 	if err != nil {
@@ -25,12 +27,12 @@ func TestFlatstackFixtures(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !fx.Flatstack {
+		if !fx.Runs(RunnerFlatstack) {
 			continue
 		}
 		selected++
 		t.Run(fx.Name, func(t *testing.T) {
-			res := RunFixture(t.Context(), fx)
+			res := RunFixtureOn(t.Context(), fx, RunnerFlatstack)
 			if !res.Passed {
 				t.Fatalf("flatstack fixture failed: %s", res.FailureReason)
 			}

--- a/tests/matrix.go
+++ b/tests/matrix.go
@@ -1,0 +1,188 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Runner names an execution backend a fixture can be checked against.
+type Runner string
+
+const (
+	// RunnerFlatstack executes the fixture through the flat bytecode runtime,
+	// which falls back to the compatibility interpreter for unsupported syntax.
+	RunnerFlatstack Runner = "flatstack"
+
+	// RunnerRuntime executes the fixture through the default interpreter.
+	RunnerRuntime Runner = "runtime"
+
+	// RunnerPHP executes the fixture through the php binary found in PATH.
+	RunnerPHP Runner = "php"
+)
+
+// Runners lists every backend the test matrix covers, in report order.
+var Runners = []Runner{RunnerFlatstack, RunnerRuntime, RunnerPHP}
+
+// ErrRunnerUnavailable reports that a runner cannot execute on this machine,
+// which is a skip rather than a failure. The php runner returns it when no php
+// binary is installed.
+var ErrRunnerUnavailable = errors.New("runner unavailable")
+
+// FixtureRunners opts a fixture out of individual runners. An absent field
+// means the runner is used; the default runtime can not be opted out of
+// because it defines the fixture's expected output.
+type FixtureRunners struct {
+	Flatstack *bool `yaml:"flatstack"`
+	PHP       *bool `yaml:"php"`
+}
+
+// Runs reports whether the fixture is checked against r.
+func (f *Fixture) Runs(r Runner) bool {
+	switch r {
+	case RunnerFlatstack:
+		return f.Runner.Flatstack == nil || *f.Runner.Flatstack
+	case RunnerPHP:
+		return f.Runner.PHP == nil || *f.Runner.PHP
+	default:
+		return true
+	}
+}
+
+// phpRun is the outcome of one php binary execution.
+type phpRun struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// executePHP runs the fixture source through the php binary. The script is
+// written next to the fixture so relative includes and __DIR__ resolve the way
+// they do for the runtime, whose root filesystem is the fixture directory.
+func executePHP(ctx context.Context, f *Fixture) (phpRun, error) {
+	binary, err := exec.LookPath("php")
+	if err != nil {
+		return phpRun{}, fmt.Errorf("php: %w", ErrRunnerUnavailable)
+	}
+
+	dir := filepath.Dir(f.Path)
+	if f.Path == "" {
+		dir = "."
+	}
+	script, cleanup, err := writePHPScript(dir, f)
+	if err != nil {
+		return phpRun{}, err
+	}
+	defer cleanup()
+
+	// The fixture output is the contract, so error display is pinned to stderr
+	// and log duplication is turned off; a php.ini differing per machine would
+	// otherwise decide whether a warning lands in the compared stdout.
+	args := []string{
+		"-d", "display_errors=stderr",
+		"-d", "log_errors=0",
+		"-d", "error_reporting=E_ALL",
+		"-d", "variables_order=EGPCS",
+		script,
+	}
+	if f.Request.Args != nil {
+		// parseArgs names the script itself first, the way $argv does.
+		args = append(args, parseArgs(f.Request.Args, f.Path)[1:]...)
+	}
+
+	var stdout, stderr strings.Builder
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = dir
+	cmd.Stdin = f.stdin()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = phpEnv(f)
+
+	runErr := cmd.Run()
+	// php names the file it ran, which is the throwaway copy; the fixture is
+	// what a reader of the failure has in front of them.
+	absolute, absErr := filepath.Abs(filepath.Join(dir, script))
+	if absErr != nil {
+		absolute = filepath.Join(dir, script)
+	}
+	message := strings.NewReplacer(
+		absolute, f.Path,
+		filepath.Join(dir, script), f.Path,
+		script, filepath.Base(f.Path),
+	).Replace(stderr.String())
+	out := phpRun{Stdout: stdout.String(), Stderr: message}
+
+	var exitErr *exec.ExitError
+	switch {
+	case runErr == nil:
+	case errors.As(runErr, &exitErr):
+		out.ExitCode = exitErr.ExitCode()
+	default:
+		return out, fmt.Errorf("run php: %w", runErr)
+	}
+	return out, nil
+}
+
+// writePHPScript materializes the fixture source as a hidden file in dir. The
+// name is derived from the fixture path so parallel fixtures never collide.
+func writePHPScript(dir string, f *Fixture) (string, func(), error) {
+	base := strings.TrimSuffix(filepath.Base(f.Path), ".phpt")
+	if base == "" || base == "." {
+		base = "fixture"
+	}
+	file, err := os.CreateTemp(dir, "."+base+".*.php")
+	if err != nil {
+		return "", nil, fmt.Errorf("write php script: %w", err)
+	}
+	name := file.Name()
+	cleanup := func() { os.Remove(name) }
+	if _, err := file.WriteString(f.PHP); err != nil {
+		file.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write php script: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("write php script: %w", err)
+	}
+	return filepath.Base(name), cleanup, nil
+}
+
+// phpEnv extends the process environment with the fixture request environment.
+func phpEnv(f *Fixture) []string {
+	if len(f.Request.Env) == 0 {
+		return nil
+	}
+	env := os.Environ()
+	for k, v := range f.Request.Env {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// phpFatal reports whether stderr carries an engine failure. An exit status is
+// not enough on its own: a script chooses its own status through exit().
+func phpFatal(stderr string) error {
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.Contains(line, "Fatal error") || strings.Contains(line, "Parse error") {
+			return errors.New(strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+// diagnostics summarizes the php process outcome for a failure report.
+func (r phpRun) diagnostics() string {
+	parts := make([]string, 0, 2)
+	if r.ExitCode != 0 {
+		parts = append(parts, fmt.Sprintf("php exit status %d", r.ExitCode))
+	}
+	if stderr := strings.TrimSpace(r.Stderr); stderr != "" {
+		parts = append(parts, "php stderr: "+strings.ReplaceAll(stderr, "\n", "; "))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/tests/matrix_test.go
+++ b/tests/matrix_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestFixtureRunsMetadata(t *testing.T) {
+	cases := []struct {
+		name      string
+		metadata  string
+		flatstack bool
+		php       bool
+	}{
+		{"default", "", true, true},
+		{"php opted out", "runner:\n  php: false\n", true, false},
+		{"flatstack opted out", "runner:\n  flatstack: false\n", false, true},
+		{"both opted in", "runner:\n  flatstack: true\n  php: true\n", true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := "name: metadata\ndescription: runner metadata\n" + c.metadata + "---\n<?php echo \"ok\";\n---\nok"
+			fx, err := ParseFixture([]byte(src), "metadata.phpt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fx.Runs(RunnerFlatstack); got != c.flatstack {
+				t.Errorf("Runs(flatstack) = %v, want %v", got, c.flatstack)
+			}
+			if got := fx.Runs(RunnerPHP); got != c.php {
+				t.Errorf("Runs(php) = %v, want %v", got, c.php)
+			}
+			// The runtime defines the expected output, so it can not be
+			// opted out of.
+			if !fx.Runs(RunnerRuntime) {
+				t.Error("Runs(runtime) = false, want true")
+			}
+		})
+	}
+}
+
+func TestRunFixtureOnPHP(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php binary is not installed")
+	}
+	fx, err := ParseFixture([]byte("name: php\ndescription: php binary run\nstdin: \"in\"\nrequest:\n  args: [\"one\"]\n---\n<?php\necho $argv[1] . stream_get_contents(STDIN);\nexit(3);\n---\nonein"), "fixtures/php.phpt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// exit(3) picks the process status, which is not a failure on its own.
+	res := RunFixtureOn(t.Context(), fx, RunnerPHP)
+	if !res.Passed {
+		t.Fatalf("fixture failed: %s", res.FailureReason)
+	}
+	if res.Runner != RunnerPHP {
+		t.Errorf("runner = %q, want %q", res.Runner, RunnerPHP)
+	}
+}
+
+func TestRunFixtureOnPHPReportsFatal(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php binary is not installed")
+	}
+	fx, err := ParseFixture([]byte("name: php fatal\ndescription: php binary failure\n---\n<?php\nthrow new Exception(\"boom\");\n---\nunreachable"), "fixtures/php_fatal.phpt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := RunFixtureOn(t.Context(), fx, RunnerPHP)
+	if res.Passed {
+		t.Fatal("fixture passed, want the fatal error reported")
+	}
+	if !strings.Contains(res.FailureReason, "boom") {
+		t.Errorf("failure reason = %q, want it to name the php error", res.FailureReason)
+	}
+	// The throwaway copy php ran is not what a reader has in front of them.
+	if strings.Contains(res.FailureReason, ".php_fatal.") {
+		t.Errorf("failure reason names the temporary script: %q", res.FailureReason)
+	}
+}
+
+func TestPHPFatalIgnoresWarnings(t *testing.T) {
+	if err := phpFatal("PHP Warning:  something in file on line 1\n"); err != nil {
+		t.Errorf("phpFatal(warning) = %v, want nil", err)
+	}
+	if err := phpFatal("PHP Fatal error:  Uncaught Error: boom\n"); err == nil {
+		t.Error("phpFatal(fatal) = nil, want an error")
+	}
+}


### PR DESCRIPTION
Closes #46.

`phpscript test --matrix` runs every `.phpt` fixture on the flat bytecode engine, the default interpreter, and the `php` binary, and prints one row per fixture with a cell per runtime. Any non-pass that is not a skip fails the run and the command exits non-zero. Every other `test` flag is honored.

```
| Fixture               | Flat stack | Runtime | PHP  |
|-----------------------|------------|---------|------|
| array_indexing.phpt   | PASS       | PASS    | PASS |
| storage_list.phpt     | PASS       | PASS    | SKIP |
```

- `--verbose` (`-v`) prints the failure of each runtime in continuation rows below its fixture, with the fixture column left empty.
- The table is ANSI in a terminal and markdown when piped.
- `--json` reports one row per fixture and runner.

## Fixture metadata

The `flatstack: true` hint is gone from all 31 fixtures that carried it; every fixture runs on every runtime. A fixture that one runtime cannot execute opts it out:

```yaml
runner:
  php: false
```

An omitted key means the runtime is used, and the default runtime cannot be opted out of because its output is what the expected-output section states. 23 fixtures opt out of php: host bindings, runtime introspection, harness request state, phpscript syntax php rejects, and the PHP 4 constructors `object_nesting.phpt` relies on.

## Defects the matrix found

Running everything everywhere surfaced four real bugs, fixed here:

- `flatHost.Echo` wrote to the base writer, so `ob_start()` captured nothing under flatstack.
- `flatHost.SetIndex` rejected native Go collections, so `$tok[0] = ...` on a slice a binding returned failed with "assign: target is not an array".
- The bytecode compiler passed output parameters by value, so `preg_match_all`'s `$matches` was never written back. It now emits an `opRef` setter bound to the caller's frame, reading the same `model.ByRefArg` table the interpreter does.
- `TokenGetAll` did not fold the whitespace ending `<?php` into `T_OPEN_TAG`, giving a script one token more than php for the same source.

The flatstack fixture harness also diverged from the runtime harness in ways unrelated to the engine: it did not register the fixture request (no `header()`, no superglobals) and returned buffered output instead of the host error body on an uncaught error. Both harnesses now behave the same.

## Verification

- `go test ./...` passes.
- `atkins` full pipeline passes, including the new `test:phpscript:matrix` job that runs the matrix over `tests/fixtures`.
- `phpscript test --matrix tests/fixtures` is green: 55 fixtures, no failures.