### PR TITLE
Fix possible fix(deps): 2 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/mod v0.39.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

The project pins golang.org/x/mod at v0.39.0, which is vulnerable to CVE-2026-56864. A compromised GOSUMDB can serve malicious module code that bypasses the Go checksum database and transparency log, allowing an attacker to inject arbitrary code into the build supply chain. This can lead to remote code execution or data compromise. The vulnerability is classified as HIGH severity because it undermines the core integrity guarantees of Go modules.

Upgrade golang.org/x/mod from v0.39.0 to v0.40.0 to address CVE‒6…4/56865.

For reference: rule `CVE-2026-56864`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
