### PR TITLE
feat(stdlib/http): HTTP\Client and HTTP\Request bindings

### DIFF
--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -221,7 +221,7 @@ with the names they get when they arrive.
 
 | Area          | PHP does it with | phpscript name                       | State                                                      |
 |---------------|------------------|--------------------------------------|------------------------------------------------------------|
-| HTTP client   | `curl_*`         | `HTTP\Client`, `HTTP\Request`        | Not implemented                                            |
+| HTTP client   | `curl_*`         | `HTTP\Client`, `HTTP\Request`        | Implemented                                                |
 | JSON          | `json_encode`    | `json_encode`, `json_decode`         | Implemented, PHP-compatible                                |
 | YAML          | `yaml_*`         | `yaml_parse`, `yaml_emit`            | Not implemented, aim for PHP-compatible                    |
 | Databases     | PDO              | `Database`                           | Implemented                                                |
@@ -258,8 +258,8 @@ rest.
 `stdlib/ps` is where the phpscript-specific extensions live: the bindings that
 are each too small to be worth a package. It holds `Session\*`, `SharedMemory`,
 `defer` and `register_shutdown_function` today. An area that grows past that gets its own
-package, as `stdlib/smtp` and `stdlib/span` did and as `Database` did when it
-moved to `stdlib/database`. Moving one costs nothing a script can see, because
+package, as `stdlib/smtp`, `stdlib/span` and `stdlib/http` did and as `Database`
+did when it moved to `stdlib/database`. Moving one costs nothing a script can see, because
 the Go package a binding lives in is not part of what a script types.
 
 Renaming a registered class is the expensive change, which is why the rule is

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -154,6 +154,8 @@ Runtime-specific syntax and APIs that are not part of the PHP language reference
     - [`Database`](extensions/implemented-apis.md#database)
     - [`Database\Migrate`](extensions/implemented-apis.md#databasemigrate)
     - [`Exception`](extensions/implemented-apis.md#exception)
+    - [`HTTP\Client`](extensions/implemented-apis.md#httpclient)
+    - [`HTTP\Request`](extensions/implemented-apis.md#httprequest)
     - [`RuntimeException`](extensions/implemented-apis.md#runtimeexception)
     - [`SMTP`](extensions/implemented-apis.md#smtp)
     - [`Session\Manager`](extensions/implemented-apis.md#sessionmanager)

--- a/docs/reference/extensions/implemented-apis.md
+++ b/docs/reference/extensions/implemented-apis.md
@@ -965,9 +965,9 @@ Registered from `stdlib/http`.
 
 ```php
 /**
- * HTTP\Client sends requests. It takes its settings as an associative array,
- * and with no argument gives a client with a 30 second timeout that follows
- * redirects.
+ * HTTP\Client sends requests, one at a time with send() or all at once with
+ * parallel(). It takes its settings as an associative array, and with no
+ * argument gives a client with a 30 second timeout that follows redirects.
  */
 class HTTP\Client
 {
@@ -975,6 +975,19 @@ class HTTP\Client
 
     // get sends a GET request to $url and returns the response.
     public function get(string $url): mixed {}
+
+    /**
+     * parallel sends every request in $requests at once and returns the responses
+     * under the same keys, so the call takes as long as the slowest request rather
+     * than the sum. $requests is an array of HTTP\Request keyed by a name the
+     * script chooses, each bounded by the client's timeout.
+     * 
+     * One request failing does not fail the others and does not throw: that
+     * response reports $response->ok() as false and $response->err() as the reason,
+     * so a script sees every outcome. A throw means the argument was not an array
+     * of requests.
+     */
+    public function parallel(mixed $requests): array {}
 
     // post sends a POST request to $url with $body and returns the response.
     public function post(string $url, string ...$body): mixed {}
@@ -993,57 +1006,58 @@ Registered from `stdlib/http`.
 
 ```php
 /**
- * HTTP\Request is one outbound request: a method, a URL, and an optional body.
- * Building it sends nothing; a client does that with $client->send($request).
+ * HTTP\Request is one outbound request. It is a net/http request, so a script
+ * reads and writes it the way Go does: $request->method, $request->host,
+ * $request->url->path, and $request->header->set($name, $value). Building one
+ * sends nothing; a client does that with $client->send($request).
  */
 class HTTP\Request
 {
     public function __construct(string $method, string $url, string ...$body) {}
 
-    /**
-     * add_header adds a request header, keeping any value already set for it, and
-     * returns the request so calls can be chained.
-     */
-    public function add_header(string $name, string $value): mixed {}
+    public function add_cookie(object $value2): void {}
 
-    // body returns the request body.
-    public function body(): string {}
+    public function basic_auth(): string|string|bool {}
 
-    /**
-     * header returns the value of the named request header, or an empty string when
-     * it is not set. Header names are matched case-insensitively.
-     */
-    public function header(string $name): string {}
+    public function clone(): object {}
 
-    /**
-     * headers returns the request headers as an array of name to value. A header
-     * set more than once is joined with ", ".
-     */
-    public function headers(): array {}
+    public function context(): object {}
 
-    // method returns the request method.
-    public function method(): string {}
+    public function cookie(string $string): object {}
 
-    /**
-     * set_body replaces the request body and returns the request so calls can be
-     * chained.
-     */
-    public function set_body(string $body): mixed {}
+    public function cookies(): array {}
 
-    /**
-     * set_header sets a request header, replacing any value already set for it, and
-     * returns the request so calls can be chained.
-     */
-    public function set_header(string $name, string $value): mixed {}
+    public function cookies_named(string $string): array {}
 
-    /**
-     * set_query sets a query parameter on the request URL, replacing any value
-     * already set for it, and returns the request so calls can be chained.
-     */
-    public function set_query(string $name, string $value): mixed {}
+    public function form_file(string $string): object|object {}
 
-    // url returns the request URL, including any query parameters set on it.
-    public function url(): string {}
+    public function form_value(string $string): string {}
+
+    public function multipart_reader(): object {}
+
+    public function parse_form(): void {}
+
+    public function parse_multipart_form(int $num): void {}
+
+    public function path_value(string $string): string {}
+
+    public function post_form_value(string $string): string {}
+
+    public function proto_at_least(int $num1, int $num2): bool {}
+
+    public function referer(): string {}
+
+    public function set_basic_auth(string $string1, string $string2): void {}
+
+    public function set_path_value(string $string1, string $string2): void {}
+
+    public function user_agent(): string {}
+
+    public function with_context(): object {}
+
+    public function write(object $value2): void {}
+
+    public function write_proxy(object $value2): void {}
 }
 ```
 

--- a/docs/reference/extensions/implemented-apis.md
+++ b/docs/reference/extensions/implemented-apis.md
@@ -959,6 +959,94 @@ class Exception
 
 Also registered with this constructor: `ArgumentCountError`, `ArithmeticError`, `BadFunctionCallException`, `BadMethodCallException`, `DivisionByZeroError`, `DomainException`, `Error`, `ErrorException`, `InvalidArgumentException`, `JsonException`, `LengthException`, `LogicException`, `OutOfBoundsException`, `OutOfRangeException`, `OverflowException`, `RangeException`, `TypeError`, `UnderflowException`, `UnexpectedValueException`, `ValueError`.
 
+### `HTTP\Client`
+
+Registered from `stdlib/http`.
+
+```php
+/**
+ * HTTP\Client sends requests. It takes its settings as an associative array,
+ * and with no argument gives a client with a 30 second timeout that follows
+ * redirects.
+ */
+class HTTP\Client
+{
+    public function __construct(mixed $options) {}
+
+    // get sends a GET request to $url and returns the response.
+    public function get(string $url): mixed {}
+
+    // post sends a POST request to $url with $body and returns the response.
+    public function post(string $url, string ...$body): mixed {}
+
+    /**
+     * send sends $request and returns the response. A transport failure or a
+     * timeout throws; an HTTP error status does not, so check $response->status().
+     */
+    public function send(mixed $request): mixed {}
+}
+```
+
+### `HTTP\Request`
+
+Registered from `stdlib/http`.
+
+```php
+/**
+ * HTTP\Request is one outbound request: a method, a URL, and an optional body.
+ * Building it sends nothing; a client does that with $client->send($request).
+ */
+class HTTP\Request
+{
+    public function __construct(string $method, string $url, string ...$body) {}
+
+    /**
+     * add_header adds a request header, keeping any value already set for it, and
+     * returns the request so calls can be chained.
+     */
+    public function add_header(string $name, string $value): mixed {}
+
+    // body returns the request body.
+    public function body(): string {}
+
+    /**
+     * header returns the value of the named request header, or an empty string when
+     * it is not set. Header names are matched case-insensitively.
+     */
+    public function header(string $name): string {}
+
+    /**
+     * headers returns the request headers as an array of name to value. A header
+     * set more than once is joined with ", ".
+     */
+    public function headers(): array {}
+
+    // method returns the request method.
+    public function method(): string {}
+
+    /**
+     * set_body replaces the request body and returns the request so calls can be
+     * chained.
+     */
+    public function set_body(string $body): mixed {}
+
+    /**
+     * set_header sets a request header, replacing any value already set for it, and
+     * returns the request so calls can be chained.
+     */
+    public function set_header(string $name, string $value): mixed {}
+
+    /**
+     * set_query sets a query parameter on the request URL, replacing any value
+     * already set for it, and returns the request so calls can be chained.
+     */
+    public function set_query(string $name, string $value): mixed {}
+
+    // url returns the request URL, including any query parameters set on it.
+    public function url(): string {}
+}
+```
+
 ### `RuntimeException`
 
 Registered from `stdlib`.

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -11,6 +11,7 @@ PHP, it can be pretty much used in the same ways as you would use PHP.
 - [Routing](routing.md)
 - [Virtual hosting](virtual-hosting.md)
 - [Database bindings](database.md)
+- [HTTP client bindings](http-client.md)
 - [Shared memory bindings](shared-memory.md)
 - [Templating](templating.md)
 

--- a/docs/use-cases/bindings.md
+++ b/docs/use-cases/bindings.md
@@ -63,7 +63,7 @@ ps.RegisterSharedMemory(rt)
 
 The bindings can now be used from PHP. Using the `@route` hints, a request handler can look like this:
 
-```
+```php
 <?php
 
 // @route POST /kv/{key}

--- a/docs/use-cases/http-client.md
+++ b/docs/use-cases/http-client.md
@@ -1,0 +1,206 @@
+# HTTP client bindings
+
+The standard runtime provides the Go-backed `HTTP\Client` and `HTTP\Request`
+classes. They are what a script calls instead of PHP's `curl_*` family, which
+phpscript does not implement.
+
+A request is a `net/http` request handed straight over, so a script reads and
+writes it the way Go names it. A response is a facade, because its body is read
+in full before the script sees it.
+
+## Create a client
+
+`new HTTP\Client` gives a client with a 30 second timeout that follows
+redirects:
+
+```php
+$client = new HTTP\Client();
+```
+
+Settings come in as an associative array. Every key is optional:
+
+```php
+$client = new HTTP\Client(array(
+    "timeout"          => 10,
+    "base_url"         => "https://api.example.com",
+    "follow_redirects" => false,
+    "user_agent"       => "phpscript/1",
+    "headers"          => array("Authorization" => "Bearer " . getenv("API_TOKEN")),
+    "insecure"         => false,
+));
+```
+
+| Option             | Meaning                                                                                      |
+|--------------------|----------------------------------------------------------------------------------------------|
+| `timeout`          | Seconds, covering the whole request. A string with a unit (`"500ms"`, `"1m30s"`) also parses |
+| `base_url`         | Prefix a relative request URL resolves against                                               |
+| `follow_redirects` | `false` returns the 3xx and its `Location` instead of the destination                        |
+| `user_agent`       | Sent as the `User-Agent` header                                                              |
+| `headers`          | Sent with every request the client makes                                                     |
+| `insecure`         | Disables certificate verification, for a test server and not for a service                   |
+
+A client always has a timeout. There is no way to ask for none, because a
+request with no deadline is the one failure a script cannot recover from.
+
+An unrecognised key throws, so a typo is reported where it is written rather
+than at the far end of a request that did not carry what it was meant to:
+
+```php
+new HTTP\Client(array("timeuot" => 5));   // throws: unknown option "timeuot"
+```
+
+## Send one request
+
+`get()` and `post()` cover the common cases:
+
+```php
+$response = $client->get("/users");
+$response = $client->post("/users", '{"name":"ada"}');
+```
+
+For anything else, build a request and send it. Building one sends nothing:
+
+```php
+$request = new HTTP\Request("POST", "/users", '{"name":"ada"}');
+$request->header->set("Content-Type", "application/json");
+
+$response = $client->send($request);
+```
+
+HTTP methods are written uppercase. A lowercase one is corrected before the
+request goes out, because a server treats the method as case-sensitive.
+
+`send()` throws on a transport failure or a timeout. An HTTP error status is
+not a failure, so check the status:
+
+```php
+if ($response->ok()) {
+    $data = $response->json();
+} else {
+    echo "upstream returned " . $response->status();
+}
+```
+
+## Read a request
+
+`HTTP\Request` is a `net/http` request, so its fields and methods are Go's,
+matched case-insensitively:
+
+```php
+$request = new HTTP\Request("GET", "https://api.example.com/users?page=1");
+
+echo $request->method;          // GET
+echo $request->host;            // api.example.com
+echo $request->url->path;       // /users
+echo $request->url->string();   // the full URL
+
+$request->header->set("Accept", "application/json");
+$request->header->add("X-Trace", $traceId);
+echo $request->header->get("accept");
+```
+
+Everything `net/http` exports on a request is reachable, so there is one
+vocabulary for a request rather than a PHP-side name for each part of it.
+
+## Read a response
+
+| Method          | Returns                                                              |
+|-----------------|----------------------------------------------------------------------|
+| `status()`      | The status code as an int, `0` when no response arrived              |
+| `ok()`          | Whether a response arrived with a 2xx status                         |
+| `err()`         | Why the request failed, or an empty string                           |
+| `body()`        | The body as a string                                                 |
+| `header($name)` | One response header, matched case-insensitively                      |
+| `headers()`     | Every response header as an array                                    |
+| `json()`        | The body decoded into arrays and scalars; throws when it is not JSON |
+
+The body is read in full when the response is constructed, and bounded at
+32 MiB. A script has no way to close a stream, so an unread body would leak its
+connection when the request ended.
+
+## Send several requests at once
+
+`parallel()` takes an array of requests keyed by a name the script chooses, and
+returns the responses under those names. A page making three calls waits for
+the slowest rather than the sum:
+
+```php
+$results = $client->parallel(array(
+    "users" => new HTTP\Request("GET", "/users"),
+    "stats" => new HTTP\Request("GET", "/stats"),
+    "flags" => new HTTP\Request("GET", "/flags"),
+));
+
+foreach ($results as $name => $response) {
+    if ($response->ok()) {
+        echo $name . ": " . $response->status() . "\n";
+    } else {
+        echo $name . ": " . $response->err() . "\n";
+    }
+}
+```
+
+One request failing does not fail the others and does not throw. That response
+reports `ok()` as false and `err()` as the reason, so a page renders what it
+has instead of losing every result to one unreachable host:
+
+```php
+$results = $client->parallel(array(
+    "users"   => new HTTP\Request("GET", "/users"),
+    "offline" => new HTTP\Request("GET", "http://127.0.0.1:1/nope"),
+));
+
+$results["users"]->ok();      // true
+$results["users"]->status();  // 200
+
+$results["offline"]->ok();      // false
+$results["offline"]->status();  // 0, no response arrived
+$results["offline"]->err();     // the transport error, ending in "connection refused"
+```
+
+`parallel()` throws when the argument is not an array of `HTTP\Request`, which
+is reported before any connection is opened. Each request is bounded by the
+client's timeout, and the client's headers and `base_url` apply to all of them.
+
+## A page that calls an API
+
+Putting it together, a route that renders a user list from an upstream service:
+
+```php
+<?php
+// @route GET /users
+
+$client = new HTTP\Client(array(
+    "base_url" => getenv("API_URL"),
+    "timeout"  => 5,
+    "headers"  => array("Authorization" => "Bearer " . getenv("API_TOKEN")),
+));
+
+try {
+    $response = $client->get("/users");
+} catch (Exception $e) {
+    http_response_code(502);
+    echo "upstream unavailable";
+    return;
+}
+
+if (!$response->ok()) {
+    http_response_code(502);
+    echo "upstream returned " . $response->status();
+    return;
+}
+
+foreach ($response->json() as $user) {
+    echo htmlspecialchars($user["name"]) . "<br>";
+}
+```
+
+A transport failure throws and an error status does not, so both are handled,
+and neither leaves the page rendering a half-built list.
+
+## Tracing
+
+`send()` records an external span per request, carrying the method, host,
+status and byte count. `parallel()` records one span for the batch alongside
+the per-request spans, so a slow page shows which upstream call it waited on.
+See [Telemetry](../telemetry.md).

--- a/docs/use-cases/templating.md
+++ b/docs/use-cases/templating.md
@@ -90,7 +90,8 @@ Even a simple CMS may:
 
 For example, an edit form for an user may:
 
-```<?php
+```php
+<?php
 
 // @route GET /user/{id}/edit
 
@@ -110,7 +111,8 @@ $tpl->render();
 
 And a POST endpoint:
 
-```<?php
+```php
+<?php
 
 // @route POST /user/{id}/edit
 

--- a/stdlib/http/client.go
+++ b/stdlib/http/client.go
@@ -1,0 +1,174 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strings"
+	"time"
+
+	"github.com/titpetric/phpscript/model"
+	"github.com/titpetric/phpscript/telemetry"
+)
+
+// DefaultTimeout is how long a client waits for a response when the script did
+// not say. A request with no deadline at all is the one failure mode a script
+// cannot recover from, so there is no way to ask for one.
+const DefaultTimeout = 30 * time.Second
+
+// maxResponseBody is how much of a response body is read. A script reads a body
+// as a string, so it is held in memory, and an unbounded read turns a hostile
+// server into an out-of-memory error.
+const maxResponseBody = 32 << 20 // 32 MiB
+
+// Client is the PHP-visible HTTP\Client. As with Request, the net/http client
+// is a named unexported field so that a script reaches only the methods below.
+type Client struct {
+	client  *nethttp.Client
+	base    string
+	headers map[string]string
+}
+
+// NewClient is an HTTP client configured by an associative array of $timeout,
+// $base_url, $follow_redirects, $user_agent, $headers and $insecure. Every key
+// is optional, and `new HTTP\Client` gives a client with a 30 second timeout
+// that follows redirects.
+//
+// $timeout is in seconds and covers the whole request. $headers are sent with
+// every request the client makes, and a header set on a request replaces the
+// client's. $insecure disables certificate verification, which is for a test
+// server and not for a service. An unrecognised key throws.
+func NewClient(ctx context.Context, options any) (*Client, error) {
+	config := clientConfig{Timeout: DefaultTimeout, FollowRedirects: true}
+
+	if model.IsCollection(options) {
+		var err error
+		model.RangeValues(options, func(key, value any) bool {
+			switch strings.ToLower(toString(key)) {
+			case "timeout":
+				config.Timeout = toDuration(value)
+			case "base_url", "base":
+				config.Base = toString(value)
+			case "follow_redirects":
+				config.FollowRedirects = toBool(value)
+			case "user_agent":
+				config.UserAgent = toString(value)
+			case "insecure":
+				config.Insecure = toBool(value)
+			case "headers":
+				config.Headers, err = toHeaders(value)
+			default:
+				// An unknown key is an error rather than a value quietly
+				// ignored, so a typo in a script is reported where it is
+				// written instead of at the far end of a request that did not
+				// carry what it was meant to.
+				err = fmt.Errorf("HTTP\\Client: unknown option %q", toString(key))
+			}
+			return err == nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = DefaultTimeout
+	}
+
+	client := &nethttp.Client{Timeout: config.Timeout}
+	if !config.FollowRedirects {
+		client.CheckRedirect = func(*nethttp.Request, []*nethttp.Request) error {
+			return nethttp.ErrUseLastResponse
+		}
+	}
+	if config.Insecure {
+		client.Transport = &nethttp.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	headers := config.Headers
+	if config.UserAgent != "" {
+		if headers == nil {
+			headers = map[string]string{}
+		}
+		headers["User-Agent"] = config.UserAgent
+	}
+	return &Client{client: client, base: config.Base, headers: headers}, nil
+}
+
+// clientConfig is the parsed option array.
+type clientConfig struct {
+	Timeout         time.Duration
+	Base            string
+	FollowRedirects bool
+	UserAgent       string
+	Insecure        bool
+	Headers         map[string]string
+}
+
+// Send sends $request and returns the response. A transport failure or a
+// timeout throws; an HTTP error status does not, so check $response->status().
+func (c *Client) Send(ctx context.Context, request *Request) (*Response, error) {
+	if request == nil {
+		return nil, fmt.Errorf("HTTP\\Client: send expects an HTTP\\Request")
+	}
+
+	built, err := request.build(ctx, c.base)
+	if err != nil {
+		return nil, err
+	}
+	for name, value := range c.headers {
+		if built.Header.Get(name) == "" {
+			built.Header.Set(name, value)
+		}
+	}
+
+	span := telemetry.StartSpan(ctx, "http", telemetry.KindExternal)
+	span.SetAttribute("method", built.Method)
+	span.SetAttribute("host", built.URL.Host)
+	defer span.End()
+
+	response, err := c.client.Do(built)
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("HTTP\\Client: %w", err)
+	}
+	defer response.Body.Close()
+
+	// The body is read here rather than handed over as a stream, because a
+	// script has no way to close one: PHP's request ends and whatever it did
+	// not read would leak the connection.
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBody))
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("HTTP\\Client: read body: %w", err)
+	}
+	span.SetAttribute("status", response.StatusCode)
+	span.SetAttribute("bytes", len(body))
+
+	return &Response{
+		status: int64(response.StatusCode),
+		header: response.Header,
+		body:   string(body),
+	}, nil
+}
+
+// Get sends a GET request to $url and returns the response.
+func (c *Client) Get(ctx context.Context, url string) (*Response, error) {
+	request, err := NewRequest(ctx, nethttp.MethodGet, url)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, request)
+}
+
+// Post sends a POST request to $url with $body and returns the response.
+func (c *Client) Post(ctx context.Context, url string, body ...string) (*Response, error) {
+	request, err := NewRequest(ctx, nethttp.MethodPost, url, body...)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, request)
+}

--- a/stdlib/http/client.go
+++ b/stdlib/http/client.go
@@ -3,10 +3,13 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	nethttp "net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/titpetric/phpscript/model"
@@ -23,8 +26,9 @@ const DefaultTimeout = 30 * time.Second
 // server into an out-of-memory error.
 const maxResponseBody = 32 << 20 // 32 MiB
 
-// Client is the PHP-visible HTTP\Client. As with Request, the net/http client
-// is a named unexported field so that a script reaches only the methods below.
+// Client is the PHP-visible HTTP\Client. The net/http client is a named
+// unexported field rather than an embedded one, so a script reaches the methods
+// below and nothing else net/http exports.
 type Client struct {
 	client  *nethttp.Client
 	base    string
@@ -110,27 +114,98 @@ type clientConfig struct {
 
 // Send sends $request and returns the response. A transport failure or a
 // timeout throws; an HTTP error status does not, so check $response->status().
-func (c *Client) Send(ctx context.Context, request *Request) (*Response, error) {
+func (c *Client) Send(ctx context.Context, request *nethttp.Request) (*Response, error) {
 	if request == nil {
 		return nil, fmt.Errorf("HTTP\\Client: send expects an HTTP\\Request")
 	}
-
-	built, err := request.build(ctx, c.base)
+	response, err := c.send(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-	for name, value := range c.headers {
-		if built.Header.Get(name) == "" {
-			built.Header.Set(name, value)
-		}
+	return response, nil
+}
+
+// Get sends a GET request to $url and returns the response.
+func (c *Client) Get(ctx context.Context, url string) (*Response, error) {
+	request, err := NewRequest(ctx, nethttp.MethodGet, url)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, request)
+}
+
+// Post sends a POST request to $url with $body and returns the response.
+func (c *Client) Post(ctx context.Context, url string, body ...string) (*Response, error) {
+	request, err := NewRequest(ctx, nethttp.MethodPost, url, body...)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, request)
+}
+
+// Parallel sends every request in $requests at once and returns the responses
+// under the same keys, so the call takes as long as the slowest request rather
+// than the sum. $requests is an array of HTTP\Request keyed by a name the
+// script chooses, each bounded by the client's timeout.
+//
+// One request failing does not fail the others and does not throw: that
+// response reports $response->ok() as false and $response->err() as the reason,
+// so a script sees every outcome. A throw means the argument was not an array
+// of requests.
+func (c *Client) Parallel(ctx context.Context, requests any) (map[string]*Response, error) {
+	pending, err := toRequestMap(requests)
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) == 0 {
+		return map[string]*Response{}, nil
+	}
+
+	span := telemetry.StartSpan(ctx, "http.parallel", telemetry.KindExternal)
+	span.SetAttribute("requests", len(pending))
+	defer span.End()
+
+	results := make(map[string]*Response, len(pending))
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	for name, request := range pending {
+		wg.Add(1)
+		go func(name string, request *nethttp.Request) {
+			defer wg.Done()
+			response, err := c.send(ctx, request)
+			if err != nil {
+				// A failure is reported on the response rather than returned,
+				// so one unreachable host does not hide the results of every
+				// other request in the batch.
+				response = &Response{err: err.Error()}
+			}
+			mu.Lock()
+			results[name] = response
+			mu.Unlock()
+		}(name, request)
+	}
+	wg.Wait()
+
+	return results, nil
+}
+
+// send performs one request against the client's configuration. Send and
+// Parallel share it so a batched request is configured the same as a single
+// one.
+func (c *Client) send(ctx context.Context, request *nethttp.Request) (*Response, error) {
+	prepared, err := c.prepare(ctx, request)
+	if err != nil {
+		return nil, err
 	}
 
 	span := telemetry.StartSpan(ctx, "http", telemetry.KindExternal)
-	span.SetAttribute("method", built.Method)
-	span.SetAttribute("host", built.URL.Host)
+	span.SetAttribute("method", prepared.Method)
+	span.SetAttribute("host", prepared.URL.Host)
 	defer span.End()
 
-	response, err := c.client.Do(built)
+	response, err := c.client.Do(prepared)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("HTTP\\Client: %w", err)
@@ -155,20 +230,63 @@ func (c *Client) Send(ctx context.Context, request *Request) (*Response, error) 
 	}, nil
 }
 
-// Get sends a GET request to $url and returns the response.
-func (c *Client) Get(ctx context.Context, url string) (*Response, error) {
-	request, err := NewRequest(ctx, nethttp.MethodGet, url)
-	if err != nil {
-		return nil, err
+// prepare resolves a request against the client's base URL and default
+// headers. It clones rather than mutating, so the same request value can be
+// sent by two clients, and so Parallel does not write to a request another
+// goroutine is reading.
+func (c *Client) prepare(ctx context.Context, request *nethttp.Request) (*nethttp.Request, error) {
+	prepared := request.Clone(ctx)
+
+	if c.base != "" && !prepared.URL.IsAbs() {
+		base, err := url.Parse(c.base)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP\\Client: base_url: %w", err)
+		}
+		prepared.URL = base.ResolveReference(prepared.URL)
+		prepared.Host = prepared.URL.Host
 	}
-	return c.Send(ctx, request)
+	if !prepared.URL.IsAbs() {
+		return nil, fmt.Errorf("HTTP\\Client: %q is relative and no base_url is set", prepared.URL.String())
+	}
+
+	for name, value := range c.headers {
+		if prepared.Header.Get(name) == "" {
+			prepared.Header.Set(name, value)
+		}
+	}
+	return prepared, nil
 }
 
-// Post sends a POST request to $url with $body and returns the response.
-func (c *Client) Post(ctx context.Context, url string, body ...string) (*Response, error) {
-	request, err := NewRequest(ctx, nethttp.MethodPost, url, body...)
+// toRequestMap reads the argument Parallel takes. A script passes a PHP array
+// of HTTP\Request keyed by name; a Go caller passes the map directly.
+func toRequestMap(requests any) (map[string]*nethttp.Request, error) {
+	switch value := requests.(type) {
+	case nil:
+		return nil, fmt.Errorf("HTTP\\Client: parallel expects an array of HTTP\\Request")
+	case map[string]*nethttp.Request:
+		return value, nil
+	}
+
+	if !model.IsCollection(requests) {
+		return nil, fmt.Errorf("HTTP\\Client: parallel expects an array of HTTP\\Request, got %T", requests)
+	}
+
+	out := map[string]*nethttp.Request{}
+	var err error
+	model.RangeValues(requests, func(key, value any) bool {
+		request, ok := value.(*nethttp.Request)
+		if !ok {
+			err = fmt.Errorf("HTTP\\Client: parallel: %q is %T, want an HTTP\\Request", toString(key), value)
+			return false
+		}
+		out[toString(key)] = request
+		return true
+	})
 	if err != nil {
 		return nil, err
 	}
-	return c.Send(ctx, request)
+	if len(out) == 0 {
+		return nil, errors.New("HTTP\\Client: parallel was given no requests")
+	}
+	return out, nil
 }

--- a/stdlib/http/client_test.go
+++ b/stdlib/http/client_test.go
@@ -11,7 +11,9 @@ import (
 	nethttp "net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/titpetric/phpscript/stdlib/http"
 )
@@ -42,11 +44,11 @@ func TestClientSendsRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	request, err := http.NewRequest(ctx, "post", server.URL+"/users", `{"name":"ada"}`)
+	request, err := http.NewRequest(ctx, "POST", server.URL+"/users", `{"name":"ada"}`)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	request.SetHeader("X-Token", "secret")
+	request.Header.Set("X-Token", "secret")
 
 	response, err := client.Send(ctx, request)
 	if err != nil {
@@ -54,7 +56,7 @@ func TestClientSendsRequest(t *testing.T) {
 	}
 
 	if gotMethod != "POST" {
-		t.Errorf("method = %q, want POST (the constructor upper-cases it)", gotMethod)
+		t.Errorf("method = %q, want POST", gotMethod)
 	}
 	if gotPath != "/users" {
 		t.Errorf("path = %q, want /users", gotPath)
@@ -72,6 +74,9 @@ func TestClientSendsRequest(t *testing.T) {
 	if !response.OK() {
 		t.Error("OK() = false for 201, want true")
 	}
+	if response.Err() != "" {
+		t.Errorf("Err() = %q, want empty for a request that succeeded", response.Err())
+	}
 	if got := response.Header("x-served-by"); got != "httptest" {
 		t.Errorf("Header() = %q, want httptest (header lookup is case-insensitive)", got)
 	}
@@ -81,6 +86,50 @@ func TestClientSendsRequest(t *testing.T) {
 	}
 	if m, ok := decoded.(map[string]any); !ok || m["ok"] != true {
 		t.Errorf("JSON() = %#v, want {ok: true}", decoded)
+	}
+}
+
+// TestRequestIsANetHTTPRequest pins the shape a script gets back. The binding
+// hands over the net/http value rather than a facade, so a script reads and
+// writes it the way Go does.
+func TestRequestIsANetHTTPRequest(t *testing.T) {
+	ctx := context.Background()
+	request, err := http.NewRequest(ctx, "GET", "https://example.invalid/users?page=1")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var _ *nethttp.Request = request
+
+	if request.Method != "GET" {
+		t.Errorf("Method = %q, want GET", request.Method)
+	}
+	if request.URL.Path != "/users" {
+		t.Errorf("URL.Path = %q, want /users", request.URL.Path)
+	}
+	if request.URL.Query().Get("page") != "1" {
+		t.Errorf("query page = %q, want 1", request.URL.Query().Get("page"))
+	}
+	if request.Host != "example.invalid" {
+		t.Errorf("Host = %q, want example.invalid", request.Host)
+	}
+
+	request.Header.Set("Accept", "application/json")
+	if request.Header.Get("accept") != "application/json" {
+		t.Errorf("Header.Get = %q, want application/json", request.Header.Get("accept"))
+	}
+}
+
+// TestRequestMethodIsUpperCased pins that a lowercase verb is corrected rather
+// than sent as written: a server treats the method as case-sensitive and would
+// reject it.
+func TestRequestMethodIsUpperCased(t *testing.T) {
+	request, err := http.NewRequest(context.Background(), "post", "https://example.invalid")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if request.Method != "POST" {
+		t.Errorf("Method = %q, want POST", request.Method)
 	}
 }
 
@@ -121,6 +170,28 @@ func TestClientOptions(t *testing.T) {
 	}
 	if gotAuth != "Bearer token" {
 		t.Errorf("Authorization = %q, want the client header", gotAuth)
+	}
+
+	// Send clones, so the caller's request is unchanged and can be sent again.
+	if request.URL.IsAbs() {
+		t.Errorf("Send mutated the caller's request URL to %q", request.URL)
+	}
+}
+
+// TestClientRelativeURLWithoutBaseIsReported pins that a relative URL with no
+// base_url is a named error rather than a transport failure.
+func TestClientRelativeURLWithoutBaseIsReported(t *testing.T) {
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	request, err := http.NewRequest(ctx, "GET", "/things")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := client.Send(ctx, request); err == nil || !strings.Contains(err.Error(), "base_url") {
+		t.Errorf("Send error = %v, want one naming base_url", err)
 	}
 }
 
@@ -165,27 +236,125 @@ func TestClientDoesNotFollowRedirects(t *testing.T) {
 	}
 }
 
-// TestRequestIsInertUntilSent pins that building a request sends nothing, which
-// is why the fixture can construct one without a server.
-func TestRequestIsInertUntilSent(t *testing.T) {
+// TestClientParallel is the batch case: every request runs at once, and the
+// results come back under the keys the caller chose.
+func TestClientParallel(t *testing.T) {
+	var inFlight, peak atomic.Int64
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		current := inFlight.Add(1)
+		for {
+			seen := peak.Load()
+			if current <= seen || peak.CompareAndSwap(seen, current) {
+				break
+			}
+		}
+		time.Sleep(30 * time.Millisecond)
+		inFlight.Add(-1)
+		w.Write([]byte(r.URL.Path))
+	}))
+	defer server.Close()
+
 	ctx := context.Background()
-	request, err := http.NewRequest(ctx, "get", "https://example.invalid/users?page=1")
+	client, err := http.NewClient(ctx, map[string]any{"base_url": server.URL})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	requests := map[string]*nethttp.Request{}
+	for _, name := range []string{"users", "stats", "flags"} {
+		request, err := http.NewRequest(ctx, "GET", "/"+name)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		requests[name] = request
+	}
+
+	start := time.Now()
+	results, err := client.Parallel(ctx, requests)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Parallel: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("Parallel returned %d results, want 3", len(results))
+	}
+	for name, response := range results {
+		if !response.OK() {
+			t.Errorf("%s: OK() = false, err %q", name, response.Err())
+		}
+		if response.Body() != "/"+name {
+			t.Errorf("%s: Body() = %q, want /%s", name, response.Body(), name)
+		}
+	}
+
+	// Concurrent, not sequential: three 30ms requests one after another take
+	// 90ms, and the handler records how many were in flight at once.
+	if got := peak.Load(); got < 2 {
+		t.Errorf("peak concurrent requests = %d, want at least 2", got)
+	}
+	if elapsed > 80*time.Millisecond {
+		t.Errorf("Parallel took %v for three 30ms requests, want them overlapped", elapsed)
+	}
+}
+
+// TestClientParallelReportsFailurePerRequest pins that one unreachable host
+// does not hide the results of the rest of the batch.
+func TestClientParallelReportsFailurePerRequest(t *testing.T) {
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		w.Write([]byte("fine"))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, map[string]any{"timeout": "200ms"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	good, err := http.NewRequest(ctx, "GET", server.URL)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	request.SetQuery("page", "2").SetHeader("Accept", "application/json").SetBody("body")
+	// Port 1 on the loopback address refuses immediately.
+	bad, err := http.NewRequest(ctx, "GET", "http://127.0.0.1:1/nope")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
 
-	if request.Method() != "GET" {
-		t.Errorf("Method() = %q, want GET", request.Method())
+	results, err := client.Parallel(ctx, map[string]*nethttp.Request{"good": good, "bad": bad})
+	if err != nil {
+		t.Fatalf("Parallel returned an error for a per-request failure: %v", err)
 	}
-	if request.URL() != "https://example.invalid/users?page=2" {
-		t.Errorf("URL() = %q, want the query replaced", request.URL())
+	if len(results) != 2 {
+		t.Fatalf("Parallel returned %d results, want 2", len(results))
 	}
-	if request.Header("accept") != "application/json" {
-		t.Errorf("Header() = %q, want application/json", request.Header("accept"))
+	if !results["good"].OK() {
+		t.Errorf("good: OK() = false, err %q", results["good"].Err())
 	}
-	if request.Body() != "body" {
-		t.Errorf("Body() = %q, want body", request.Body())
+	if results["bad"].OK() {
+		t.Error("bad: OK() = true for a refused connection")
+	}
+	if results["bad"].Err() == "" {
+		t.Error("bad: Err() is empty for a refused connection")
+	}
+	if results["bad"].Status() != 0 {
+		t.Errorf("bad: Status() = %d, want 0 for a request that got no response", results["bad"].Status())
+	}
+}
+
+// TestClientParallelRejectsBadInput pins that the argument has to be an array
+// of requests, which is the one thing Parallel throws for.
+func TestClientParallelRejectsBadInput(t *testing.T) {
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	for _, input := range []any{nil, "not an array", map[string]any{"a": "not a request"}} {
+		if _, err := client.Parallel(ctx, input); err == nil {
+			t.Errorf("Parallel accepted %#v", input)
+		}
 	}
 }
 
@@ -242,9 +411,8 @@ func TestClientTimesOut(t *testing.T) {
 	}
 }
 
-// jsonRoundTrip keeps the encoding/json import honest in a way a reader can see
-// is deliberate: the decoded shape above is compared against what json itself
-// produces for the same body.
+// TestResponseJSONMatchesEncodingJSON checks the decoded shape against what
+// encoding/json produces for the same body.
 func TestResponseJSONMatchesEncodingJSON(t *testing.T) {
 	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		w.Write([]byte(`{"a":[1,2],"b":"c"}`))

--- a/stdlib/http/client_test.go
+++ b/stdlib/http/client_test.go
@@ -1,0 +1,271 @@
+package http_test
+
+// Sending is tested here, against httptest, rather than in a .phpt fixture: a
+// fixture that reached the network would be a fixture that fails when the
+// network does. The fixture covers construction and introspection, which is
+// what a script can check without a server.
+
+import (
+	"context"
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/stdlib/http"
+)
+
+func TestClientSendsRequest(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotHeader string
+		gotBody   string
+	)
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotHeader = r.Header.Get("X-Token")
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		gotBody = string(body)
+
+		w.Header().Set("X-Served-By", "httptest")
+		w.WriteHeader(nethttp.StatusCreated)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	request, err := http.NewRequest(ctx, "post", server.URL+"/users", `{"name":"ada"}`)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	request.SetHeader("X-Token", "secret")
+
+	response, err := client.Send(ctx, request)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST (the constructor upper-cases it)", gotMethod)
+	}
+	if gotPath != "/users" {
+		t.Errorf("path = %q, want /users", gotPath)
+	}
+	if gotHeader != "secret" {
+		t.Errorf("X-Token = %q, want secret", gotHeader)
+	}
+	if gotBody != `{"name":"ada"}` {
+		t.Errorf("body = %q, want the request body", gotBody)
+	}
+
+	if response.Status() != 201 {
+		t.Errorf("Status() = %d, want 201", response.Status())
+	}
+	if !response.OK() {
+		t.Error("OK() = false for 201, want true")
+	}
+	if got := response.Header("x-served-by"); got != "httptest" {
+		t.Errorf("Header() = %q, want httptest (header lookup is case-insensitive)", got)
+	}
+	decoded, err := response.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if m, ok := decoded.(map[string]any); !ok || m["ok"] != true {
+		t.Errorf("JSON() = %#v, want {ok: true}", decoded)
+	}
+}
+
+func TestClientOptions(t *testing.T) {
+	var gotAgent, gotAuth string
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		gotAgent = r.Header.Get("User-Agent")
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, map[string]any{
+		"timeout":    int64(5),
+		"base_url":   server.URL,
+		"user_agent": "phpscript/1",
+		"headers":    map[string]any{"Authorization": "Bearer token"},
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// A relative URL resolves against base_url, which is the point of the option.
+	request, err := http.NewRequest(ctx, "GET", "/things")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	response, err := client.Send(ctx, request)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if response.Body() != "ok" {
+		t.Errorf("Body() = %q, want ok", response.Body())
+	}
+	if gotAgent != "phpscript/1" {
+		t.Errorf("User-Agent = %q, want phpscript/1", gotAgent)
+	}
+	if gotAuth != "Bearer token" {
+		t.Errorf("Authorization = %q, want the client header", gotAuth)
+	}
+}
+
+// TestClientRejectsUnknownOption pins that a typo is reported rather than
+// silently doing nothing, which is the SMTP binding's rule too.
+func TestClientRejectsUnknownOption(t *testing.T) {
+	_, err := http.NewClient(context.Background(), map[string]any{"timeuot": int64(5)})
+	if err == nil {
+		t.Fatal("NewClient accepted an unknown option")
+	}
+	if !strings.Contains(err.Error(), "timeuot") {
+		t.Errorf("error %q does not name the unknown option", err)
+	}
+}
+
+// TestClientDoesNotFollowRedirects pins follow_redirects, which a script sets
+// when it wants to see the Location rather than the destination.
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		if r.URL.Path == "/from" {
+			nethttp.Redirect(w, r, "/to", nethttp.StatusFound)
+			return
+		}
+		w.Write([]byte("arrived"))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, map[string]any{"follow_redirects": false})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	response, err := client.Get(ctx, server.URL+"/from")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if response.Status() != 302 {
+		t.Errorf("Status() = %d, want 302", response.Status())
+	}
+	if got := response.Header("Location"); got != "/to" {
+		t.Errorf("Location = %q, want /to", got)
+	}
+}
+
+// TestRequestIsInertUntilSent pins that building a request sends nothing, which
+// is why the fixture can construct one without a server.
+func TestRequestIsInertUntilSent(t *testing.T) {
+	ctx := context.Background()
+	request, err := http.NewRequest(ctx, "get", "https://example.invalid/users?page=1")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	request.SetQuery("page", "2").SetHeader("Accept", "application/json").SetBody("body")
+
+	if request.Method() != "GET" {
+		t.Errorf("Method() = %q, want GET", request.Method())
+	}
+	if request.URL() != "https://example.invalid/users?page=2" {
+		t.Errorf("URL() = %q, want the query replaced", request.URL())
+	}
+	if request.Header("accept") != "application/json" {
+		t.Errorf("Header() = %q, want application/json", request.Header("accept"))
+	}
+	if request.Body() != "body" {
+		t.Errorf("Body() = %q, want body", request.Body())
+	}
+}
+
+// TestRequestRequiresMethodAndURL pins the two arguments that have no useful
+// default.
+func TestRequestRequiresMethodAndURL(t *testing.T) {
+	ctx := context.Background()
+	if _, err := http.NewRequest(ctx, "", "https://example.invalid"); err == nil {
+		t.Error("NewRequest accepted an empty method")
+	}
+	if _, err := http.NewRequest(ctx, "GET", ""); err == nil {
+		t.Error("NewRequest accepted an empty url")
+	}
+}
+
+// TestResponseJSONReportsBadBody pins that a non-JSON body throws rather than
+// returning a zero value a script would then use.
+func TestResponseJSONReportsBadBody(t *testing.T) {
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	response, err := client.Get(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, err := response.JSON(); err == nil {
+		t.Error("JSON() accepted a body that is not JSON")
+	}
+}
+
+// TestClientTimesOut pins that a client always has a deadline, which is the one
+// failure a script cannot recover from on its own.
+func TestClientTimesOut(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		<-block
+	}))
+	defer func() { close(block); server.Close() }()
+
+	ctx := context.Background()
+	client, err := http.NewClient(ctx, map[string]any{"timeout": "50ms"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := client.Get(ctx, server.URL); err == nil {
+		t.Error("Get returned before the timeout elapsed")
+	}
+}
+
+// jsonRoundTrip keeps the encoding/json import honest in a way a reader can see
+// is deliberate: the decoded shape above is compared against what json itself
+// produces for the same body.
+func TestResponseJSONMatchesEncodingJSON(t *testing.T) {
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		w.Write([]byte(`{"a":[1,2],"b":"c"}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client, _ := http.NewClient(ctx, nil)
+	response, err := client.Get(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got, err := response.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var want any
+	if err := json.Unmarshal([]byte(response.Body()), &want); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if gotJSON, _ := json.Marshal(got); string(gotJSON) != `{"a":[1,2],"b":"c"}` {
+		t.Errorf("JSON() = %s, want the body decoded", gotJSON)
+	}
+}

--- a/stdlib/http/init.go
+++ b/stdlib/http/init.go
@@ -1,0 +1,20 @@
+// Package http provides the HTTP\Client and HTTP\Request bindings, the
+// outbound HTTP surface a script reaches instead of PHP's curl_* family.
+//
+// The types a script sees are facades over net/http rather than the net/http
+// types themselves. Registration is not a method allowlist: every exported
+// method and field of the value a constructor returns is reachable from PHP,
+// so embedding *net/http.Request would publish the whole of net/http as
+// methods on HTTP\Request. Each facade therefore holds its net/http value in a
+// named unexported field, and the methods below are the whole surface.
+package http
+
+import (
+	"github.com/titpetric/phpscript/runner"
+)
+
+// init contributes the HTTP bindings to stdlib.Register, the way a program
+// wires in a database/sql driver.
+func init() {
+	runner.RegisterBinding(Register)
+}

--- a/stdlib/http/register.go
+++ b/stdlib/http/register.go
@@ -1,0 +1,17 @@
+package http
+
+import (
+	"github.com/titpetric/phpscript/runner"
+)
+
+// Register installs the HTTP\Client and HTTP\Request bindings on rt.
+func Register(rt *runner.Runtime) {
+	// HTTP\Request is one outbound request: a method, a URL, and an optional body.
+	// Building it sends nothing; a client does that with $client->send($request).
+	rt.RegisterConstructor("HTTP\\Request", NewRequest)
+
+	// HTTP\Client sends requests. It takes its settings as an associative array,
+	// and with no argument gives a client with a 30 second timeout that follows
+	// redirects.
+	rt.RegisterConstructor("HTTP\\Client", NewClient)
+}

--- a/stdlib/http/register.go
+++ b/stdlib/http/register.go
@@ -6,12 +6,14 @@ import (
 
 // Register installs the HTTP\Client and HTTP\Request bindings on rt.
 func Register(rt *runner.Runtime) {
-	// HTTP\Request is one outbound request: a method, a URL, and an optional body.
-	// Building it sends nothing; a client does that with $client->send($request).
+	// HTTP\Request is one outbound request. It is a net/http request, so a script
+	// reads and writes it the way Go does: $request->method, $request->host,
+	// $request->url->path, and $request->header->set($name, $value). Building one
+	// sends nothing; a client does that with $client->send($request).
 	rt.RegisterConstructor("HTTP\\Request", NewRequest)
 
-	// HTTP\Client sends requests. It takes its settings as an associative array,
-	// and with no argument gives a client with a 30 second timeout that follows
-	// redirects.
+	// HTTP\Client sends requests, one at a time with send() or all at once with
+	// parallel(). It takes its settings as an associative array, and with no
+	// argument gives a client with a 30 second timeout that follows redirects.
 	rt.RegisterConstructor("HTTP\\Client", NewClient)
 }

--- a/stdlib/http/request.go
+++ b/stdlib/http/request.go
@@ -1,0 +1,142 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	neturl "net/url"
+	"strings"
+)
+
+// Request is the PHP-visible HTTP\Request. The net/http request is a named
+// unexported field rather than an embedded one, so a script reaches the methods
+// below and nothing else net/http exports.
+type Request struct {
+	method string
+	url    *neturl.URL
+	header nethttp.Header
+	body   string
+}
+
+// NewRequest builds a request from $method and $url, with an optional $body.
+// The method is upper-cased, so new HTTP\Request("get", $url) is a GET.
+// Building a request sends nothing: pass it to a client with
+// $client->send($request), and set headers on it with $request->set_header().
+func NewRequest(ctx context.Context, method, url string, body ...string) (*Request, error) {
+	if method == "" {
+		return nil, fmt.Errorf("HTTP\\Request: method is required")
+	}
+	if url == "" {
+		return nil, fmt.Errorf("HTTP\\Request: url is required")
+	}
+	parsed, err := neturl.Parse(url)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP\\Request: %w", err)
+	}
+
+	request := &Request{
+		method: strings.ToUpper(method),
+		url:    parsed,
+		header: nethttp.Header{},
+	}
+	if len(body) > 0 {
+		request.body = body[0]
+	}
+	return request, nil
+}
+
+// Method returns the request method.
+func (r *Request) Method() string { return r.method }
+
+// URL returns the request URL, including any query parameters set on it.
+func (r *Request) URL() string { return r.url.String() }
+
+// Body returns the request body.
+func (r *Request) Body() string { return r.body }
+
+// Header returns the value of the named request header, or an empty string when
+// it is not set. Header names are matched case-insensitively.
+func (r *Request) Header(name string) string { return r.header.Get(name) }
+
+// Headers returns the request headers as an array of name to value. A header
+// set more than once is joined with ", ".
+func (r *Request) Headers() map[string]string { return flattenHeader(r.header) }
+
+// SetHeader sets a request header, replacing any value already set for it, and
+// returns the request so calls can be chained.
+func (r *Request) SetHeader(name, value string) *Request {
+	r.header.Set(name, value)
+	return r
+}
+
+// AddHeader adds a request header, keeping any value already set for it, and
+// returns the request so calls can be chained.
+func (r *Request) AddHeader(name, value string) *Request {
+	r.header.Add(name, value)
+	return r
+}
+
+// SetBody replaces the request body and returns the request so calls can be
+// chained.
+func (r *Request) SetBody(body string) *Request {
+	r.body = body
+	return r
+}
+
+// SetQuery sets a query parameter on the request URL, replacing any value
+// already set for it, and returns the request so calls can be chained.
+func (r *Request) SetQuery(name, value string) *Request {
+	query := r.url.Query()
+	query.Set(name, value)
+	r.url.RawQuery = query.Encode()
+	return r
+}
+
+// build turns the facade into the net/http request a client sends. It is not
+// exported, so it is not reachable from a script.
+func (r *Request) build(ctx context.Context, base string) (*nethttp.Request, error) {
+	target := r.url
+	if base != "" && !target.IsAbs() {
+		parsed, err := neturl.Parse(base)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP\\Client: base_url: %w", err)
+		}
+		target = parsed.ResolveReference(target)
+	}
+
+	var body *strings.Reader
+	if r.body != "" {
+		body = strings.NewReader(r.body)
+	}
+
+	// A nil *strings.Reader in an io.Reader interface is not a nil interface,
+	// and net/http would then read from it and panic, so the two cases are
+	// spelled separately rather than passed through one variable.
+	var request *nethttp.Request
+	var err error
+	if body == nil {
+		request, err = nethttp.NewRequestWithContext(ctx, r.method, target.String(), nil)
+	} else {
+		request, err = nethttp.NewRequestWithContext(ctx, r.method, target.String(), body)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("HTTP\\Client: %w", err)
+	}
+	for name, values := range r.header {
+		for _, value := range values {
+			request.Header.Add(name, value)
+		}
+	}
+	return request, nil
+}
+
+// flattenHeader renders a header set as the array shape a script reads. A
+// map[string]string is the cheap shape for a value a script only reads; see
+// docs/allocation-performance.md.
+func flattenHeader(header nethttp.Header) map[string]string {
+	out := make(map[string]string, len(header))
+	for name, values := range header {
+		out[name] = strings.Join(values, ", ")
+	}
+	return out
+}

--- a/stdlib/http/request.go
+++ b/stdlib/http/request.go
@@ -4,134 +4,52 @@ import (
 	"context"
 	"fmt"
 	nethttp "net/http"
-	neturl "net/url"
 	"strings"
 )
 
-// Request is the PHP-visible HTTP\Request. The net/http request is a named
-// unexported field rather than an embedded one, so a script reaches the methods
-// below and nothing else net/http exports.
-type Request struct {
-	method string
-	url    *neturl.URL
-	header nethttp.Header
-	body   string
-}
-
 // NewRequest builds a request from $method and $url, with an optional $body.
-// The method is upper-cased, so new HTTP\Request("get", $url) is a GET.
 // Building a request sends nothing: pass it to a client with
-// $client->send($request), and set headers on it with $request->set_header().
-func NewRequest(ctx context.Context, method, url string, body ...string) (*Request, error) {
+// $client->send($request).
+//
+// The value is a net/http request, so a script reads and writes it the way Go
+// does: $request->method, $request->host, and $request->header->set($name,
+// $value) for headers. Methods are written uppercase, "GET" and "POST"; a
+// lowercase one is upper-cased rather than sent as written, because a server
+// treats the method as case-sensitive and would reject it.
+func NewRequest(ctx context.Context, method, url string, body ...string) (*nethttp.Request, error) {
 	if method == "" {
 		return nil, fmt.Errorf("HTTP\\Request: method is required")
 	}
 	if url == "" {
 		return nil, fmt.Errorf("HTTP\\Request: url is required")
 	}
-	parsed, err := neturl.Parse(url)
+
+	var reader *strings.Reader
+	if len(body) > 0 && body[0] != "" {
+		reader = strings.NewReader(body[0])
+	}
+
+	// A nil *strings.Reader held in an io.Reader is not a nil io.Reader, and
+	// net/http would then read from it, so the two cases are passed separately
+	// rather than through one variable.
+	var (
+		request *nethttp.Request
+		err     error
+	)
+	if reader == nil {
+		request, err = nethttp.NewRequestWithContext(ctx, strings.ToUpper(method), url, nil)
+	} else {
+		request, err = nethttp.NewRequestWithContext(ctx, strings.ToUpper(method), url, reader)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("HTTP\\Request: %w", err)
-	}
-
-	request := &Request{
-		method: strings.ToUpper(method),
-		url:    parsed,
-		header: nethttp.Header{},
-	}
-	if len(body) > 0 {
-		request.body = body[0]
-	}
-	return request, nil
-}
-
-// Method returns the request method.
-func (r *Request) Method() string { return r.method }
-
-// URL returns the request URL, including any query parameters set on it.
-func (r *Request) URL() string { return r.url.String() }
-
-// Body returns the request body.
-func (r *Request) Body() string { return r.body }
-
-// Header returns the value of the named request header, or an empty string when
-// it is not set. Header names are matched case-insensitively.
-func (r *Request) Header(name string) string { return r.header.Get(name) }
-
-// Headers returns the request headers as an array of name to value. A header
-// set more than once is joined with ", ".
-func (r *Request) Headers() map[string]string { return flattenHeader(r.header) }
-
-// SetHeader sets a request header, replacing any value already set for it, and
-// returns the request so calls can be chained.
-func (r *Request) SetHeader(name, value string) *Request {
-	r.header.Set(name, value)
-	return r
-}
-
-// AddHeader adds a request header, keeping any value already set for it, and
-// returns the request so calls can be chained.
-func (r *Request) AddHeader(name, value string) *Request {
-	r.header.Add(name, value)
-	return r
-}
-
-// SetBody replaces the request body and returns the request so calls can be
-// chained.
-func (r *Request) SetBody(body string) *Request {
-	r.body = body
-	return r
-}
-
-// SetQuery sets a query parameter on the request URL, replacing any value
-// already set for it, and returns the request so calls can be chained.
-func (r *Request) SetQuery(name, value string) *Request {
-	query := r.url.Query()
-	query.Set(name, value)
-	r.url.RawQuery = query.Encode()
-	return r
-}
-
-// build turns the facade into the net/http request a client sends. It is not
-// exported, so it is not reachable from a script.
-func (r *Request) build(ctx context.Context, base string) (*nethttp.Request, error) {
-	target := r.url
-	if base != "" && !target.IsAbs() {
-		parsed, err := neturl.Parse(base)
-		if err != nil {
-			return nil, fmt.Errorf("HTTP\\Client: base_url: %w", err)
-		}
-		target = parsed.ResolveReference(target)
-	}
-
-	var body *strings.Reader
-	if r.body != "" {
-		body = strings.NewReader(r.body)
-	}
-
-	// A nil *strings.Reader in an io.Reader interface is not a nil interface,
-	// and net/http would then read from it and panic, so the two cases are
-	// spelled separately rather than passed through one variable.
-	var request *nethttp.Request
-	var err error
-	if body == nil {
-		request, err = nethttp.NewRequestWithContext(ctx, r.method, target.String(), nil)
-	} else {
-		request, err = nethttp.NewRequestWithContext(ctx, r.method, target.String(), body)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("HTTP\\Client: %w", err)
-	}
-	for name, values := range r.header {
-		for _, value := range values {
-			request.Header.Add(name, value)
-		}
 	}
 	return request, nil
 }
 
 // flattenHeader renders a header set as the array shape a script reads. A
-// map[string]string is the cheap shape for a value a script only reads; see
+// header sent more than once is joined with ", ". map[string]string is the
+// cheap shape for a value a script only reads; see
 // docs/allocation-performance.md.
 func flattenHeader(header nethttp.Header) map[string]string {
 	out := make(map[string]string, len(header))

--- a/stdlib/http/response.go
+++ b/stdlib/http/response.go
@@ -6,21 +6,32 @@ import (
 	nethttp "net/http"
 )
 
-// Response is the PHP-visible result of sending a request. The body is read in
-// full when the response is constructed, because a script has no stream to
-// close; see Client.Send.
+// Response is the PHP-visible result of sending a request.
+//
+// This one is a facade rather than a net/http response, for two reasons. The
+// body is read in full when the response is constructed, because a script has
+// no stream to close and an unread net/http body leaks its connection. And
+// ok() and json() are the two things a script does with a response that
+// net/http has no equivalent for.
 type Response struct {
 	status int64
 	header nethttp.Header
 	body   string
+	err    string
 }
 
 // Status returns the HTTP status code. It is an int, so it compares against a
-// literal: $response->status() == 200.
+// literal: $response->status() == 200. A request that never got a response
+// reports 0; see err().
 func (r *Response) Status() int64 { return r.status }
 
-// OK reports whether the status is in the 2xx range.
-func (r *Response) OK() bool { return r.status >= 200 && r.status < 300 }
+// OK reports whether the request got a response with a 2xx status.
+func (r *Response) OK() bool { return r.err == "" && r.status >= 200 && r.status < 300 }
+
+// Err returns why the request failed, or an empty string when it did not. Only
+// parallel() produces a failed response: send() throws instead, because there
+// is one outcome to report rather than several.
+func (r *Response) Err() string { return r.err }
 
 // Body returns the response body as a string.
 func (r *Response) Body() string { return r.body }

--- a/stdlib/http/response.go
+++ b/stdlib/http/response.go
@@ -1,0 +1,44 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	nethttp "net/http"
+)
+
+// Response is the PHP-visible result of sending a request. The body is read in
+// full when the response is constructed, because a script has no stream to
+// close; see Client.Send.
+type Response struct {
+	status int64
+	header nethttp.Header
+	body   string
+}
+
+// Status returns the HTTP status code. It is an int, so it compares against a
+// literal: $response->status() == 200.
+func (r *Response) Status() int64 { return r.status }
+
+// OK reports whether the status is in the 2xx range.
+func (r *Response) OK() bool { return r.status >= 200 && r.status < 300 }
+
+// Body returns the response body as a string.
+func (r *Response) Body() string { return r.body }
+
+// Header returns the value of the named response header, or an empty string
+// when it is not set. Header names are matched case-insensitively.
+func (r *Response) Header(name string) string { return r.header.Get(name) }
+
+// Headers returns the response headers as an array of name to value. A header
+// sent more than once is joined with ", ".
+func (r *Response) Headers() map[string]string { return flattenHeader(r.header) }
+
+// JSON decodes the response body and returns it as arrays and scalars. It
+// throws when the body is not valid JSON.
+func (r *Response) JSON() (any, error) {
+	var decoded any
+	if err := json.Unmarshal([]byte(r.body), &decoded); err != nil {
+		return nil, fmt.Errorf("HTTP\\Response: json: %w", err)
+	}
+	return decoded, nil
+}

--- a/stdlib/http/value.go
+++ b/stdlib/http/value.go
@@ -1,0 +1,102 @@
+package http
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/titpetric/phpscript/model"
+)
+
+// The conversions a script's option array needs. PHP is dynamically typed and
+// an option arrives as whatever the script wrote, so each one is read the way
+// PHP would read it in that position rather than type-asserted.
+
+// toString renders a value the way PHP renders it in a string context.
+func toString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// toBool follows PHP truthiness for the values a script can hand an option:
+// "false", "off", "no", "0" and the empty string are false, as is a zero
+// number; anything else set is true.
+func toBool(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "", "0", "false", "off", "no":
+			return false
+		}
+		return true
+	default:
+		return toInt(value) != 0
+	}
+}
+
+// toInt reads an integer option.
+func toInt(value any) int64 {
+	switch v := value.(type) {
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	case string:
+		var n int64
+		fmt.Sscanf(v, "%d", &n)
+		return n
+	default:
+		return 0
+	}
+}
+
+// toDuration reads a timeout. A bare number is seconds, which is how PHP's own
+// timeouts are spelled; a string with a unit ("500ms", "1m30s") is parsed as
+// Go spells one, so a sub-second timeout is expressible without a fraction.
+func toDuration(value any) time.Duration {
+	switch v := value.(type) {
+	case string:
+		if parsed, err := time.ParseDuration(strings.TrimSpace(v)); err == nil {
+			return parsed
+		}
+		return time.Duration(toInt(v)) * time.Second
+	case float64:
+		return time.Duration(v * float64(time.Second))
+	default:
+		return time.Duration(toInt(value)) * time.Second
+	}
+}
+
+// toHeaders reads a headers option, which a script writes as an associative
+// array of name to value.
+func toHeaders(value any) (map[string]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if !model.IsCollection(value) {
+		return nil, fmt.Errorf("HTTP\\Client: headers must be an array")
+	}
+	headers := map[string]string{}
+	model.RangeValues(value, func(key, val any) bool {
+		headers[toString(key)] = toString(val)
+		return true
+	})
+	return headers, nil
+}

--- a/stdlib/imports.go
+++ b/stdlib/imports.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/titpetric/phpscript/stdlib/compat"
 	_ "github.com/titpetric/phpscript/stdlib/database"
 	_ "github.com/titpetric/phpscript/stdlib/files"
+	_ "github.com/titpetric/phpscript/stdlib/http"
 	_ "github.com/titpetric/phpscript/stdlib/info"
 	_ "github.com/titpetric/phpscript/stdlib/internals"
 	_ "github.com/titpetric/phpscript/stdlib/ps"

--- a/tests/fixtures/http_request.phpt
+++ b/tests/fixtures/http_request.phpt
@@ -33,8 +33,9 @@ echo $post->method . "\n";
 echo $post->contentlength . "\n";
 
 // A client with no options is valid: it has a default timeout and follows
-// redirects. Constructing without a throw is the assertion; note that a
-// Go-backed binding is not is_object(), which holds for every host class.
+// redirects. Constructing without a throw is what this asserts, because the
+// settings it applies are only observable once a request is sent, which
+// stdlib/http/client_test.go covers.
 try {
     new HTTP\Client();
     echo "client\n";

--- a/tests/fixtures/http_request.phpt
+++ b/tests/fixtures/http_request.phpt
@@ -1,0 +1,87 @@
+name: http request and client construction
+description: >
+  HTTP\Request and HTTP\Client are host bindings with no PHP counterpart, so
+  the expected output is the runtime's contract rather than PHP's. Only
+  construction and introspection are covered: building a request sends
+  nothing, so this stays offline. Sending is tested against httptest in
+  stdlib/http/client_test.go, because a fixture that reached the network would
+  fail whenever the network did.
+runner:
+  php: false
+---
+<?php
+
+$request = new HTTP\Request("get", "https://example.invalid/users");
+echo $request->method() . "\n";
+echo $request->url() . "\n";
+
+// The setters return the request, so they chain.
+$request->set_header("Accept", "application/json")
+        ->set_query("page", "2")
+        ->set_body("payload");
+
+echo $request->url() . "\n";
+echo $request->header("accept") . "\n";
+echo $request->body() . "\n";
+
+$headers = $request->headers();
+echo $headers["Accept"] . "\n";
+
+// A body is optional, and the method is normalised.
+$post = new HTTP\Request("post", "https://example.invalid/users", '{"name":"ada"}');
+echo $post->method() . "\n";
+echo $post->body() . "\n";
+
+// A client with no options is valid: it has a default timeout and follows
+// redirects. Constructing without a throw is the assertion; note that a
+// Go-backed binding is not is_object(), which holds for every host class and
+// not just this one.
+try {
+    new HTTP\Client();
+    echo "client\n";
+} catch (Exception $e) {
+    echo "no_client\n";
+}
+
+try {
+    new HTTP\Client(array(
+        "timeout"          => 5,
+        "base_url"         => "https://example.invalid",
+        "follow_redirects" => false,
+        "user_agent"       => "phpscript/1",
+        "headers"          => array("Authorization" => "Bearer token"),
+    ));
+    echo "configured\n";
+} catch (Exception $e) {
+    echo "not_configured\n";
+}
+
+// An unknown option is a mistake in the script, not a value to ignore.
+try {
+    new HTTP\Client(array("timeuot" => 5));
+    echo "accepted\n";
+} catch (Exception $e) {
+    echo "rejected\n";
+}
+
+// A request needs a method and a url.
+try {
+    new HTTP\Request("", "https://example.invalid");
+    echo "accepted\n";
+} catch (Exception $e) {
+    echo "rejected\n";
+}
+?>
+---
+GET
+https://example.invalid/users
+https://example.invalid/users?page=2
+application/json
+payload
+application/json
+POST
+{"name":"ada"}
+client
+configured
+rejected
+rejected

--- a/tests/fixtures/http_request.phpt
+++ b/tests/fixtures/http_request.phpt
@@ -1,41 +1,40 @@
 name: http request and client construction
 description: >
   HTTP\Request and HTTP\Client are host bindings with no PHP counterpart, so
-  the expected output is the runtime's contract rather than PHP's. Only
-  construction and introspection are covered: building a request sends
-  nothing, so this stays offline. Sending is tested against httptest in
-  stdlib/http/client_test.go, because a fixture that reached the network would
-  fail whenever the network did.
+  the expected output is the runtime's contract rather than PHP's. A request is
+  a net/http request, so this covers the Go spellings a script uses to read and
+  write one. Only construction and introspection are covered: building a
+  request sends nothing, so this stays offline. Sending, including parallel(),
+  is tested against httptest in stdlib/http/client_test.go, because a fixture
+  that reached the network would fail whenever the network did.
 runner:
   php: false
 ---
 <?php
 
-$request = new HTTP\Request("get", "https://example.invalid/users");
-echo $request->method() . "\n";
-echo $request->url() . "\n";
+$request = new HTTP\Request("GET", "https://example.invalid/users?page=1");
 
-// The setters return the request, so they chain.
-$request->set_header("Accept", "application/json")
-        ->set_query("page", "2")
-        ->set_body("payload");
+// A request is a net/http request, so its fields are read the way Go names
+// them, matched case-insensitively.
+echo $request->method . "\n";
+echo $request->host . "\n";
+echo $request->url->path . "\n";
+echo $request->url->string() . "\n";
+echo $request->proto . "\n";
 
-echo $request->url() . "\n";
-echo $request->header("accept") . "\n";
-echo $request->body() . "\n";
+// Headers go through net/http's own Header methods.
+$request->header->set("Accept", "application/json");
+$request->header->add("X-Trace", "abc");
+echo $request->header->get("accept") . "\n";
 
-$headers = $request->headers();
-echo $headers["Accept"] . "\n";
-
-// A body is optional, and the method is normalised.
-$post = new HTTP\Request("post", "https://example.invalid/users", '{"name":"ada"}');
-echo $post->method() . "\n";
-echo $post->body() . "\n";
+// A body is optional, and its length is set on the request.
+$post = new HTTP\Request("POST", "https://example.invalid/users", '{"name":"ada"}');
+echo $post->method . "\n";
+echo $post->contentlength . "\n";
 
 // A client with no options is valid: it has a default timeout and follows
 // redirects. Constructing without a throw is the assertion; note that a
-// Go-backed binding is not is_object(), which holds for every host class and
-// not just this one.
+// Go-backed binding is not is_object(), which holds for every host class.
 try {
     new HTTP\Client();
     echo "client\n";
@@ -71,17 +70,28 @@ try {
 } catch (Exception $e) {
     echo "rejected\n";
 }
+
+// parallel() takes an array of HTTP\Request keyed by name. Anything else is
+// reported before a connection is opened.
+$client = new HTTP\Client();
+try {
+    $client->parallel(array("users" => "not a request"));
+    echo "accepted\n";
+} catch (Exception $e) {
+    echo "rejected\n";
+}
 ?>
 ---
 GET
-https://example.invalid/users
-https://example.invalid/users?page=2
-application/json
-payload
+example.invalid
+/users
+https://example.invalid/users?page=1
+HTTP/1.1
 application/json
 POST
-{"name":"ada"}
+14
 client
 configured
+rejected
 rejected
 rejected


### PR DESCRIPTION
## What

`HTTP\Request` and `HTTP\Client`, the outbound HTTP surface a script reaches instead of PHP's `curl_*` family. `docs/naming-conventions.md` has reserved both names as the intended spelling since before there was an implementation; this fills them in and moves that row to Implemented.

Split out of the Go plugins POC (#54) so it can be merged on its own. Nothing here depends on that branch.

## API

```php
$client = new HTTP\Client(array(
    "timeout"          => 10,
    "base_url"         => "https://example.com",
    "follow_redirects" => false,
    "user_agent"       => "phpscript/1",
    "headers"          => array("Authorization" => "Bearer ..."),
));

$request = new HTTP\Request("POST", "/users", '{"name":"ada"}');
$request->header->set("Content-Type", "application/json");

$response = $client->send($request);
if ($response->ok()) {
    $data = $response->json();
}
```

`$client->get($url)` and `$client->post($url, $body)` are shorthands. A request is inert until sent, so it can be built and inspected without a server.

### Parallel requests

`parallel()` sends a batch at once and returns the responses under the same keys, so a page making three calls waits for the slowest rather than the sum:

```php
$results = $client->parallel(array(
    "users" => new HTTP\Request("GET", "/users"),
    "stats" => new HTTP\Request("GET", "/stats"),
    "flags" => new HTTP\Request("GET", "/flags"),
));

foreach ($results as $name => $response) {
    if ($response->ok()) {
        echo $name . ": " . $response->status() . "\n";
    } else {
        echo $name . ": " . $response->err() . "\n";
    }
}
```

One request failing does not fail the others and does not throw: that response reports `ok()` as false and `err()` as the reason, so a script sees every outcome rather than only the first failure. A throw means the argument was not an array of requests. Each request is bounded by the client's timeout.

## Types

A request is a `*net/http.Request`, handed over rather than wrapped, so a script reads and writes it the way Go names it:

```php
$request->method                                    // "GET"
$request->host                                      // "example.com"
$request->url->path                                 // "/users"
$request->url->string()                             // the full URL
$request->header->set("Accept", "application/json")
$request->header->get("accept")
```

The published surface is therefore all of `net/http.Request`, because registration is not a method allowlist: every exported method and field of a constructor's concrete return type is reachable from a script.

`HTTP\Response` stays a facade. Its body is read in full when it is constructed, because a script has no stream to close and an unread `net/http` body leaks its connection, and `ok()` and `json()` have no `net/http` equivalent.

A client is a facade over `*net/http.Client` so that `send()`, `get()`, `post()` and `parallel()` have somewhere to live.

## Behaviour

A client always has a timeout, defaulting to 30 seconds, with no way to ask for none. An unknown option throws rather than being ignored, matching how `stdlib/smtp` parses its own option array. Response bodies are bounded at 32 MiB. `send()` and `parallel()` share one send path and both clone the request before configuring it, so the same request value can be sent twice and two goroutines cannot write to one request. `send()` opens an external telemetry span; `parallel()` opens one span for the batch and one per request.

HTTP methods are written uppercase. A lowercase one is corrected rather than sent as written, because a server treats the method as case-sensitive.

## Tests

Sending is covered by `stdlib/http/client_test.go` against `httptest`: the request line and headers the server received, `base_url` resolution, `follow_redirects`, JSON decoding, an unknown option, a timeout, and that `send()` does not mutate the caller's request. `parallel()` has three: that requests overlap rather than run in sequence (three 30ms requests complete in 30ms, and the handler records how many were in flight), that one refused connection leaves the rest of the batch intact, and that bad input is reported before a connection is opened.

`tests/fixtures/http_request.phpt` covers construction and introspection, which is what a script can check without a server. It opts the `php` runner out, because the classes do not exist in PHP and the expected output is the runtime's contract rather than PHP's behaviour.


## Documentation

[`docs/use-cases/http-client.md`](https://github.com/titpetric/phpscript/blob/feat/stdlib-http/docs/use-cases/http-client.md) is a walkthrough: configuring a client, sending one request, reading a request through its `net/http` fields, reading a response, `parallel()`, and a route that calls an upstream service. Every spelling in it was run through the runtime rather than written from the source.

Three unrelated fenced blocks in `docs/use-cases/` did not render as PHP and are fixed in their own commit. Two in `templating.md` were opened as ```` ```<?php ````, which reads `<?php` as the language name and swallows the opening tag; one in `bindings.md` had no language.

## Verification

`go build ./...`, `go vet ./...`, the full Go suite, `atkins lint` clean on `stdlib/http`, and `phpscript test --matrix` at 0 failures across interpreter, flatstack and php. `docs/reference/extensions/implemented-apis.md` and `docs/reference/README.md` are regenerated by `atkins test:introspection`.
