### PR TITLE
feat(flatstack): compile and execute defer() natively with zero-allocation frame unwind

### DIFF
--- a/docs/coverage/phpscript-detail.md
+++ b/docs/coverage/phpscript-detail.md
@@ -43,7 +43,7 @@ github.com/titpetric/phpscript/config/config.go, symbols 4, coverage 88.75%
 github.com/titpetric/phpscript/config.go, symbols 2, coverage 69.60%
 github.com/titpetric/phpscript/config/server.go, symbols 1, coverage 100.00%
 github.com/titpetric/phpscript/config/virtualhost.go, symbols 9, coverage 96.42%
-github.com/titpetric/phpscript/flatstack/engine/compiler.go, symbols 28, coverage 87.93%
+github.com/titpetric/phpscript/flatstack/engine/compiler.go, symbols 28, coverage 87.60%
 github.com/titpetric/phpscript/flatstack/engine/vm.go, symbols 12, coverage 83.23%
 github.com/titpetric/phpscript/flatstack/flatstack.go, symbols 10, coverage 50.00%
 github.com/titpetric/phpscript/formatter/comments.go, symbols 7, coverage 91.63%

--- a/docs/coverage/phpscript-detail.md
+++ b/docs/coverage/phpscript-detail.md
@@ -43,8 +43,8 @@ github.com/titpetric/phpscript/config/config.go, symbols 4, coverage 88.75%
 github.com/titpetric/phpscript/config.go, symbols 2, coverage 69.60%
 github.com/titpetric/phpscript/config/server.go, symbols 1, coverage 100.00%
 github.com/titpetric/phpscript/config/virtualhost.go, symbols 9, coverage 96.42%
-github.com/titpetric/phpscript/flatstack/engine/compiler.go, symbols 28, coverage 87.64%
-github.com/titpetric/phpscript/flatstack/engine/vm.go, symbols 12, coverage 83.27%
+github.com/titpetric/phpscript/flatstack/engine/compiler.go, symbols 28, coverage 87.93%
+github.com/titpetric/phpscript/flatstack/engine/vm.go, symbols 12, coverage 83.23%
 github.com/titpetric/phpscript/flatstack/flatstack.go, symbols 10, coverage 50.00%
 github.com/titpetric/phpscript/formatter/comments.go, symbols 7, coverage 91.63%
 github.com/titpetric/phpscript/formatter/format.go, symbols 54, coverage 81.57%
@@ -96,8 +96,8 @@ github.com/titpetric/phpscript/runner/coverage/profile.go, symbols 4, coverage 9
 github.com/titpetric/phpscript/runner/coverage/row.go, symbols 5, coverage 100.00%
 github.com/titpetric/phpscript/runner/expr_cache.go, symbols 9, coverage 81.37%
 github.com/titpetric/phpscript/runner/filemode.go, symbols 5, coverage 77.50%
-github.com/titpetric/phpscript/runner/flatstack.go, symbols 35, coverage 92.19%
-github.com/titpetric/phpscript/runner/helpers.go, symbols 34, coverage 88.88%
+github.com/titpetric/phpscript/runner/flatstack.go, symbols 36, coverage 92.40%
+github.com/titpetric/phpscript/runner/helpers.go, symbols 34, coverage 89.47%
 github.com/titpetric/phpscript/runner/include_cache.go, symbols 6, coverage 81.43%
 github.com/titpetric/phpscript/runner/instanceof.go, symbols 5, coverage 55.22%
 github.com/titpetric/phpscript/runner/memory.go, symbols 8, coverage 46.24%
@@ -107,7 +107,7 @@ github.com/titpetric/phpscript/runner/output.go, symbols 3, coverage 47.23%
 github.com/titpetric/phpscript/runner/redeclare.go, symbols 7, coverage 81.07%
 github.com/titpetric/phpscript/runner/request.go, symbols 42, coverage 94.96%
 github.com/titpetric/phpscript/runner/response.go, symbols 6, coverage 100.00%
-github.com/titpetric/phpscript/runner/runner.go, symbols 52, coverage 81.23%
+github.com/titpetric/phpscript/runner/runner.go, symbols 52, coverage 81.27%
 github.com/titpetric/phpscript/runner/runtime.go, symbols 94, coverage 91.32%
 github.com/titpetric/phpscript/runner/scope.go, symbols 11, coverage 88.89%
 github.com/titpetric/phpscript/runner/size.go, symbols 6, coverage 82.40%

--- a/docs/coverage/phpscript.md
+++ b/docs/coverage/phpscript.md
@@ -20,7 +20,7 @@ github.com/titpetric/phpscript/cmd/phpscript/test, symbols 89, coverage 80.07%
 github.com/titpetric/phpscript/cmd/phpscript/version, symbols 2, coverage 0.00%
 github.com/titpetric/phpscript/config, symbols 14, coverage 94.49%
 github.com/titpetric/phpscript/flatstack, symbols 10, coverage 50.00%
-github.com/titpetric/phpscript/flatstack/engine, symbols 40, coverage 86.52%
+github.com/titpetric/phpscript/flatstack/engine, symbols 40, coverage 86.29%
 github.com/titpetric/phpscript/formatter, symbols 70, coverage 79.60%
 github.com/titpetric/phpscript/internal/apidoc, symbols 55, coverage 84.01%
 github.com/titpetric/phpscript/internal/arrayi64, symbols 1, coverage 100.00%

--- a/docs/coverage/phpscript.md
+++ b/docs/coverage/phpscript.md
@@ -20,7 +20,7 @@ github.com/titpetric/phpscript/cmd/phpscript/test, symbols 89, coverage 80.07%
 github.com/titpetric/phpscript/cmd/phpscript/version, symbols 2, coverage 0.00%
 github.com/titpetric/phpscript/config, symbols 14, coverage 94.49%
 github.com/titpetric/phpscript/flatstack, symbols 10, coverage 50.00%
-github.com/titpetric/phpscript/flatstack/engine, symbols 40, coverage 86.33%
+github.com/titpetric/phpscript/flatstack/engine, symbols 40, coverage 86.52%
 github.com/titpetric/phpscript/formatter, symbols 70, coverage 79.60%
 github.com/titpetric/phpscript/internal/apidoc, symbols 55, coverage 84.01%
 github.com/titpetric/phpscript/internal/arrayi64, symbols 1, coverage 100.00%
@@ -31,7 +31,7 @@ github.com/titpetric/phpscript/lint, symbols 36, coverage 86.23%
 github.com/titpetric/phpscript/list, symbols 24, coverage 76.85%
 github.com/titpetric/phpscript/model, symbols 153, coverage 36.58%
 github.com/titpetric/phpscript/parser, symbols 165, coverage 91.34%
-github.com/titpetric/phpscript/runner, symbols 408, coverage 86.59%
+github.com/titpetric/phpscript/runner, symbols 409, coverage 86.68%
 github.com/titpetric/phpscript/runner/bindings, symbols 24, coverage 86.72%
 github.com/titpetric/phpscript/runner/coverage, symbols 29, coverage 93.99%
 github.com/titpetric/phpscript/scripts/list-apis, symbols 1, coverage 0.00%

--- a/docs/flatstack.md
+++ b/docs/flatstack.md
@@ -145,6 +145,8 @@ Flat bytecode currently supports these statements:
 - Top-level PHP class declarations and free function declarations
 - `include` / `include_once` / `require` as statements or expressions
 - `list()` / array destructuring assignment
+- `defer()`, registered on the frame in flight and run LIFO when that frame
+  returns
 
 It supports these expressions:
 
@@ -186,7 +188,6 @@ unsupported form. The major remaining forms are:
   `usort()` or `call_user_func()` can call one
 - By-reference closure captures `use (&$x)`, closure parameter defaults, and
   variadic or by-reference closure parameters
-- `defer()`, which registers its callback on the frame that called it
 - Anonymous classes, `new class { ... }`. The bytecode carries a class name
   where an anonymous class carries its declaration
 - `try` without a `catch` clause

--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -117,6 +117,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 
 | tests/fixtures/exceptions    | Flat stack | Runtime | PHP  |
 |------------------------------|------------|---------|------|
+| catch_across_frames.phpt     | PASS       | PASS    | PASS |
 | catch_type_matching.phpt     | PASS       | PASS    | PASS |
 | die_exit.phpt                | PASS       | PASS    | PASS |
 | die_message.phpt             | PASS       | PASS    | PASS |
@@ -350,7 +351,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/bindings    | 27       | 27     | 0      |
 | tests/fixtures/comparison  | 1        | 1      | 0      |
 | tests/fixtures/errors      | 3        | 3      | 0      |
-| tests/fixtures/exceptions  | 9        | 9      | 0      |
+| tests/fixtures/exceptions  | 10       | 10     | 0      |
 | tests/fixtures/flatstack   | 8        | 8      | 0      |
 | tests/fixtures/functions   | 10       | 10     | 0      |
 | tests/fixtures/gd          | 7        | 7      | 0      |
@@ -365,4 +366,4 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/stdlib      | 23       | 23     | 0      |
 | tests/fixtures/strings     | 19       | 19     | 0      |
 | tests/fixtures/syntax      | 9        | 9      | 0      |
-| **Total**                  | 228      | 228    | 0      |
+| **Total**                  | 229      | 229    | 0      |

--- a/flatstack/catch_test.go
+++ b/flatstack/catch_test.go
@@ -98,3 +98,53 @@ func TestFlatstackCatchClauseSelection(t *testing.T) {
 		})
 	}
 }
+
+// TestFlatstackCatchSurvivesCalleeJumps pins the handler discipline across
+// frames: opJump discards a handler when the jump leaves its try's pc range,
+// and a callee's pcs are always outside the caller's range, so the range rule
+// is scoped to the frame that armed the handler. Before that scoping, the
+// first branch in a called function silently disarmed the caller's catch.
+func TestFlatstackCatchSurvivesCalleeJumps(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "branch in the callee",
+			source: `<?php function work() { if (true) { echo "body"; } throw new RuntimeException("x"); } try { work(); } catch (RuntimeException $e) { echo "-caught"; }`,
+			want:   "body-caught",
+		},
+		{
+			name:   "loop in the callee",
+			source: `<?php function work() { for ($i = 0; $i < 2; $i++) { echo "."; } throw new RuntimeException("x"); } try { work(); } catch (RuntimeException $e) { echo "-caught"; }`,
+			want:   "..-caught",
+		},
+		{
+			name:   "callee catches its own throw first",
+			source: `<?php function work() { try { throw new LogicException("inner"); } catch (LogicException $e) { echo "inner"; } throw new RuntimeException("x"); } try { work(); } catch (RuntimeException $e) { echo "-outer"; }`,
+			want:   "inner-outer",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := flatstack.Supports(program); err != nil {
+				t.Fatalf("expected native bytecode support: %v", err)
+			}
+			var output strings.Builder
+			runtime := flatstack.New(&output, flatstack.Options{})
+			stdlib.Register(runtime)
+			if err := runtime.Run(program); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if got := output.String(); got != test.want {
+				t.Fatalf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/flatstack/closure_test.go
+++ b/flatstack/closure_test.go
@@ -148,11 +148,6 @@ func TestFlatstackRejectsClosureForms(t *testing.T) {
 			source: `<?php $f = function () { return 1; }; echo $f();`,
 			want:   "unsupported expression *model.Invoke",
 		},
-		{
-			name:   "defer",
-			source: `<?php defer(function () { echo "late"; });`,
-			want:   "unsupported defer() registers on the calling frame",
-		},
 	}
 
 	for _, test := range tests {
@@ -169,5 +164,15 @@ func TestFlatstackRejectsClosureForms(t *testing.T) {
 				t.Fatalf("error = %v, want one containing %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestFlatstackSupportsDefer(t *testing.T) {
+	program, err := parser.Parse(`<?php defer(function () { echo "late"; });`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("defer unexpectedly rejected: %v", err)
 	}
 }

--- a/flatstack/engine/compiler.go
+++ b/flatstack/engine/compiler.go
@@ -859,12 +859,14 @@ func (c *compiler) expr(expr model.Expr, path string) error {
 		case "compact":
 			return unsupported(path, "compact() requires scope reflection")
 		case "defer":
-			// defer() registers its callback on the frame that called it, and
-			// the frame runs it on the way out. The bytecode engine hands a
-			// binding a throwaway scope per call, so the registration would be
-			// dropped rather than run late. It only became reachable once
-			// closures compiled, since the callback is nearly always one.
-			return unsupported(path, "defer() registers on the calling frame")
+			if len(node.Args) != 1 {
+				return unsupported(path, "defer() expects 1 argument")
+			}
+			if err := c.expr(node.Args[0], path+".arg[0]"); err != nil {
+				return err
+			}
+			c.emit(instruction{op: opDefer})
+			return nil
 		}
 		for i, argument := range node.Args {
 			// An output parameter is handed to the binding as a setter for the

--- a/flatstack/engine/program.go
+++ b/flatstack/engine/program.go
@@ -56,6 +56,9 @@ const (
 	// opDefineConst pops the value and declares it under the name a top-level
 	// `const` statement wrote, through the same host table define() uses.
 	opDefineConst
+	// opDefer pops the callable and registers it on the frame in flight; the
+	// VM runs the registrations LIFO when the frame returns.
+	opDefer
 )
 
 type instruction struct {
@@ -185,4 +188,6 @@ type Host interface {
 	Truthy(any) bool
 	Entries(any) []Entry
 	Echo(any) error
+	// InvokeCallable runs a deferred callable value on the host bridge.
+	InvokeCallable(any) error
 }

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -608,8 +608,16 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 			}
 			stack = append(stack, host.Truthy(value))
 		case opJump:
+			// A jump out of a try's pc range discards its handler; that is how
+			// leaving the region disarms the catch. The range only means
+			// anything in the frame that armed it: a callee's pcs lie outside
+			// the caller's try body, so a jump there - an if, a loop, the skip
+			// over an inline closure - must leave the caller's handlers alone.
 			for len(handlers) > 0 {
 				handler := handlers[len(handlers)-1]
+				if handler.frameDepth != len(callFrames) {
+					break
+				}
 				if inst.target >= handler.start && inst.target <= handler.end {
 					break
 				}

--- a/flatstack/engine/vm.go
+++ b/flatstack/engine/vm.go
@@ -22,6 +22,7 @@ type vmScratch struct {
 	stack       []any
 	locals      []any
 	initialized []bool
+	deferred    []any
 }
 
 // release returns the scratch buffers to the pool with every slot zeroed.
@@ -35,12 +36,17 @@ func (s *vmScratch) release(stack []any) {
 	clear(s.stack[:cap(s.stack)])
 	clear(s.locals[:cap(s.locals)])
 	clear(s.initialized[:cap(s.initialized)])
+	clear(s.deferred[:cap(s.deferred)])
+	s.deferred = s.deferred[:0]
 	scratchPool.Put(s)
 }
 
 var scratchPool = sync.Pool{
 	New: func() any {
-		return &vmScratch{stack: make([]any, 0, 32)}
+		return &vmScratch{
+			stack:    make([]any, 0, 32),
+			deferred: make([]any, 0, 8),
+		}
 	},
 }
 
@@ -93,6 +99,10 @@ type callFrame struct {
 	// here and handing the callee an empty one is what keeps a foreach that
 	// calls a function from being closed by the call it made.
 	iterators map[int]*iteratorState
+
+	// deferMark is the caller's boundary in scratch.deferred; opReturn unwinds
+	// the registrations above it, LIFO, before control leaves the frame.
+	deferMark int
 }
 
 // MemoryHost is an optional Host extension for memory accounting, discovered
@@ -179,10 +189,34 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 	var iterators map[int]*iteratorState
 	var handlers []errorHandler
 	var callFrames []callFrame
+
+	entryDeferMark := len(scratch.deferred)
+	unwindDeferred := func(mark int) error {
+		var errs []error
+		for len(scratch.deferred) > mark {
+			last := len(scratch.deferred) - 1
+			cb := scratch.deferred[last]
+			scratch.deferred[last] = nil
+			scratch.deferred = scratch.deferred[:last]
+			if cb != nil {
+				if callErr := host.InvokeCallable(cb); callErr != nil {
+					errs = append(errs, callErr)
+				}
+			}
+		}
+		if len(errs) > 0 {
+			return errors.Join(errs...)
+		}
+		return nil
+	}
+
 	defer func() {
+		unwindErr := unwindDeferred(entryDeferMark)
 		scratch.release(stack)
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("flatstack: VM panic at pc %d: %v", pc, recovered)
+		} else if err == nil && unwindErr != nil {
+			err = unwindErr
 		}
 	}()
 
@@ -227,6 +261,7 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 		}
 		for len(callFrames) > handler.frameDepth {
 			frame := callFrames[len(callFrames)-1]
+			_ = unwindDeferred(frame.deferMark)
 			callFrames = callFrames[:len(callFrames)-1]
 			locals = frame.locals
 			initialized = frame.initialized
@@ -620,6 +655,7 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 						extras:      extras,
 						refWrites:   refWrites,
 						iterators:   iterators,
+						deferMark:   len(scratch.deferred),
 					})
 					locals = make([]any, len(program.localNames))
 					initialized = make([]bool, len(program.localNames))
@@ -677,6 +713,7 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 						extras:      extras,
 						refWrites:   refWrites,
 						iterators:   iterators,
+						deferMark:   len(scratch.deferred),
 					})
 					locals = make([]any, len(program.localNames))
 					initialized = make([]bool, len(program.localNames))
@@ -857,6 +894,12 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 			}
 			if len(callFrames) > 0 {
 				lastFrame := callFrames[len(callFrames)-1]
+				if unwindErr := unwindDeferred(lastFrame.deferMark); unwindErr != nil {
+					if handle(unwindErr) {
+						continue
+					}
+					return unwindErr
+				}
 				callFrames = callFrames[:len(callFrames)-1]
 				pc = lastFrame.returnPC
 				locals = lastFrame.locals
@@ -869,6 +912,12 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 				}
 				stack = append(stack, retVal)
 			} else {
+				if unwindErr := unwindDeferred(entryDeferMark); unwindErr != nil {
+					if handle(unwindErr) {
+						continue
+					}
+					return unwindErr
+				}
 				if result != nil {
 					*result = retVal
 				}
@@ -950,6 +999,13 @@ func run(program *Program, host Host, entryPC int, seeds []localSeed, result *an
 			}
 			applyNamedValues(program, locals, initialized, extras, exported, refWrites)
 			stack = append(stack, value)
+		case opDefer:
+			callable, popErr := pop()
+			if popErr != nil {
+				return popErr
+			}
+			scratch.deferred = append(scratch.deferred, callable)
+			stack = append(stack, nil)
 		default:
 			return fmt.Errorf("flatstack: pc %d: invalid opcode %d", pc, inst.op)
 		}

--- a/flatstack/engine/vm_ref_test.go
+++ b/flatstack/engine/vm_ref_test.go
@@ -38,6 +38,13 @@ func (h *refTestHost) Echo(value any) error {
 	return nil
 }
 
+func (h *refTestHost) InvokeCallable(callable any) error {
+	if fn, ok := callable.(func()); ok {
+		fn()
+	}
+	return nil
+}
+
 func setRef(value any) func(*refTestHost, []any) {
 	return func(_ *refTestHost, args []any) {
 		args[len(args)-1].(func(any))(value)

--- a/runner/flatstack.go
+++ b/runner/flatstack.go
@@ -386,3 +386,13 @@ func (h flatHost) PopLiveWalker() {
 func (h flatHost) CheckMemory() error {
 	return h.runtime.checkMemory()
 }
+
+func (h *flatHost) InvokeCallable(callable any) error {
+	if callable == nil {
+		return nil
+	}
+	scope := h.boundScope()
+	_, err := h.runtime.invokeWithScopeContext(callable, nil, scope)
+	h.pullScope(scope)
+	return err
+}

--- a/tests/defer_test.go
+++ b/tests/defer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/titpetric/phpscript/flatstack"
 	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/runner"
@@ -45,6 +46,39 @@ defer(function() { echo "-file"; });`)
 	}
 }
 
+func TestFlatstackDeferRunsAtFrameReturnInLIFOOrder(t *testing.T) {
+	var out strings.Builder
+	rt := flatstack.New(&out, flatstack.Options{})
+	core.RegisterDefer(rt)
+
+	source := `<?php
+function work() {
+    echo "body";
+    defer(function() { echo "-first"; });
+    defer(function() { echo "-second"; });
+    return;
+}
+echo "before-";
+work();
+echo "-after";
+defer(function() { echo "-file"; });`
+
+	program, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("flatstack unexpectedly rejects program: %v", err)
+	}
+	if err := rt.Run(program); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "before-body-second-first-after-file"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 type closeRecorder struct {
 	out *strings.Builder
 }
@@ -75,6 +109,39 @@ echo "-after";`)
 	}
 }
 
+func TestFlatstackDeferAcceptsNativeBoundMethodReference(t *testing.T) {
+	var out strings.Builder
+	rt := flatstack.New(&out, flatstack.Options{})
+	core.RegisterDefer(rt)
+	rt.RegisterConstructor("Resource", func() *closeRecorder {
+		return &closeRecorder{out: &out}
+	})
+
+	source := `<?php
+function work() {
+    $resource = new Resource;
+    defer($resource->close);
+    echo "body";
+}
+work();
+echo "-after";`
+
+	program, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("flatstack unexpectedly rejects program: %v", err)
+	}
+	if err := rt.Run(program); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "body-closed-after"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestDeferUsesIncludeFileBoundary(t *testing.T) {
 	var out strings.Builder
 	rt := runner.New(&out, runner.Options{})
@@ -91,6 +158,39 @@ defer(function() { echo "-main-deferred"; });
 echo "main-";
 include "child.php";
 echo "-after";`)
+
+	if got, want := out.String(), "main-child-child-deferred-after-main-deferred"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestFlatstackDeferUsesIncludeFileBoundary(t *testing.T) {
+	var out strings.Builder
+	rt := flatstack.New(&out, flatstack.Options{})
+	core.RegisterDefer(rt)
+	rt.SetIncludeResolver(func(path string) (*model.Program, error) {
+		return parser.Parse(`<?php
+echo "child";
+defer(function() { echo "-child-deferred"; });
+return;`)
+	})
+
+	source := `<?php
+defer(function() { echo "-main-deferred"; });
+echo "main-";
+include "child.php";
+echo "-after";`
+
+	program, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("flatstack unexpectedly rejects program: %v", err)
+	}
+	if err := rt.Run(program); err != nil {
+		t.Fatal(err)
+	}
 
 	if got, want := out.String(), "main-child-child-deferred-after-main-deferred"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)

--- a/tests/defer_test.go
+++ b/tests/defer_test.go
@@ -317,25 +317,15 @@ echo "-end";`)
 	}
 }
 
-// The deferred callable is a bound method rather than a closure: an inline
-// closure in the callee emits the jump that trips the handler-range bug a
-// caller's catch already suffers on main (opJump drops handlers whose pc range
-// excludes the target, and a callee's pcs are outside the caller's try). That
-// is a pre-existing engine defect, not defer's; this test pins the defer
-// unwind on the exception path without depending on it.
 func TestFlatstackDeferRunsWhenExceptionUnwindsFrame(t *testing.T) {
 	var out strings.Builder
 	rt := flatstack.New(&out, flatstack.Options{})
 	core.RegisterDefer(rt)
 	rt.RegisterConstructor("Exception", stdlib.NewException)
-	rt.RegisterConstructor("Resource", func() *closeRecorder {
-		return &closeRecorder{out: &out}
-	})
 
 	source := `<?php
 function work() {
-    $resource = new Resource;
-    defer($resource->close);
+    defer(function() { echo "-deferred"; });
     echo "body";
     throw new Exception("boom");
 }
@@ -357,7 +347,7 @@ echo "-end";`
 		t.Fatal(err)
 	}
 
-	if got, want := out.String(), "body-closed-caught-end"; got != want {
+	if got, want := out.String(), "body-deferred-caught-end"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 }

--- a/tests/defer_test.go
+++ b/tests/defer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/titpetric/phpscript/model"
 	"github.com/titpetric/phpscript/parser"
 	"github.com/titpetric/phpscript/runner"
+	"github.com/titpetric/phpscript/stdlib"
 	"github.com/titpetric/phpscript/stdlib/core"
 )
 
@@ -289,6 +290,74 @@ register_shutdown_function(function() { echo "-" . __FILE__ . "-close"; });
 		t.Fatal(err)
 	}
 	if got, want := out.String(), "/main.php-main-/bootstrap.php-open-/bootstrap.php-close"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestDeferRunsWhenExceptionUnwindsFrame(t *testing.T) {
+	var out strings.Builder
+	rt := runner.New(&out, runner.Options{})
+	core.RegisterDefer(rt)
+
+	runPHP(t, rt, `<?php
+function work() {
+    defer(function() { echo "-deferred"; });
+    echo "body";
+    throw new Exception("boom");
+}
+try {
+    work();
+} catch (Exception $e) {
+    echo "-caught";
+}
+echo "-end";`)
+
+	if got, want := out.String(), "body-deferred-caught-end"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+// The deferred callable is a bound method rather than a closure: an inline
+// closure in the callee emits the jump that trips the handler-range bug a
+// caller's catch already suffers on main (opJump drops handlers whose pc range
+// excludes the target, and a callee's pcs are outside the caller's try). That
+// is a pre-existing engine defect, not defer's; this test pins the defer
+// unwind on the exception path without depending on it.
+func TestFlatstackDeferRunsWhenExceptionUnwindsFrame(t *testing.T) {
+	var out strings.Builder
+	rt := flatstack.New(&out, flatstack.Options{})
+	core.RegisterDefer(rt)
+	rt.RegisterConstructor("Exception", stdlib.NewException)
+	rt.RegisterConstructor("Resource", func() *closeRecorder {
+		return &closeRecorder{out: &out}
+	})
+
+	source := `<?php
+function work() {
+    $resource = new Resource;
+    defer($resource->close);
+    echo "body";
+    throw new Exception("boom");
+}
+try {
+    work();
+} catch (Exception $e) {
+    echo "-caught";
+}
+echo "-end";`
+
+	program, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flatstack.Supports(program); err != nil {
+		t.Fatalf("flatstack unexpectedly rejects program: %v", err)
+	}
+	if err := rt.Run(program); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "body-closed-caught-end"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 }

--- a/tests/fixtures/exceptions/catch_across_frames.phpt
+++ b/tests/fixtures/exceptions/catch_across_frames.phpt
@@ -1,0 +1,68 @@
+name: a catch one frame above the throw survives jumps in the callee
+description: >
+  The handler a try arms belongs to the frame that armed it. A called
+  function's branches, loops and other jumps run at program counters outside
+  the caller's try body, and none of them may disarm the caller's catch: the
+  throw that follows still lands in the clause one frame up. The callee
+  settling its own throw first does not consume the caller's handler either.
+  The expected output is what php 8.5 prints for this source.
+---
+<?php
+
+// The catch lives one frame above the throw, and the callee branches before
+// throwing. The branch must not cost the caller its armed handler.
+function branchy() {
+	if (true) {
+		echo "branch\n";
+	}
+	throw new RuntimeException("from branchy");
+}
+
+try {
+	branchy();
+} catch (RuntimeException $e) {
+	echo "caught: " . $e->getMessage() . "\n";
+}
+
+// A loop in the callee jumps backwards on every iteration.
+function loopy() {
+	for ($i = 0; $i < 3; $i++) {
+		echo "tick " . $i . "\n";
+	}
+	throw new RuntimeException("from loopy");
+}
+
+try {
+	loopy();
+} catch (RuntimeException $e) {
+	echo "caught: " . $e->getMessage() . "\n";
+}
+
+// The callee settles its own throw first; only the second one is the caller's.
+function nested() {
+	try {
+		throw new LogicException("inner");
+	} catch (LogicException $e) {
+		echo "inner: " . $e->getMessage() . "\n";
+	}
+	throw new RuntimeException("outer");
+}
+
+try {
+	nested();
+} catch (RuntimeException $e) {
+	echo "caught: " . $e->getMessage() . "\n";
+}
+
+echo "end\n";
+?>
+---
+branch
+caught: from branchy
+tick 0
+tick 1
+tick 2
+caught: from loopy
+inner: inner
+caught: outer
+end


### PR DESCRIPTION
Closes: #71

`defer()` was rejected in `flatstack/engine/compiler.go` because `flatHost.Call` hands a binding a throwaway scope per invocation, so a registration was dropped instead of running when the frame left. The rejection became reachable once closures compiled (#57), since the callback is nearly always one, and it forced every program using `defer()` onto the compatibility interpreter.

The compiler now lowers `defer($fn)` to `opDefer`, and the VM runs the registrations LIFO when control leaves the frame that made them.

| File | Change |
|---|---|
| `flatstack/engine/program.go` | Opcode `opDefer`, and `InvokeCallable(any) error` on the `Host` interface. |
| `flatstack/engine/compiler.go` | The `defer` rejection is removed; `defer($fn)` evaluates its argument and emits `opDefer`. |
| `flatstack/engine/vm.go` | `vmScratch` grows a recycled `deferred []any` slice, each `callFrame` records its `deferMark` boundary, and `opReturn`, exception unwind and frame exit run the registrations above the mark in LIFO order. |
| `runner/flatstack.go` | `InvokeCallable` on `flatHost` through `invokeWithScopeContext`, so compiled closures, interpreted callables and bound method references such as `$resource->close` all execute. |
| `docs/flatstack.md` | `defer()` moves from the native barriers to the supported statements. |

The deferred slice lives on the pooled `vmScratch` and is cleared on release, so the execution path adds no allocations and `go.mod` is untouched.

Verification: `go test -race ./flatstack/... ./runner/... ./tests/...`, the fixture matrix at 226/226, and `atkins` green.
