### PR TITLE
fix(stdlib): is_object answers for a value a Go binding returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ vendor
 # venom's per-run logs. Neither is committed.
 venom*.log
 demos/*/templates/cache/
+*.so
 
 # Local agent/editor state, never committed.
 /.claude

--- a/docs/reference/extensions/implemented-apis.md
+++ b/docs/reference/extensions/implemented-apis.md
@@ -272,7 +272,11 @@ function is_numeric(mixed $value): bool
 ```
 
 ```php
-// is_object reports whether $value is an object.
+/**
+ * is_object reports whether $value is an object. A value a Go binding
+ * returned is one: a script constructs it with new, calls its methods and
+ * reads its properties the same way it does an interpreted object.
+ */
 function is_object(mixed $value): bool
 ```
 

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -1127,8 +1127,10 @@ func registerLang(rt *runner.Runtime) {
 	rt.RegisterFunc("is_string", func(value any) bool { _, ok := value.(string); return ok })
 	// is_bool reports whether $value is a boolean.
 	rt.RegisterFunc("is_bool", func(value any) bool { _, ok := value.(bool); return ok })
-	// is_object reports whether $value is an object.
-	rt.RegisterFunc("is_object", func(value any) bool { _, ok := value.(*model.Object); return ok })
+	// is_object reports whether $value is an object. A value a Go binding
+	// returned is one: a script constructs it with new, calls its methods and
+	// reads its properties the same way it does an interpreted object.
+	rt.RegisterFunc("is_object", isObject)
 	// get_included_files returns the names of the files included or required so far.
 	rt.RegisterFunc("get_included_files", func() []string { return rt.IncludedFiles() })
 	// is_numeric reports whether $value is an int or a float; unlike PHP, numeric strings return false.
@@ -1357,4 +1359,35 @@ func arrValues(a any) []any {
 	out := make([]any, 0, n)
 	model.RangeValues(a, func(_, v any) bool { out = append(out, v); return true })
 	return out
+}
+
+// isObject reports whether value is what PHP calls an object, backing
+// is_object.
+//
+// An interpreted object is one. So is a value a Go binding handed over: a
+// script constructs it with new, calls its methods and reads its properties
+// the same way, and get_class, method_exists and spl_object_id all reflect
+// over it to answer.
+//
+// A collection is an array rather than an object, which is why the check comes
+// before the struct test: *model.Array is itself a pointer to a struct.
+func isObject(value any) bool {
+	if value == nil {
+		return false
+	}
+	if _, ok := value.(*model.Object); ok {
+		return true
+	}
+	if model.IsCollection(value) {
+		return false
+	}
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	return rv.Kind() == reflect.Struct
 }

--- a/tests/fixtures/is_object.phpt
+++ b/tests/fixtures/is_object.phpt
@@ -1,0 +1,37 @@
+name: is_object
+description: >
+  is_object answers for a value a Go binding returned, not only for an
+  interpreted object. Exception is the case both runtimes can be held to: it is
+  a Go type here and a class in PHP, and both call it an object. The expected
+  output is what php prints for the same source.
+---
+<?php
+
+class PhpThing {
+    public $x = 1;
+}
+
+function show($label, $v) {
+    echo $label . "=" . (is_object($v) ? "object" : "not_object") . "\n";
+}
+
+show("php_object", new PhpThing());
+show("exception", new Exception("boom"));
+show("array", array(1, 2, 3));
+show("empty_array", array());
+show("string", "x");
+show("int", 1);
+show("float", 1.5);
+show("bool", true);
+show("null", null);
+?>
+---
+php_object=object
+exception=object
+array=not_object
+empty_array=not_object
+string=not_object
+int=not_object
+float=not_object
+bool=not_object
+null=not_object


### PR DESCRIPTION
## What

`is_object` matched `*model.Object` and nothing else, so every value a Go binding handed over was not an object:

```php
is_object(new Exception("boom"));   // false
is_object(new Database("main"));    // false
is_object(new SharedMemory());      // false
```

Real PHP returns true for all three, and `Exception` is a class there.

## Why it is a defect and not a definition

Nothing else in the runtime agreed with `is_object`. For the same value:

| Function | Go binding value | PHP object |
|---|---|---|
| `is_object` | **false** | true |
| `is_array` | false | false |
| `get_class` | the Go type name | the class name |
| `method_exists` | true, reflected over the Go methods | true |
| `spl_object_id` | an identity | an identity |

So a Go binding was not an object, not an array and not a scalar, which is a kind of value PHP does not have. Of the five functions above, four reflect over the Go value; `is_object` matched `*model.Object` and nothing else.

## What changed

A value is an object when it is an interpreted object, or a Go struct or a pointer to one. The collection check runs first, because `*model.Array` is itself a pointer to a struct and an array is not an object.

```php
is_object(new PhpThing())      // true, unchanged
is_object(new Exception("x"))  // true, was false
is_object(array(1, 2, 3))      // false, unchanged
is_object("x")                 // false, unchanged
```

## Still divergent

A closure is not an object here, where PHP says it is. `Closure` is a class in PHP; a closure here is a Go function with no class behind it, so `get_class` returns nothing for one. Calling it an object while nothing else object-like works would be the same inconsistency in the other direction. It is left as it is rather than half-fixed.

## Tests

`tests/fixtures/is_object.phpt` is checked against `php`, which is possible because `Exception` is a Go type here and a class there, and both runtimes call it an object. It passes on all three runners:

```
| is_object.phpt | PASS       | PASS    | PASS |
```

## Verification

`go build ./...`, the full Go suite, and `phpscript test --matrix` at 0 failures across interpreter, flatstack and php. `docs/reference/extensions/implemented-apis.md` is regenerated.
