### PR TITLE
Compile closures to flatstack bytecode

### DIFF
--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -161,6 +161,8 @@ It supports these expressions:
 - Registered/free function calls and method calls
 - Property reads
 - String concatenation with `.`
+- Anonymous functions, including a by-value `use (...)` capture list, a `$this`
+  carried away from an enclosing method, and `static function () {}`
 
 The native operations above do not use `expr-lang`; arithmetic, coercion,
 comparison, array access, and truthiness are implemented by the flat VM and its
@@ -179,7 +181,12 @@ The complete program atomically selects fallback when it contains any currently
 unsupported form. The major remaining forms are:
 
 - Property increment/decrement and class-constant / static-property forms
-- Closures and callback bodies
+- Invoking a callable held in a value: `$fn(...)`, `$array[0](...)`,
+  `$this->handler(...)`. A closure compiles, but only a binding such as
+  `usort()` or `call_user_func()` can call one
+- By-reference closure captures `use (&$x)`, closure parameter defaults, and
+  variadic or by-reference closure parameters
+- `defer()`, which registers its callback on the frame that called it
 - `try` without a `catch` clause
 - Casts
 - PHP constructors (`__construct`) still run in the interpreter

--- a/flatstack/closure_test.go
+++ b/flatstack/closure_test.go
@@ -1,0 +1,173 @@
+package flatstack_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/titpetric/phpscript/flatstack"
+	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/stdlib"
+)
+
+// TestFlatstackCompilesClosures covers the anonymous-function forms the compiler
+// lowers. Every case asserts Supports before it checks the output, because a
+// fallback to the interpreter would produce the same output and hide a compiler
+// that quietly stopped handling the form.
+func TestFlatstackCompilesClosures(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "comparator argument",
+			source: `<?php $n = array(3, 1, 2); usort($n, function ($a, $b) { return $a - $b; }); echo implode(",", $n);`,
+			want:   "1,2,3",
+		},
+		{
+			name:   "comparator held in a variable",
+			source: `<?php $c = function ($a, $b) { return strlen($a) - strlen($b); }; $w = array("ccc", "a", "bb"); usort($w, $c); echo implode(",", $w);`,
+			want:   "a,bb,ccc",
+		},
+		{
+			// The capture is read where the closure value is created, so a
+			// later write to the captured variable is not visible to it.
+			name:   "use captures a snapshot",
+			source: `<?php $m = 3; $f = function ($x) use ($m) { return $x * $m; }; $m = 10; echo implode(",", array_map($f, array(1, 2)));`,
+			want:   "3,6",
+		},
+		{
+			name:   "parameter shadows a capture of the same name",
+			source: `<?php $x = "outer"; echo call_user_func(function ($x) { return $x; }, "inner");`,
+			want:   "inner",
+		},
+		{
+			name:   "an omitted argument binds null",
+			source: `<?php echo var_export(call_user_func(function ($a, $b) { return $b; }, 1), true);`,
+			want:   "NULL",
+		},
+		{
+			name:   "a closure written in a method carries $this",
+			source: `<?php class Box { public $n = "box"; function tag($items) { return array_map(function ($i) { return $this->n . ":" . $i; }, $items); } } $b = new Box; echo implode(",", $b->tag(array("a", "b")));`,
+			want:   "box:a,box:b",
+		},
+		{
+			name:   "static closure",
+			source: `<?php echo call_user_func(static function () { return "static"; });`,
+			want:   "static",
+		},
+		{
+			name:   "a closure returning a closure",
+			source: `<?php $add = function ($x) { return function ($y) use ($x) { return $x + $y; }; }; echo implode(",", array_map(call_user_func($add, 10), array(1, 2)));`,
+			want:   "11,12",
+		},
+		{
+			name:   "control flow and a call in the body",
+			source: `<?php function twice($v) { return $v * 2; } echo call_user_func(function ($limit) { $sum = 0; for ($i = 0; $i < $limit; $i++) { $sum += twice($i); } return $sum; }, 4);`,
+			want:   "12",
+		},
+		{
+			// A closure created inside a try is jumped over without leaving the
+			// handler the try armed, and one that throws is caught by the try
+			// the call was made from.
+			name:   "created and throwing inside a try",
+			source: `<?php try { $f = function () { throw new Exception("boom"); }; echo implode(",", array_map($f, array(1))); } catch (Exception $e) { echo "caught:", $e->getMessage(); }`,
+			want:   "caught:boom",
+		},
+		{
+			// usort() has the caller's variables bound while it runs its
+			// comparator. The comparator installs its own binding for the calls
+			// it makes, and has to leave the caller's in place on the way out.
+			name:   "a comparator does not overwrite the caller's variables",
+			source: `<?php $a = 1; $b = 2; $n = array(3, 1, 2); usort($n, function ($a, $b) { return $a - $b; }); echo $a, $b, implode(",", $n);`,
+			want:   "121,2,3",
+		},
+		{
+			// preg_match writes an output parameter through the frame the call
+			// was made from, which for this one is the closure's own.
+			name:   "an output parameter inside a closure body",
+			source: `<?php $keep = "kept"; $hits = array_map(function ($s) { preg_match('/([0-9])/', $s, $m); return $m[1]; }, array("a1", "b2")); echo implode(",", $hits), $keep;`,
+			want:   "1,2kept",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := flatstack.Supports(program); err != nil {
+				t.Fatalf("expected native bytecode support: %v", err)
+			}
+			var output strings.Builder
+			runtime := flatstack.New(&output, flatstack.Options{})
+			stdlib.Register(runtime)
+			if err := runtime.Run(program); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if got := output.String(); got != test.want {
+				t.Fatalf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestFlatstackRejectsClosureForms pins the closure forms that keep going to the
+// interpreter. Each one needs something a compiled frame does not have: a
+// reference cell for the enclosing variable, an expression evaluated on the
+// missing-argument path, or the caller's scope itself.
+func TestFlatstackRejectsClosureForms(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "by-reference capture",
+			source: `<?php $n = 0; $f = function () use (&$n) { $n++; };`,
+			want:   "unsupported by-reference capture use (&$n)",
+		},
+		{
+			name:   "parameter default",
+			source: `<?php $f = function ($a = 1) { return $a; };`,
+			want:   "unsupported closure parameter default",
+		},
+		{
+			name:   "by-reference parameter",
+			source: `<?php $f = function (&$a) { $a = 1; };`,
+			want:   "unsupported by-reference closure parameter",
+		},
+		{
+			name:   "variadic parameter",
+			source: `<?php $f = function (...$rest) { return $rest; };`,
+			want:   "unsupported variadic closure parameter",
+		},
+		{
+			name:   "invoking a callable held in a value",
+			source: `<?php $f = function () { return 1; }; echo $f();`,
+			want:   "unsupported expression *model.Invoke",
+		},
+		{
+			name:   "defer",
+			source: `<?php defer(function () { echo "late"; });`,
+			want:   "unsupported defer() registers on the calling frame",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = flatstack.Supports(program)
+			if err == nil {
+				t.Fatal("expected the form to be rejected")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want one containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -779,8 +779,16 @@ func (c *compiler) expr(expr model.Expr, path string) error {
 		}
 		c.program.code[endJump].target = len(c.program.code)
 	case *model.Call:
-		if node.Name == "compact" {
+		switch node.Name {
+		case "compact":
 			return unsupported(path, "compact() requires scope reflection")
+		case "defer":
+			// defer() registers its callback on the frame that called it, and
+			// the frame runs it on the way out. The bytecode engine hands a
+			// binding a throwaway scope per call, so the registration would be
+			// dropped rather than run late. It only became reachable once
+			// closures compiled, since the callback is nearly always one.
+			return unsupported(path, "defer() registers on the calling frame")
 		}
 		for i, argument := range node.Args {
 			// An output parameter is handed to the binding as a setter for the
@@ -831,9 +839,76 @@ func (c *compiler) expr(expr model.Expr, path string) error {
 		return c.assignment(node.Target, node.Op, node.Value, true, path)
 	case *model.Include:
 		return c.include(node, path)
+	case *model.Closure:
+		return c.closure(node, path)
 	default:
 		return unsupported(path, "expression %T", expr)
 	}
+	return nil
+}
+
+// closure compiles an anonymous function. The body is laid out inline and
+// jumped over, the way funcDecl lays out a named function, and the opClosure
+// left behind builds the callable value when control reaches it.
+//
+// The value is a func(...any) (any, error), the one shape Runtime.Callable
+// reduces every PHP callable to, so usort() and array_map() invoke a compiled
+// closure without knowing which backend produced it.
+func (c *compiler) closure(node *model.Closure, path string) error {
+	def := closureDef{thisSlot: -1}
+	for i, param := range node.Params {
+		paramPath := fmt.Sprintf("%s.param[%d]", path, i)
+		switch {
+		case param.Default != nil:
+			// A default is an expression evaluated at call time in the scope of
+			// the declaration, and no instruction runs on the path where the
+			// argument is missing.
+			return unsupported(paramPath, "closure parameter default")
+		case param.ByRef:
+			return unsupported(paramPath, "by-reference closure parameter")
+		case param.Variadic:
+			return unsupported(paramPath, "variadic closure parameter")
+		}
+		def.paramSlots = append(def.paramSlots, c.slot(param.Name))
+	}
+	for _, use := range node.Uses {
+		if use.ByRef {
+			// `use (&$x)` binds the enclosing variable itself, and a compiled
+			// closure frame holds copies. Rejecting it sends the program to the
+			// interpreter rather than silently compiling it as by-value.
+			return unsupported(path, "by-reference capture use (&$%s)", use.Name)
+		}
+		def.captures = append(def.captures, c.slot(use.Name))
+	}
+	// A closure written in a method carries `$this` away with it, and a
+	// `static function` is declared not to. The interpreter drops the class
+	// with the receiver, so `self::` in a static closure resolves the same way
+	// on both backends.
+	if !node.Static && c.class != "" {
+		def.thisSlot = c.slot("this")
+	}
+
+	jumpAround := c.emit(instruction{op: opJump, target: -1})
+	def.entryPC = len(c.program.code)
+
+	// The body is its own control-flow scope: a loop around the closure is not
+	// one its `break` can leave, and a `return` in it returns from the closure.
+	enclosingLoops, enclosingClass := c.loops, c.class
+	c.loops = nil
+	if node.Static {
+		c.class = ""
+	}
+	err := c.block(node.Body, path+".body")
+	c.loops, c.class = enclosingLoops, enclosingClass
+	if err != nil {
+		return err
+	}
+	c.emit(instruction{op: opPushConst, a: c.constant(nil)})
+	c.emit(instruction{op: opReturn})
+	c.program.code[jumpAround].target = len(c.program.code)
+
+	c.program.closures = append(c.program.closures, def)
+	c.emit(instruction{op: opClosure, a: len(c.program.closures) - 1})
 	return nil
 }
 

--- a/flatstack/engine/program.go
+++ b/flatstack/engine/program.go
@@ -48,6 +48,7 @@ const (
 	opVivifyProperty
 	opClassConst
 	opCast
+	opClosure
 )
 
 type instruction struct {
@@ -63,6 +64,30 @@ type instruction struct {
 type userFuncDef struct {
 	entryPC int
 	params  []string
+}
+
+// closureDef is one compiled anonymous function. Its body sits inline in the
+// instruction stream, jumped over the way a function declaration's body is, and
+// opClosure turns the definition into a callable value.
+//
+// The slot numbers are frame offsets, and the same number means the same name
+// in every frame: Program.localNames is per program, not per function. That is
+// what lets a capture be copied straight from the creating frame into the
+// closure's own frame without a name lookup.
+type closureDef struct {
+	entryPC int
+	// paramSlots holds one slot per declared parameter, in order. An argument
+	// the caller did not pass leaves the slot null, which is what the
+	// interpreter's bindParams does.
+	paramSlots []int
+	// captures holds the slots of the `use (...)` list. They are read where the
+	// closure value is created, not where it is called, so the capture is the
+	// snapshot PHP's by-value `use` describes.
+	captures []int
+	// thisSlot is the slot holding the receiver a closure written inside a
+	// method carries away, or -1 for a `static function` and for one written
+	// outside a class.
+	thisSlot int
 }
 
 // catchClause is one compiled `catch (Type $var) { ... }`. declaredType is kept
@@ -84,6 +109,9 @@ type Program struct {
 	// catchGroups holds the clause list of every compiled try, in source
 	// order; opTryPush carries the index of its own group.
 	catchGroups [][]catchClause
+	// closures holds one entry per anonymous function in the program, in source
+	// order; opClosure carries the index of its own definition.
+	closures []closureDef
 }
 
 // Entry is one key/value pair produced for foreach.

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -93,12 +93,42 @@ type MemoryHost interface {
 	CheckMemory() error
 }
 
+// localSeed is one local written into a frame before it starts running: the
+// captures and the arguments of a closure call.
+type localSeed struct {
+	slot  int
+	value any
+}
+
+// hostLocals is the optional Host capability that exposes the script's
+// variables to a binding for the duration of a call.
+type hostLocals interface {
+	BindLocals(map[string]any)
+	TakeLocals() map[string]any
+}
+
 // Run executes a previously validated flat instruction stream.
-func Run(program *Program, host Host) (err error) {
+func Run(program *Program, host Host) error {
 	if program == nil {
 		return nil
 	}
-	pc := 0
+	if registrar, ok := host.(interface{ RegisterClass(*model.Class) }); ok {
+		for _, class := range program.classes {
+			registrar.RegisterClass(class)
+		}
+	}
+	return run(program, host, 0, nil, nil)
+}
+
+// run executes one frame, starting at entryPC with seeds already written into
+// its locals. The value the frame returns is reported through result, which is
+// nil for the top-level frame because nothing consumes it.
+//
+// A closure call re-enters here rather than pushing a call frame on the running
+// loop: the call arrives from a host binding (usort() invoking its comparator),
+// not from an instruction, so there is no loop to push onto.
+func run(program *Program, host Host, entryPC int, seeds []localSeed, result *any) (err error) {
+	pc := entryPC
 	scratch := scratchPool.Get().(*vmScratch)
 	stack := scratch.stack[:0]
 	nlocal := len(program.localNames)
@@ -110,9 +140,9 @@ func Run(program *Program, host Host) (err error) {
 	initialized := scratch.initialized[:nlocal]
 	clear(locals)
 	clear(initialized)
-	if registrar, ok := host.(interface{ RegisterClass(*model.Class) }); ok {
-		for _, class := range program.classes {
-			registrar.RegisterClass(class)
+	for _, seed := range seeds {
+		if seed.slot >= 0 && seed.slot < len(locals) {
+			locals[seed.slot], initialized[seed.slot] = seed.value, true
 		}
 	}
 	extras := map[string]any{}
@@ -287,13 +317,22 @@ func Run(program *Program, host Host) (err error) {
 			}
 			stack = append(stack, stack[len(stack)-1])
 		case opLoad:
-			if initialized[inst.a] {
-				stack = append(stack, locals[inst.a])
-			} else if extra, ok := extras[program.localNames[inst.a]]; ok {
-				stack = append(stack, extra)
-			} else {
-				stack = append(stack, host.Lookup(program.localNames[inst.a]))
+			stack = append(stack, loadLocal(host, program, locals, initialized, extras, inst.a))
+		case opClosure:
+			def := program.closures[inst.a]
+			captured := make([]localSeed, 0, len(def.captures)+1)
+			for _, slot := range def.captures {
+				captured = append(captured, localSeed{
+					slot:  slot,
+					value: loadLocal(host, program, locals, initialized, extras, slot),
+				})
 			}
+			// An unbound `$this` is left out rather than captured as null, so
+			// the closure body reads it the way any other unset local is read.
+			if def.thisSlot >= 0 && initialized[def.thisSlot] {
+				captured = append(captured, localSeed{slot: def.thisSlot, value: locals[def.thisSlot]})
+			}
+			stack = append(stack, closureValue(program, host, def, captured))
 		case opStore:
 			value, popErr := pop()
 			if popErr != nil {
@@ -770,7 +809,9 @@ func Run(program *Program, host Host) (err error) {
 				}
 				stack = append(stack, retVal)
 			} else {
-				stack = append(stack, retVal)
+				if result != nil {
+					*result = retVal
+				}
 				return nil
 			}
 		case opEnsureArray:
@@ -855,6 +896,65 @@ func Run(program *Program, host Host) (err error) {
 		pc++
 	}
 	return nil
+}
+
+// loadLocal reads a frame slot the way opLoad does: the local if the frame set
+// it, otherwise a variable a host binding introduced, otherwise whatever the
+// host knows under that name (a global or a constant).
+func loadLocal(host Host, program *Program, locals []any, initialized []bool, extras map[string]any, slot int) any {
+	if initialized[slot] {
+		return locals[slot]
+	}
+	if extra, ok := extras[program.localNames[slot]]; ok {
+		return extra
+	}
+	return host.Lookup(program.localNames[slot])
+}
+
+// closureValue turns a compiled closure into the func(...any) (any, error)
+// shape Runtime.Callable reduces every PHP callable to, so a binding invokes a
+// bytecode closure exactly as it invokes an interpreted one.
+//
+// captured is the snapshot taken where the closure value was created. Each call
+// gets a fresh frame seeded with it, so one call cannot see another's writes,
+// and the closure keeps working after the frame it was written in is gone.
+func closureValue(program *Program, host Host, def closureDef, captured []localSeed) func(...any) (any, error) {
+	return func(args ...any) (any, error) {
+		seeds := make([]localSeed, 0, len(captured)+len(def.paramSlots))
+		seeds = append(seeds, captured...)
+		// Parameters are seeded after the captures, so a parameter of the same
+		// name shadows the capture, as it does in PHP. An argument the caller
+		// omitted binds null, matching the interpreter's bindParams.
+		for i, slot := range def.paramSlots {
+			var value any
+			if i < len(args) {
+				value = args[i]
+			}
+			seeds = append(seeds, localSeed{slot: slot, value: value})
+		}
+		// The locals the host is holding belong to the call this closure was
+		// handed to: usort() had a snapshot taken before it invoked the
+		// comparator, and the VM writes that snapshot back when usort()
+		// returns. The body installs its own on every call it makes, so the
+		// caller's has to be put back on the way out.
+		defer restoreHostLocals(host)()
+		var result any
+		if err := run(program, host, def.entryPC, seeds, &result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+}
+
+// restoreHostLocals captures the host's current variable binding and returns the
+// call that reinstates it.
+func restoreHostLocals(host Host) func() {
+	binder, ok := host.(hostLocals)
+	if !ok {
+		return func() {}
+	}
+	saved := binder.TakeLocals()
+	return func() { binder.BindLocals(saved) }
 }
 
 func bindHostLocals(host Host, program *Program, locals []any, initialized []bool, extras map[string]any) {

--- a/flatstack/load_test.go
+++ b/flatstack/load_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/titpetric/phpscript/flatstack"
 	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
+	"github.com/titpetric/phpscript/stdlib"
 	"github.com/titpetric/phpscript/tests"
 )
 
@@ -276,17 +277,24 @@ $storage->get("missing");
 	}
 }
 
+// TestFlatstackRejectsWholeProgramBeforeSideEffects checks that a rejected
+// program runs once, on the interpreter, rather than partly on each backend.
+// The constructor counts its calls, so a compile that gave up after the `new`
+// had already run would report two.
+//
+// compact() is the unsupported construct: it reads the caller's variables by
+// name, which the compiler has no scope to reflect over, so it stays rejected.
 func TestFlatstackRejectsWholeProgramBeforeSideEffects(t *testing.T) {
 	program, err := parser.Parse(`<?php
 $storage = new Storage;
-$fn = function() { return 1; };
+$keep = compact('storage');
 echo 42;
 `)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := flatstack.Supports(program); err == nil {
-		t.Fatal("program with a closure should require interpreter fallback")
+		t.Fatal("program with compact() should require interpreter fallback")
 	}
 
 	var constructions atomic.Int64
@@ -296,6 +304,9 @@ echo 42;
 	}
 	var output strings.Builder
 	runtime := flatstack.New(&output, flatstack.Options{})
+	// compact() is a stdlib registration; without it the interpreter reports an
+	// undefined function instead of running the fallback.
+	stdlib.Register(runtime)
 	runtime.RegisterConstructor("Storage", constructor)
 	if err := runtime.Run(program); err != nil {
 		t.Fatal(err)

--- a/flatstack/load_test.go
+++ b/flatstack/load_test.go
@@ -308,6 +308,30 @@ echo 42;
 	}
 }
 
+// TestFlatstackSupportsArrayCallbackClosures fails until the compiler learns
+// *model.Closure, and is the only signal that it has: runFlat discards the
+// compile error and reruns the program on the interpreter, so the fixture in
+// tests/fixtures/arrays/array_callbacks.phpt passes either way.
+//
+// A closure argument is the most common reason a real library drops out of the
+// bytecode engine. One usort() comparator costs the whole file, because Compile
+// rejects a program on any unsupported node.
+func TestFlatstackSupportsArrayCallbackClosures(t *testing.T) {
+	program, err := parser.Parse(`<?php
+$n = array(3, 1, 2);
+usort($n, function ($a, $b) {
+	return $a - $b;
+});
+echo implode(",", $n);
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("usort closure should compile to bytecode: %v", err)
+	}
+}
+
 func TestFlatstackSharedCacheParallel(t *testing.T) {
 	program, err := parser.Parse(`<?php $a = "shared"; $b = "-cache"; echo $a . $b; ?>`)
 	if err != nil {

--- a/stdlib/database/migrate.go
+++ b/stdlib/database/migrate.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"path"
 	"strings"
@@ -52,7 +53,21 @@ func (m *DatabaseMigrate) Run(ctx context.Context) error {
 	defer span.End()
 	span.SetAttribute("migrations", len(m.migrations))
 
-	err := migrate.RunWithFS(ctx, m.database, m.migrations, migrate.NewOptions())
+	// mig requires a log sink and returns logger.ErrNoLogFn without one. The
+	// lines it writes are per-file status, so they go on the span. Writing them
+	// to the script's output would put them in whatever the script is producing,
+	// which for a migration run at startup is an HTTP body or a rendered page.
+	var progress strings.Builder
+	options := migrate.NewOptions()
+	options.LogFn = func(format string, args ...any) {
+		fmt.Fprintf(&progress, format, args...)
+		progress.WriteByte('\n')
+	}
+
+	err := migrate.RunWithFS(ctx, m.database, m.migrations, options)
+	if progress.Len() > 0 {
+		span.SetAttribute("log", strings.TrimRight(progress.String(), "\n"))
+	}
 	span.RecordError(err)
 	return err
 }

--- a/tests/fixtures/arrays/array_callbacks.phpt
+++ b/tests/fixtures/arrays/array_callbacks.phpt
@@ -2,10 +2,9 @@ name: array callbacks with closures
 description: >
   usort and array_map take a closure, inline and held in a variable. The
   comparator sorts by length and then alphabetically, the shape a template
-  engine uses to replace the longest variable names first. This passes on
-  flatstack today by falling back to the compatibility interpreter;
-  TestFlatstackSupportsArrayCallbackClosures is what holds the bytecode
-  engine to compiling it.
+  engine uses to replace the longest variable names first. This compiles to
+  flatstack bytecode; TestFlatstackSupportsArrayCallbackClosures is what holds
+  the bytecode engine to it, since a fallback would still produce this output.
 ---
 <?php
 $vars = array('$var', '$v', '$variable', '$var1');

--- a/tests/fixtures/arrays/array_callbacks.phpt
+++ b/tests/fixtures/arrays/array_callbacks.phpt
@@ -1,0 +1,32 @@
+name: array callbacks with closures
+description: >
+  usort and array_map take a closure, inline and held in a variable. The
+  comparator sorts by length and then alphabetically, the shape a template
+  engine uses to replace the longest variable names first. This passes on
+  flatstack today by falling back to the compatibility interpreter;
+  TestFlatstackSupportsArrayCallbackClosures is what holds the bytecode
+  engine to compiling it.
+---
+<?php
+$vars = array('$var', '$v', '$variable', '$var1');
+usort($vars, function ($a, $b) {
+	if (strlen($a) == strlen($b)) {
+		if ($a == $b) {
+			return 0;
+		}
+		return ($a < $b) ? 1 : -1;
+	}
+	return (strlen($a) < strlen($b)) ? 1 : -1;
+});
+echo implode(",", $vars), "\n";
+
+echo implode(",", array_map(function ($n) { return $n * 2; }, array(1, 2, 3))), "\n";
+
+$byLength = function ($a, $b) { return strlen($a) - strlen($b); };
+$words = array("ccc", "a", "bb");
+usort($words, $byLength);
+echo implode(",", $words), "\n";
+---
+$variable,$var1,$var,$v
+2,4,6
+a,bb,ccc

--- a/tests/fixtures/flatstack/closure_compiles.phpt
+++ b/tests/fixtures/flatstack/closure_compiles.phpt
@@ -1,0 +1,61 @@
+name: closures compile to bytecode
+description: >
+  An anonymous function is a *model.Closure node. The flatstack compiler lays
+  its body out inline and leaves an instruction that builds the callable, so a
+  file that hands usort() or array_map() a comparator stays on bytecode instead
+  of dropping its whole program back to the interpreter.
+  tests/fixtures/functions/closure_capture.phpt covers the capture rules
+  themselves; this one covers the compiled path.
+---
+<?php
+
+$words = array("ccc", "a", "bb");
+usort($words, function ($a, $b) {
+	return strlen($a) - strlen($b);
+});
+echo implode(",", $words), "\n";
+
+$factor = 3;
+$scale = function ($n) use ($factor) {
+	return $n * $factor;
+};
+$factor = 10;
+echo implode(",", array_map($scale, array(1, 2, 3))), "\n";
+
+class Tagger
+{
+	public $prefix = "tag";
+
+	function tag($items)
+	{
+		return array_map(function ($item) {
+			return $this->prefix . ":" . $item;
+		}, $items);
+	}
+}
+
+$tagger = new Tagger();
+echo implode(",", $tagger->tag(array("a", "b"))), "\n";
+
+echo call_user_func(static function () {
+	$total = 0;
+	foreach (array(1, 2, 3) as $n) {
+		$total += $n;
+	}
+	return $total;
+}), "\n";
+
+try {
+	array_map(function ($n) {
+		throw new Exception("no " . $n);
+	}, array(1));
+	echo "not reached\n";
+} catch (Exception $error) {
+	echo "caught: ", $error->getMessage(), "\n";
+}
+---
+a,bb,ccc
+3,6,9
+tag:a,tag:b
+6
+caught: no 1


### PR DESCRIPTION
`*model.Closure` had no case in the compiler's expression dispatch, so it fell through to `default`. `Compile` is whole-program, so one `usort()` comparator dropped a whole file to the compatibility interpreter.

## Changes

| File | Change |
|---|---|
| `flatstack/engine/compiler.go` | `case *model.Closure`. The body is laid out inline and jumped over, the shape `funcDecl` already used, leaving an `opClosure` at the landing point. |
| `flatstack/engine/program.go` | `closureDef`: parameter slots, capture slots, `thisSlot`, entry PC. |
| `flatstack/engine/vm.go` | `Run` split into `run(program, host, entryPC, seeds, *result)`, one frame from an entry PC with locals pre-seeded. Adds `opClosure` and `closureValue`. `Run` keeps its signature. |

A closure call arrives from a host binding rather than an instruction, so there is no running loop to push a frame onto, which is why `Run` was split. The value is a `func(...any) (any, error)`, the shape `Runtime.Callable` reduces every PHP callable to, so `usort`, `array_map`, `preg_replace_callback` and `spl_autoload_register` invoke it without knowing which backend produced it. Captures are snapshotted where the closure value is created, and each call gets a fresh frame seeded with them.

Compiles: positional parameters, by-value `use`, a parameter shadowing a capture, `$this` carried out of a method, `static function`, nested closures, and bodies with loops, `try`/`catch`/`finally`, `throw`, `exit()` and output parameters.

## Still rejected, so the program falls back

| Form | Reason |
|---|---|
| `use (&$x)` | Binds the enclosing variable; a compiled frame holds copies. |
| Parameter defaults, variadic and by-ref parameters | The default is an expression on the missing-argument path, where no instruction runs. |
| `$fn(...)`, `$arr[0](...)` (`*model.Invoke`) | A separate node and a separate feature. A closure compiles, but only a host binding can call one. |
| `Closure::bind`, `bindTo` | Depends on `Invoke` and on closures being objects. |

## Two fixes that came with it

`usort()` binds the caller's variables while it runs the comparator, and the comparator installs its own for every call it makes. Without restoring, the comparator's `$a` and `$b` were written back into the caller's frame. `restoreHostLocals` reinstates the caller's binding on the way out of every closure call.

`defer()` registers its callback on the frame that called it, and `flatHost.Call` hands each binding a throwaway scope, so the registration was dropped. It was unreachable until closures compiled, since the callback is always one. `defer` is now rejected by the compiler, which restores the fallback. Making it work needs a persistent host scope and a frame notion for compiled user functions.

## Unrelated commit

`9a50f29` binds a log sink for mig migrations. mig v0.5.3 made `Options.LogFn` mandatory, and `RunWithFS` returns before touching the database without one. The sink writes into the migrate span, because mig logs a status line per file and a startup migration would otherwise put those lines in the HTTP body the script is producing.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` and the fixture matrix at 117/117. Five fixtures move from fallback to bytecode: `arrays/array_callbacks`, `regex/preg_replace_callback`, `functions/callables`, `output/gettype` and `autoloading/autoloading`.
