### PR TITLE
fix(flatstack): include extras, per-frame state, case-insensitive methods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,3 +123,10 @@ Memory reporting differs from PHP's allocator view:
   walks does not raise the peak, unlike PHP's allocator-level high-water mark.
 - Exceeding `memory_limit` raises a catchable `RuntimeException`; PHP treats
   it as a fatal error that `catch` cannot intercept.
+
+Includes:
+
+- `include` and `require` both abort the request when the file cannot be
+  loaded; PHP `include` emits a warning and continues.
+- Nested `class` declarations are a no-op (not registered), matching the
+  interpreter hoist; PHP registers them when the statement runs.

--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -141,7 +141,9 @@ Flat bytecode currently supports these statements:
 - `if`/`else`
 - `for`/`while` and `foreach`, including nested `break` and `continue`
 - `switch`, fallthrough, and `break`
-- `try`/`catch` and `throw` (a `finally` block still selects fallback)
+- `try`/`catch`/`finally` and `throw`
+- Top-level PHP class declarations (`new` and method calls already native)
+- `include` / `include_once` / `require` as statements or expressions
 
 It supports these expressions:
 
@@ -174,13 +176,13 @@ not a claim that half of the PHP language is implemented.
 The complete program atomically selects fallback when it contains any currently
 unsupported form. The major remaining forms are:
 
-- User function declarations/calls and `return`
-- PHP class declarations, property writes, class constants, and property
-  increment/decrement
-- Includes as statements or expressions
+- Property increment/decrement and class-constant / static-property forms
 - Closures and callback bodies
-- `finally`
+- `try` without a `catch` clause
 - Casts and destructuring/list assignment
+- PHP constructors (`__construct`) still run in the interpreter
+- Nested `class` declarations (same as the interpreter hoist)
+- Included files still execute through the interpreter
 
 These are not called "unsupported programs" at the public runtime boundary:
 they are valid phpscript programs and execute through runner. "Unsupported" in

--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -142,8 +142,9 @@ Flat bytecode currently supports these statements:
 - `for`/`while` and `foreach`, including nested `break` and `continue`
 - `switch`, fallthrough, and `break`
 - `try`/`catch`/`finally` and `throw`
-- Top-level PHP class declarations (`new` and method calls already native)
+- Top-level PHP class declarations and free function declarations
 - `include` / `include_once` / `require` as statements or expressions
+- `list()` / array destructuring assignment
 
 It supports these expressions:
 
@@ -179,10 +180,12 @@ unsupported form. The major remaining forms are:
 - Property increment/decrement and class-constant / static-property forms
 - Closures and callback bodies
 - `try` without a `catch` clause
-- Casts and destructuring/list assignment
+- Casts
 - PHP constructors (`__construct`) still run in the interpreter
-- Nested `class` declarations (same as the interpreter hoist)
+- Nested `class` declarations (no-op, same as the interpreter hoist; PHP registers them at runtime)
 - Included files still execute through the interpreter
+- `include` and `require` both fail the request on a missing file (PHP `include` is a warning)
+- A host without Include fails at `opInclude`, after earlier opcodes have run
 
 These are not called "unsupported programs" at the public runtime boundary:
 they are valid phpscript programs and execute through runner. "Unsupported" in
@@ -273,11 +276,10 @@ go test ./tests -run '^$' -fuzz '^FuzzFlatstackImportSwapFallback$' -fuzztime=30
 
 The highest-value next steps are:
 
-1. Add bytecode call frames for user functions, returns, and closures.
-2. Add PHP class declarations, object-property writes, and class constants.
-3. Integrate include compilation/execution while preserving include scope,
-   include-once state, return values, and autoload semantics.
-4. Complete exception `finally` semantics and remaining lvalue/cast forms.
+1. Compile included files to bytecode instead of the interpreter.
+2. Compile PHP constructors on the native path.
+3. Nested `class` declarations at runtime (PHP semantics).
+4. Complete exception `finally` semantics on `return`/`throw` and remaining lvalue/cast forms.
 5. Add instruction, call-depth, and deadline budgets to native execution.
 6. Pool operand/local/iterator storage to reduce per-run allocations.
 7. Cache native-rejection decisions and use a structural cache key where

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -155,6 +155,12 @@ func (c *compiler) stmt(stmt model.Stmt, path string) error {
 		c.emit(instruction{op: opPop})
 	case *model.FuncDecl:
 		if node.Class != "" {
+			for _, class := range c.program.classes {
+				if class.Name == node.Class {
+					class.Methods[node.Name] = node
+					break
+				}
+			}
 			return c.classMethod(node.Class, node, path)
 		}
 		return c.funcDecl(node, path)

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -37,6 +37,20 @@ func Compile(ast *model.Program) (program *Program, err error) {
 	}()
 	c := &compiler{locals: make(map[string]int)}
 	if ast != nil {
+		c.collectClasses(ast.Stmts)
+		for _, class := range c.program.classes {
+			for _, method := range class.Methods {
+				if method == nil {
+					continue
+				}
+				if method.Name == "__construct" || method.Name == class.Name {
+					continue
+				}
+				if err := c.classMethod(class.Name, method, "class."+class.Name+"."+method.Name); err != nil {
+					return nil, err
+				}
+			}
+		}
 		for i, stmt := range ast.Stmts {
 			if err := c.stmt(stmt, fmt.Sprintf("stmt[%d]", i)); err != nil {
 				return nil, err
@@ -131,9 +145,17 @@ func (c *compiler) stmt(stmt model.Stmt, path string) error {
 			return err
 		}
 		c.emit(instruction{op: opThrow})
+	case *model.ClassDecl:
+		// Top-level classes are hoisted before execution. Nested declarations
+		// are a no-op here, matching the interpreter.
+	case *model.Include:
+		if err := c.include(node, path); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opPop})
 	case *model.FuncDecl:
 		if node.Class != "" {
-			return unsupported(path, "class method decl %s::%s", node.Class, node.Name)
+			return c.classMethod(node.Class, node, path)
 		}
 		return c.funcDecl(node, path)
 	case *model.Return:
@@ -183,9 +205,98 @@ func (c *compiler) stmt(stmt model.Stmt, path string) error {
 	return nil
 }
 
+func (c *compiler) collectClasses(stmts []model.Stmt) {
+	for _, stmt := range stmts {
+		decl, ok := stmt.(*model.ClassDecl)
+		if !ok {
+			continue
+		}
+		class := &model.Class{
+			Name:    decl.Name,
+			Fields:  decl.Fields,
+			Statics: decl.Statics,
+			Consts:  decl.Consts,
+			Methods: make(map[string]*model.FuncDecl, len(decl.Methods)),
+		}
+		for _, method := range decl.Methods {
+			class.Methods[method.Name] = method
+		}
+		c.program.classes = append(c.program.classes, class)
+	}
+}
+
+func (c *compiler) classMethod(className string, node *model.FuncDecl, path string) error {
+	jumpAround := c.emit(instruction{op: opJump, target: -1})
+	funcPC := len(c.program.code)
+	enclosing := c.loops
+	c.loops = nil
+	defer func() { c.loops = enclosing }()
+	params := make([]string, 0, 1+len(node.Params))
+	params = append(params, "this")
+	_ = c.slot("this")
+	for _, param := range node.Params {
+		params = append(params, param.Name)
+		_ = c.slot(param.Name)
+	}
+	if err := c.block(node.Body, path+".body"); err != nil {
+		return err
+	}
+	c.emit(instruction{op: opPushConst, a: c.constant(nil)})
+	c.emit(instruction{op: opReturn})
+	c.program.code[jumpAround].target = len(c.program.code)
+	if c.program.userFuncs == nil {
+		c.program.userFuncs = make(map[string]userFuncDef)
+	}
+	c.program.userFuncs[className+"::"+node.Name] = userFuncDef{entryPC: funcPC, params: params}
+	return nil
+}
+
+func (c *compiler) ensureContainer(expr model.Expr, path string) error {
+	switch node := model.UnwrapParenthesized(expr).(type) {
+	case *model.Var:
+		c.emit(instruction{op: opLoad, a: c.slot(node.Name)})
+		c.emit(instruction{op: opEnsureArray})
+		c.emit(instruction{op: opDup})
+		c.emit(instruction{op: opStore, a: c.slot(node.Name)})
+		return nil
+	case *model.Index:
+		if node.Index == nil {
+			return unsupported(path, "append container")
+		}
+		if err := c.ensureContainer(node.Base, path+".base"); err != nil {
+			return err
+		}
+		if err := c.expr(node.Index, path+".index"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opVivifyIndex})
+		return nil
+	case *model.PropAccess:
+		if err := c.expr(node.Base, path+".base"); err != nil {
+			return err
+		}
+		c.emit(instruction{op: opVivifyProperty, name: node.Name})
+		return nil
+	default:
+		return c.expr(expr, path)
+	}
+}
+
+func (c *compiler) include(node *model.Include, path string) error {
+	if err := c.expr(node.Path, path+".path"); err != nil {
+		return err
+	}
+	once := 0
+	if node.Once {
+		once = 1
+	}
+	c.emit(instruction{op: opInclude, a: once, name: node.Keyword})
+	return nil
+}
+
 func (c *compiler) tryStmt(node *model.Try, path string) error {
-	if len(node.Catches) == 0 && len(node.Finally) == 0 {
-		return unsupported(path, "try without catch or finally")
+	if len(node.Catches) == 0 {
+		return unsupported(path, "try without catch")
 	}
 	catchSlot := -1
 	var catch *model.Catch
@@ -500,7 +611,7 @@ func (c *compiler) assignment(target model.Expr, operator string, value model.Ex
 		}
 		c.emit(instruction{op: opStore, a: c.slot(target.Name), b: boolInt(keep), name: operator, extra: constructorID})
 	case *model.Index:
-		if err := c.expr(target.Base, path+".target.base"); err != nil {
+		if err := c.ensureContainer(target.Base, path+".target.base"); err != nil {
 			return err
 		}
 		appendValue := target.Index == nil || operator == "[]="
@@ -656,6 +767,8 @@ func (c *compiler) expr(expr model.Expr, path string) error {
 			return unsupported(path, "assignment expression operator %q", node.Op)
 		}
 		return c.assignment(node.Target, node.Op, node.Value, true, path)
+	case *model.Include:
+		return c.include(node, path)
 	default:
 		return unsupported(path, "expression %T", expr)
 	}

--- a/flatstack/engine/program.go
+++ b/flatstack/engine/program.go
@@ -41,6 +41,10 @@ const (
 	opTryPop
 	opThrow
 	opReturn
+	opInclude
+	opEnsureArray
+	opVivifyIndex
+	opVivifyProperty
 )
 
 type instruction struct {
@@ -64,6 +68,7 @@ type Program struct {
 	constants  []any
 	localNames []string
 	userFuncs  map[string]userFuncDef
+	classes    []*model.Class
 }
 
 // Entry is one key/value pair produced for foreach.

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -51,12 +51,14 @@ type errorHandler struct {
 	start      int
 	end        int
 	stackDepth int
+	frameDepth int
 }
 
 type callFrame struct {
 	returnPC    int
 	locals      []any
 	initialized []bool
+	extras      map[string]any
 }
 
 // MemoryHost is an optional Host extension for memory accounting, discovered
@@ -98,14 +100,7 @@ func Run(program *Program, host Host) (err error) {
 			registrar.RegisterClass(class)
 		}
 	}
-	if registrar, ok := host.(interface{ RegisterUserFunc(string) }); ok {
-		for name := range program.userFuncs {
-			if strings.Contains(name, "::") {
-				continue
-			}
-			registrar.RegisterUserFunc(name)
-		}
-	}
+	extras := map[string]any{}
 	iterators := make(map[int]*iteratorState)
 	var handlers []errorHandler
 	var callFrames []callFrame
@@ -147,10 +142,20 @@ func Run(program *Program, host Host) (err error) {
 			clear(stack[handler.stackDepth:])
 			stack = stack[:handler.stackDepth]
 		}
+		for len(callFrames) > handler.frameDepth {
+			frame := callFrames[len(callFrames)-1]
+			callFrames = callFrames[:len(callFrames)-1]
+			locals = frame.locals
+			initialized = frame.initialized
+			extras = frame.extras
+			if extras == nil {
+				extras = map[string]any{}
+			}
+		}
 		for errors.Unwrap(runErr) != nil {
 			runErr = errors.Unwrap(runErr)
 		}
-		if handler.local >= 0 {
+		if handler.local >= 0 && handler.local < len(locals) {
 			locals[handler.local], initialized[handler.local] = runErr, true
 		}
 		pc = handler.target
@@ -218,6 +223,8 @@ func Run(program *Program, host Host) (err error) {
 		case opLoad:
 			if initialized[inst.a] {
 				stack = append(stack, locals[inst.a])
+			} else if extra, ok := extras[program.localNames[inst.a]]; ok {
+				stack = append(stack, extra)
 			} else {
 				stack = append(stack, host.Lookup(program.localNames[inst.a]))
 			}
@@ -417,17 +424,19 @@ func Run(program *Program, host Host) (err error) {
 			if argErr != nil {
 				return argErr
 			}
-			bindHostLocals(host, program, locals, initialized)
+			bindHostLocals(host, program, locals, initialized, extras)
 			var value any
 			if inst.op == opCall {
-				if def, ok := program.userFuncs[inst.name]; ok {
+				if def, ok := lookupUserFunc(program.userFuncs, inst.name); ok {
 					callFrames = append(callFrames, callFrame{
 						returnPC:    pc,
 						locals:      locals,
 						initialized: initialized,
+						extras:      extras,
 					})
 					locals = make([]any, len(program.localNames))
 					initialized = make([]bool, len(program.localNames))
+					extras = map[string]any{}
 					for i, paramName := range def.params {
 						if i < len(arguments) {
 							slot := -1
@@ -446,9 +455,10 @@ func Run(program *Program, host Host) (err error) {
 					continue
 				}
 				value, err = host.Call(inst.name, inst.extra, arguments)
-				applyHostLocals(host, program, locals, initialized)
+				applyHostLocals(host, program, locals, initialized, extras)
 			} else {
 				value, err = host.Construct(inst.name, arguments)
+				applyHostLocals(host, program, locals, initialized, extras)
 			}
 			if err != nil {
 				if handle(err) {
@@ -462,21 +472,23 @@ func Run(program *Program, host Host) (err error) {
 			if argErr != nil {
 				return argErr
 			}
-			bindHostLocals(host, program, locals, initialized)
+			bindHostLocals(host, program, locals, initialized, extras)
 			receiver, popErr := pop()
 			if popErr != nil {
 				return popErr
 			}
 			if obj, ok := receiver.(*model.Object); ok && obj.Class != nil {
 				key := obj.Class.Name + "::" + inst.name
-				if def, ok := program.userFuncs[key]; ok {
+				if def, ok := lookupUserFunc(program.userFuncs, key); ok {
 					callFrames = append(callFrames, callFrame{
 						returnPC:    pc,
 						locals:      locals,
 						initialized: initialized,
+						extras:      extras,
 					})
 					locals = make([]any, len(program.localNames))
 					initialized = make([]bool, len(program.localNames))
+					extras = map[string]any{}
 					bound := append([]any{receiver}, arguments...)
 					for i, paramName := range def.params {
 						if i >= len(bound) {
@@ -494,7 +506,7 @@ func Run(program *Program, host Host) (err error) {
 				}
 			}
 			value, callErr := host.CallMethod(receiver, inst.name, arguments)
-			applyHostLocals(host, program, locals, initialized)
+			applyHostLocals(host, program, locals, initialized, extras)
 			if callErr != nil {
 				if handle(callErr) {
 					continue
@@ -603,6 +615,7 @@ func Run(program *Program, host Host) (err error) {
 				start:      pc + 1,
 				end:        inst.b,
 				stackDepth: len(stack),
+				frameDepth: len(callFrames),
 			})
 		case opTryPop:
 			if len(handlers) == 0 {
@@ -636,6 +649,10 @@ func Run(program *Program, host Host) (err error) {
 				pc = lastFrame.returnPC
 				locals = lastFrame.locals
 				initialized = lastFrame.initialized
+				extras = lastFrame.extras
+				if extras == nil {
+					extras = map[string]any{}
+				}
 				stack = append(stack, retVal)
 			} else {
 				stack = append(stack, retVal)
@@ -691,10 +708,15 @@ func Run(program *Program, host Host) (err error) {
 			if popErr != nil {
 				return popErr
 			}
-			vars := make(map[string]any, len(program.localNames))
+			vars := make(map[string]any, len(program.localNames)+len(extras))
 			for i, name := range program.localNames {
 				if initialized[i] && (len(name) == 0 || name[0] != 0) {
 					vars[name] = locals[i]
+				}
+			}
+			for name, value := range extras {
+				if _, ok := vars[name]; !ok {
+					vars[name] = value
 				}
 			}
 			includer, ok := host.(interface {
@@ -710,7 +732,7 @@ func Run(program *Program, host Host) (err error) {
 				}
 				return includeErr
 			}
-			applyNamedValues(host, program, locals, initialized, exported, len(callFrames) == 0)
+			applyNamedValues(program, locals, initialized, extras, exported)
 			stack = append(stack, value)
 		default:
 			return fmt.Errorf("flatstack: pc %d: invalid opcode %d", pc, inst.op)
@@ -720,29 +742,34 @@ func Run(program *Program, host Host) (err error) {
 	return nil
 }
 
-func bindHostLocals(host Host, program *Program, locals []any, initialized []bool) {
+func bindHostLocals(host Host, program *Program, locals []any, initialized []bool, extras map[string]any) {
 	binder, ok := host.(interface{ BindLocals(map[string]any) })
 	if !ok {
 		return
 	}
-	vars := make(map[string]any, len(program.localNames))
+	vars := make(map[string]any, len(program.localNames)+len(extras))
 	for i, name := range program.localNames {
 		if initialized[i] && (len(name) == 0 || name[0] != 0) {
 			vars[name] = locals[i]
 		}
 	}
+	for name, value := range extras {
+		if _, ok := vars[name]; !ok {
+			vars[name] = value
+		}
+	}
 	binder.BindLocals(vars)
 }
 
-func applyHostLocals(host Host, program *Program, locals []any, initialized []bool) {
+func applyHostLocals(host Host, program *Program, locals []any, initialized []bool, extras map[string]any) {
 	taker, ok := host.(interface{ TakeLocals() map[string]any })
 	if !ok {
 		return
 	}
-	applyNamedValues(host, program, locals, initialized, taker.TakeLocals(), false)
+	applyNamedValues(program, locals, initialized, extras, taker.TakeLocals())
 }
 
-func applyNamedValues(host Host, program *Program, locals []any, initialized []bool, names map[string]any, extrasToGlobal bool) {
+func applyNamedValues(program *Program, locals []any, initialized []bool, extras map[string]any, names map[string]any) {
 	if names == nil {
 		return
 	}
@@ -758,23 +785,24 @@ func applyNamedValues(host Host, program *Program, locals []any, initialized []b
 				break
 			}
 		}
-		if !found && extrasToGlobal {
-			if setter, ok := host.(interface{ SetGlobal(string, any) }); ok {
-				setter.SetGlobal(name, value)
-			}
+		if !found && extras != nil {
+			extras[name] = value
 		}
 	}
 }
 
+func lookupUserFunc(funcs map[string]userFuncDef, key string) (userFuncDef, bool) {
+	if def, ok := funcs[key]; ok {
+		return def, true
+	}
+	for name, def := range funcs {
+		if strings.EqualFold(name, key) {
+			return def, true
+		}
+	}
+	return userFuncDef{}, false
+}
+
 func phpEmptyContainer(value any) bool {
-	if value == nil {
-		return true
-	}
-	if b, ok := value.(bool); ok && !b {
-		return true
-	}
-	if s, ok := value.(string); ok && s == "" {
-		return true
-	}
-	return false
+	return value == nil
 }

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/titpetric/phpscript/model"
@@ -92,6 +93,19 @@ func Run(program *Program, host Host) (err error) {
 	initialized := scratch.initialized[:nlocal]
 	clear(locals)
 	clear(initialized)
+	if registrar, ok := host.(interface{ RegisterClass(*model.Class) }); ok {
+		for _, class := range program.classes {
+			registrar.RegisterClass(class)
+		}
+	}
+	if registrar, ok := host.(interface{ RegisterUserFunc(string) }); ok {
+		for name := range program.userFuncs {
+			if strings.Contains(name, "::") {
+				continue
+			}
+			registrar.RegisterUserFunc(name)
+		}
+	}
 	iterators := make(map[int]*iteratorState)
 	var handlers []errorHandler
 	var callFrames []callFrame
@@ -403,6 +417,7 @@ func Run(program *Program, host Host) (err error) {
 			if argErr != nil {
 				return argErr
 			}
+			bindHostLocals(host, program, locals, initialized)
 			var value any
 			if inst.op == opCall {
 				if def, ok := program.userFuncs[inst.name]; ok {
@@ -431,6 +446,7 @@ func Run(program *Program, host Host) (err error) {
 					continue
 				}
 				value, err = host.Call(inst.name, inst.extra, arguments)
+				applyHostLocals(host, program, locals, initialized)
 			} else {
 				value, err = host.Construct(inst.name, arguments)
 			}
@@ -446,11 +462,39 @@ func Run(program *Program, host Host) (err error) {
 			if argErr != nil {
 				return argErr
 			}
+			bindHostLocals(host, program, locals, initialized)
 			receiver, popErr := pop()
 			if popErr != nil {
 				return popErr
 			}
+			if obj, ok := receiver.(*model.Object); ok && obj.Class != nil {
+				key := obj.Class.Name + "::" + inst.name
+				if def, ok := program.userFuncs[key]; ok {
+					callFrames = append(callFrames, callFrame{
+						returnPC:    pc,
+						locals:      locals,
+						initialized: initialized,
+					})
+					locals = make([]any, len(program.localNames))
+					initialized = make([]bool, len(program.localNames))
+					bound := append([]any{receiver}, arguments...)
+					for i, paramName := range def.params {
+						if i >= len(bound) {
+							break
+						}
+						for s, name := range program.localNames {
+							if name == paramName {
+								locals[s], initialized[s] = bound[i], true
+								break
+							}
+						}
+					}
+					pc = def.entryPC
+					continue
+				}
+			}
 			value, callErr := host.CallMethod(receiver, inst.name, arguments)
+			applyHostLocals(host, program, locals, initialized)
 			if callErr != nil {
 				if handle(callErr) {
 					continue
@@ -597,10 +641,140 @@ func Run(program *Program, host Host) (err error) {
 				stack = append(stack, retVal)
 				return nil
 			}
+		case opEnsureArray:
+			value, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			if _, ok := value.(*model.Array); !ok && phpEmptyContainer(value) {
+				value = host.Array(nil)
+			}
+			stack = append(stack, value)
+		case opVivifyIndex:
+			index, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			base, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value := host.Index(base, index)
+			if _, ok := value.(*model.Array); !ok && phpEmptyContainer(value) {
+				value = host.Array(nil)
+				if err = host.SetIndex(base, index, value, false, "="); err != nil {
+					if handle(err) {
+						continue
+					}
+					return err
+				}
+			}
+			stack = append(stack, value)
+		case opVivifyProperty:
+			receiver, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			value := host.GetProperty(receiver, inst.name)
+			if _, ok := value.(*model.Array); !ok && phpEmptyContainer(value) {
+				value = host.Array(nil)
+				if err = host.SetProperty(receiver, inst.name, value, "="); err != nil {
+					if handle(err) {
+						continue
+					}
+					return err
+				}
+			}
+			stack = append(stack, value)
+		case opInclude:
+			pathValue, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			vars := make(map[string]any, len(program.localNames))
+			for i, name := range program.localNames {
+				if initialized[i] && (len(name) == 0 || name[0] != 0) {
+					vars[name] = locals[i]
+				}
+			}
+			includer, ok := host.(interface {
+				Include(path any, keyword string, once bool, vars map[string]any) (any, map[string]any, error)
+			})
+			if !ok {
+				return fmt.Errorf("flatstack: pc %d: host does not implement include", pc)
+			}
+			value, exported, includeErr := includer.Include(pathValue, inst.name, inst.a != 0, vars)
+			if includeErr != nil {
+				if handle(includeErr) {
+					continue
+				}
+				return includeErr
+			}
+			applyNamedValues(host, program, locals, initialized, exported, len(callFrames) == 0)
+			stack = append(stack, value)
 		default:
 			return fmt.Errorf("flatstack: pc %d: invalid opcode %d", pc, inst.op)
 		}
 		pc++
 	}
 	return nil
+}
+
+func bindHostLocals(host Host, program *Program, locals []any, initialized []bool) {
+	binder, ok := host.(interface{ BindLocals(map[string]any) })
+	if !ok {
+		return
+	}
+	vars := make(map[string]any, len(program.localNames))
+	for i, name := range program.localNames {
+		if initialized[i] && (len(name) == 0 || name[0] != 0) {
+			vars[name] = locals[i]
+		}
+	}
+	binder.BindLocals(vars)
+}
+
+func applyHostLocals(host Host, program *Program, locals []any, initialized []bool) {
+	taker, ok := host.(interface{ TakeLocals() map[string]any })
+	if !ok {
+		return
+	}
+	applyNamedValues(host, program, locals, initialized, taker.TakeLocals(), false)
+}
+
+func applyNamedValues(host Host, program *Program, locals []any, initialized []bool, names map[string]any, extrasToGlobal bool) {
+	if names == nil {
+		return
+	}
+	for name, value := range names {
+		if len(name) == 0 || name[0] == 0 {
+			continue
+		}
+		found := false
+		for i, localName := range program.localNames {
+			if localName == name {
+				locals[i], initialized[i] = value, true
+				found = true
+				break
+			}
+		}
+		if !found && extrasToGlobal {
+			if setter, ok := host.(interface{ SetGlobal(string, any) }); ok {
+				setter.SetGlobal(name, value)
+			}
+		}
+	}
+}
+
+func phpEmptyContainer(value any) bool {
+	if value == nil {
+		return true
+	}
+	if b, ok := value.(bool); ok && !b {
+		return true
+	}
+	if s, ok := value.(string); ok && s == "" {
+		return true
+	}
+	return false
 }

--- a/flatstack/load_test.go
+++ b/flatstack/load_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/tests"
 )
@@ -84,6 +85,9 @@ func TestFlatstackNativeLanguageCoverage(t *testing.T) {
 		{"foreach variables", `<?php foreach (array("a" => 1, "b" => 2) as $k => $v) echo $k . $v;`, "a1b2"},
 		{"foreach index targets", `<?php $state = array(); foreach (array("x" => 7) as $state["k"] => $state["v"]) echo $state["k"] . $state["v"];`, "x7"},
 		{"elvis evaluates condition once", `<?php $value = "kept"; echo $value ?: "fallback";`, "kept"},
+		{"php class declaration", `<?php class Greeter { function hello() { echo "hi"; } } $g = new Greeter; $g->hello();`, "hi"},
+		{"class method calls user function", `<?php function tag() { echo "F"; } class C { function m() { tag(); } } $o = new C; $o->m();`, "F"},
+		{"class method this property", `<?php class Box { public $n = 3; function show() { echo $this->n; } } $b = new Box; $b->show();`, "3"},
 	}
 
 	for _, test := range tests {
@@ -104,6 +108,77 @@ func TestFlatstackNativeLanguageCoverage(t *testing.T) {
 				t.Fatalf("output = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestFlatstackNativeInclude(t *testing.T) {
+	program, err := parser.Parse(`<?php $message = include("plugin.php"); echo $message;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("expected native bytecode support: %v", err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		if path != "plugin.php" {
+			t.Fatalf("include path = %q", path)
+		}
+		return parser.Parse(`<?php return "Hello world!";`)
+	})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "Hello world!" {
+		t.Fatalf("output = %q, want %q", got, "Hello world!")
+	}
+}
+
+func TestFlatstackIncludeDefinesCallerVar(t *testing.T) {
+	program, err := parser.Parse(`<?php include("defs.php"); echo $x;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		return parser.Parse(`<?php $x = "z";`)
+	})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "z" {
+		t.Fatalf("output = %q, want z", got)
+	}
+}
+
+func TestFlatstackIncludeOnce(t *testing.T) {
+	program, err := parser.Parse(`<?php include_once("once.php"); include_once("once.php");`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	var hits atomic.Int64
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		hits.Add(1)
+		return parser.Parse(`<?php echo "x";`)
+	})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("include_once resolved %d times, want 1", hits.Load())
+	}
+	if got := output.String(); got != "x" {
+		t.Fatalf("output = %q, want x", got)
 	}
 }
 
@@ -132,14 +207,14 @@ $storage->get("missing");
 func TestFlatstackRejectsWholeProgramBeforeSideEffects(t *testing.T) {
 	program, err := parser.Parse(`<?php
 $storage = new Storage;
-class UnsupportedClass {}
+$fn = function() { return 1; };
 echo 42;
 `)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := flatstack.Supports(program); err == nil {
-		t.Fatal("program with a class declaration should require interpreter fallback")
+		t.Fatal("program with a closure should require interpreter fallback")
 	}
 
 	var constructions atomic.Int64

--- a/flatstack/load_test.go
+++ b/flatstack/load_test.go
@@ -88,6 +88,8 @@ func TestFlatstackNativeLanguageCoverage(t *testing.T) {
 		{"php class declaration", `<?php class Greeter { function hello() { echo "hi"; } } $g = new Greeter; $g->hello();`, "hi"},
 		{"class method calls user function", `<?php function tag() { echo "F"; } class C { function m() { tag(); } } $o = new C; $o->m();`, "F"},
 		{"class method this property", `<?php class Box { public $n = 3; function show() { echo $this->n; } } $b = new Box; $b->show();`, "3"},
+		{"throw from user function caught", `<?php function boom() { throw "x"; } try { boom(); echo "no"; } catch (Exception $e) { echo "ok"; }`, "ok"},
+		{"method call is case insensitive", `<?php class Greeter { function hello() { echo "hi"; } } $g = new Greeter; $g->Hello();`, "hi"},
 	}
 
 	for _, test := range tests {
@@ -179,6 +181,76 @@ func TestFlatstackIncludeOnce(t *testing.T) {
 	}
 	if got := output.String(); got != "x" {
 		t.Fatalf("output = %q, want x", got)
+	}
+}
+
+func TestFlatstackIncludeChainSeesPriorIncludeVars(t *testing.T) {
+	program, err := parser.Parse(`<?php include("a.php"); include("b.php");`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		if path == "a.php" {
+			return parser.Parse(`<?php $x = "A";`)
+		}
+		return parser.Parse(`<?php echo $x;`)
+	})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "A" {
+		t.Fatalf("output = %q, want A", got)
+	}
+}
+
+func TestFlatstackIncludeDoesNotLeakAcrossRuns(t *testing.T) {
+	first, err := parser.Parse(`<?php include("leak.php");`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := parser.Parse(`<?php echo $leak;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		return parser.Parse(`<?php $leak = "L";`)
+	})
+	if err := runtime.Run(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Run(second); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "" {
+		t.Fatalf("output = %q, want empty (no leak across Run)", got)
+	}
+}
+
+func TestFlatstackIncludeInFunctionDoesNotLeakToCaller(t *testing.T) {
+	program, err := parser.Parse(`<?php function load() { include("in.php"); } load(); echo $x;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatal(err)
+	}
+	var output strings.Builder
+	runtime := flatstack.New(&output, flatstack.Options{})
+	runtime.SetIncludeResolver(func(path string) (*model.Program, error) {
+		return parser.Parse(`<?php $x = "A";`)
+	})
+	if err := runtime.Run(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "" {
+		t.Fatalf("output = %q, want empty (include vars stay in the function)", got)
 	}
 }
 

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -25,19 +25,38 @@ func (rt *Runtime) runFlat(ast *model.Program) (bool, error) {
 		}
 		rt.exprCache.setFlat(ast, program)
 	}
-	return true, flatvm.Run(program, flatHost{runtime: rt})
+	if err := rt.hoist(ast.Stmts, rt.entrypoint); err != nil {
+		return false, nil
+	}
+	return true, flatvm.Run(program, &flatHost{runtime: rt})
 }
 
 type flatHost struct {
 	runtime *Runtime
+	locals  map[string]any
+}
+
+func (h flatHost) boundScope() *Scope {
+	scope := h.runtime.newScope()
+	for name, value := range h.locals {
+		scope.Set(name, value)
+	}
+	return scope
 }
 
 func (h flatHost) Construct(class string, args []any) (any, error) {
-	return h.runtime.helperNew(&scopeRef{scope: h.runtime.newScope()})(strings.TrimPrefix(class, "\\"), args...)
+	return h.runtime.helperNew(&scopeRef{scope: h.boundScope()})(strings.TrimPrefix(class, "\\"), args...)
 }
 
-func (h flatHost) CallMethod(receiver any, method string, args []any) (any, error) {
-	return h.runtime.helperCall(&scopeRef{scope: h.runtime.newScope()})(receiver, method, args...)
+func (h *flatHost) CallMethod(receiver any, method string, args []any) (any, error) {
+	scope := h.boundScope()
+	result, err := h.runtime.helperCall(&scopeRef{scope: scope})(receiver, method, args...)
+	h.pullScope(scope)
+	return result, err
+}
+
+func (h flatHost) SetGlobal(name string, value any) {
+	h.runtime.globals[name] = value
 }
 
 func (h flatHost) GetProperty(receiver any, name string) any {
@@ -223,8 +242,73 @@ func (h flatHost) Entries(value any) []flatvm.Entry {
 	return entries
 }
 
-func (h flatHost) Call(name, fallback string, args []any) (any, error) {
-	return h.runtime.helperFunc(&scopeRef{scope: h.runtime.newScope()})(name, fallback, args...)
+func (h *flatHost) Call(fnName, fallback string, args []any) (any, error) {
+	scope := h.boundScope()
+	result, err := h.runtime.helperFunc(&scopeRef{scope: scope})(fnName, fallback, args...)
+	h.pullScope(scope)
+	return result, err
+}
+
+func (h *flatHost) pullScope(scope *Scope) {
+	if h.locals == nil {
+		h.locals = map[string]any{}
+	}
+	for name, value := range scope.vars {
+		if name == "__FILE__" || name == "__DIR__" {
+			continue
+		}
+		h.locals[name] = value
+	}
+}
+
+func (h *flatHost) TakeLocals() map[string]any {
+	return h.locals
+}
+
+func (h *flatHost) BindLocals(vars map[string]any) {
+	h.locals = vars
+}
+
+func (h *flatHost) RegisterUserFunc(name string) {
+	h.runtime.userFns[name] = struct{}{}
+}
+
+func (h flatHost) RegisterClass(class *model.Class) {
+	for _, method := range class.Methods {
+		if method != nil && method.Filename == "" {
+			method.Filename = h.runtime.entrypoint
+		}
+	}
+	h.runtime.RegisterClass(class)
+}
+
+func (h flatHost) Include(path any, keyword string, once bool, vars map[string]any) (any, map[string]any, error) {
+	filename := phpString(path)
+	if once {
+		clean := cleanFSPath(filename)
+		for _, included := range h.runtime.included {
+			if included == clean {
+				return true, vars, nil
+			}
+		}
+	}
+	scope := h.runtime.newScope()
+	for name, value := range vars {
+		scope.Set(name, value)
+	}
+	result, err := h.runtime.includeFile(filename, scope)
+	if err != nil {
+		return nil, nil, err
+	}
+	exported := make(map[string]any, len(scope.vars))
+	for name, value := range scope.vars {
+		if name == "__FILE__" || name == "__DIR__" {
+			continue
+		}
+		exported[name] = value
+	}
+	_ = keyword
+	return result, exported, nil
 }
 
 // MemoryCheckInterval reports how often the VM should poll the memory limit;

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -44,8 +44,11 @@ func (h flatHost) boundScope() *Scope {
 	return scope
 }
 
-func (h flatHost) Construct(class string, args []any) (any, error) {
-	return h.runtime.helperNew(&scopeRef{scope: h.boundScope()})(strings.TrimPrefix(class, "\\"), args...)
+func (h *flatHost) Construct(class string, args []any) (any, error) {
+	scope := h.boundScope()
+	result, err := h.runtime.helperNew(&scopeRef{scope: scope})(strings.TrimPrefix(class, "\\"), args...)
+	h.pullScope(scope)
+	return result, err
 }
 
 func (h *flatHost) CallMethod(receiver any, method string, args []any) (any, error) {
@@ -269,10 +272,6 @@ func (h *flatHost) BindLocals(vars map[string]any) {
 	h.locals = vars
 }
 
-func (h *flatHost) RegisterUserFunc(name string) {
-	h.runtime.userFns[name] = struct{}{}
-}
-
 func (h flatHost) RegisterClass(class *model.Class) {
 	for _, method := range class.Methods {
 		if method != nil && method.Filename == "" {
@@ -285,9 +284,9 @@ func (h flatHost) RegisterClass(class *model.Class) {
 func (h flatHost) Include(path any, keyword string, once bool, vars map[string]any) (any, map[string]any, error) {
 	filename := phpString(path)
 	if once {
-		clean := cleanFSPath(filename)
+		want := cleanFSPath(filename)
 		for _, included := range h.runtime.included {
-			if included == clean {
+			if included == want || cleanFSPath(included) == want {
 				return true, vars, nil
 			}
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -628,7 +628,16 @@ func (rt *Runtime) evalInclude(n *model.Include, scope *Scope) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rt.includeFile(phpString(path), scope)
+	filename := phpString(path)
+	if n.Once {
+		want := cleanFSPath(filename)
+		for _, included := range rt.included {
+			if included == want || cleanFSPath(included) == want {
+				return true, nil
+			}
+		}
+	}
+	return rt.includeFile(filename, scope)
 }
 
 // noopTrace is the span closer returned when no observer is registered. It

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -740,6 +740,18 @@ func (rt *Runtime) PHPInfo() error {
 
 // RegisterClass adds a resolved class to the class table so `new Name` works.
 func (rt *Runtime) RegisterClass(c *model.Class) {
+	if existing, ok := rt.classes[c.Name]; ok && existing != nil {
+		if existing.Methods == nil {
+			existing.Methods = map[string]*model.FuncDecl{}
+		}
+		for name, method := range c.Methods {
+			existing.Methods[name] = method
+		}
+		if len(c.Fields) > 0 {
+			existing.Fields = c.Fields
+		}
+		return
+	}
 	rt.classes[c.Name] = c
 }
 


### PR DESCRIPTION
Follow-up to native ClassDecl/Include on the flat bytecode path.

- Variables defined by include are passed to later includes via extras, not runtime globals (no leak across Run).
- Extras are isolated per call frame so include inside a function does not leak to the caller.
- Compiled method dispatch is case-insensitive, matching PHP and the interpreter.
- Constructor host locals are copied back; include_once is honored on both engines.
- Remaining barriers stay documented: nested class no-op, included files still interpreted, include/require both fail-closed on a missing file.

`go test ./...` is green.