### PR TITLE
POC: hand the request being served to a script (#77)

### DIFF
--- a/demos/example/README.md
+++ b/demos/example/README.md
@@ -18,7 +18,18 @@ created next to the sources on first start.
 | `GET /`                            | [index.php](./index.php)                      |
 | `POST /bookmarks`                  | [bookmark-create.php](./bookmark-create.php)  |
 | `POST /bookmarks/{id}/delete`      | [bookmark-delete.php](./bookmark-delete.php)  |
+| `GET POST /api/echo[/{rest...}]`   | [api-echo.php](./api-echo.php)                |
 | `@startup`                         | [migrate.php](./migrate.php)                  |
+
+`api-echo.php` is not part of the bookmark list. It answers an httpbin-style
+JSON description of the request it was given, and is here because it is the one
+endpoint that reads the request through `HTTP\Request::current()` rather than
+through the superglobals:
+
+```sh
+curl -s localhost:8080/api/echo/a/b?x=1
+curl -s -XPOST -H 'content-type: application/json' -d '{"a":1}' localhost:8080/api/echo
+```
 
 `include/Compiler.php` and `include/Template.php` are
 [minitpl](https://github.com/titpetric/minitpl), vendored from

--- a/demos/example/api-echo.php
+++ b/demos/example/api-echo.php
@@ -1,0 +1,59 @@
+<?php
+
+// @route: /api/echo
+// @route: /api/echo/{rest...}
+//
+// An httpbin-style echo of the request being served. Every value in the answer
+// is read off the request and encoded here, in PHP: HTTP\Request::current()
+// hands the request over, it does not render one.
+//
+// Two annotations because a trailing-segment route only matches once there is
+// something to trail: /api/echo/{rest...} does not answer for /api/echo. Each
+// is written without a method, which registers it for GET and for POST.
+//
+//	curl -s localhost:8080/api/echo/a/b?x=1
+//	curl -s -XPOST -H 'content-type: application/json' -d '{"a":1}' \
+//		localhost:8080/api/echo
+
+$request = HTTP\Request::current();
+
+// The body is read the PHP way. $request->body is an io.ReadCloser, which is a
+// stream a script has no way to hold, and only the two form content types reach
+// $_POST; php://input is what a JSON API or a webhook reads.
+$body = file_get_contents("php://input");
+
+// The decoded body is present only when the client said it sent JSON, and is
+// null otherwise, the way httpbin answers. header->get() is net/http's own
+// case-insensitive lookup.
+$json = null;
+$type = $request->header->get("content-type");
+if ($body !== "" && str_contains($type, "application/json")) {
+	$json = json_decode($body, true);
+}
+
+// The trailing segments come from $_REQUEST rather than $request->pathvalue():
+// each router publishes them under its own name, chi under "*", and $_REQUEST
+// carries them under the name the annotation wrote.
+$rest = isset($_REQUEST["rest"]) ? $_REQUEST["rest"] : "";
+
+// $_GET, getallheaders() and $_POST are ordered arrays. The same three read off
+// the request are Go maps -- $request->url->query() and $request->header --
+// which re-randomise their order on every pass, so an answer built from them
+// would differ between two identical requests. The cast to an object is what
+// writes an empty one as {} rather than [].
+$answer = array(
+	"method" => $request->method,
+	"proto" => $request->proto,
+	"host" => $request->host,
+	"path" => $request->url->path,
+	"rest" => $rest,
+	"url" => $_SERVER["REQUEST_SCHEME"] . "://" . $request->host . $request->requesturi,
+	"args" => (object)$_GET,
+	"headers" => (object)getallheaders(),
+	"form" => (object)$_POST,
+	"body" => $body,
+	"json" => $json,
+);
+
+header("Content-Type: application/json");
+echo json_encode($answer);

--- a/demos/example/tests/venom.yml
+++ b/demos/example/tests/venom.yml
@@ -83,6 +83,55 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.body ShouldNotContainSubstring &lt;script&gt;
 
+  - name: the echo endpoint answers a GET with its query and trailing path
+    steps:
+      - type: http
+        method: GET
+        url: "{{.host}}/api/echo/a/b?x=1"
+        headers:
+          X-Trace: venom
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.Content-Type ShouldContainSubstring application/json
+          - result.bodyjson.method ShouldEqual GET
+          - result.bodyjson.path ShouldEqual /api/echo/a/b
+          - result.bodyjson.rest ShouldEqual a/b
+          - result.bodyjson.args.x ShouldEqual 1
+          - result.bodyjson.headers.X-Trace ShouldEqual venom
+          - result.bodyjson.body ShouldBeEmpty
+          - result.bodyjson.json ShouldBeNil
+
+  # A JSON body reaches no superglobal: only the two form content types populate
+  # $_POST, so the endpoint reads php://input and decodes it itself.
+  - name: the echo endpoint decodes a JSON body
+    steps:
+      - type: http
+        method: POST
+        url: "{{.host}}/api/echo"
+        headers:
+          Content-Type: application/json
+        body: '{"name":"venom","n":2}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.method ShouldEqual POST
+          - result.bodyjson.rest ShouldBeEmpty
+          - result.bodyjson.json.name ShouldEqual venom
+          - result.bodyjson.json.n ShouldEqual 2
+
+  - name: the echo endpoint reports a form body as form
+    steps:
+      - type: http
+        method: POST
+        url: "{{.host}}/api/echo"
+        headers:
+          Content-Type: application/x-www-form-urlencoded
+        body: "title=venom"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.form.title ShouldEqual venom
+          - result.bodyjson.body ShouldEqual title=venom
+          - result.bodyjson.json ShouldBeNil
+
   - name: static assets are served from the web root
     steps:
       - type: http

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -14,7 +14,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | Status | Package                                              | Coverage | Cognitive | Lines |
 |--------|------------------------------------------------------|----------|-----------|-------|
 | ❌     | github.com/titpetric/phpscript                       | 34.80%   | 22        | 96    |
-| ✅     | github.com/titpetric/phpscript/annotations           | 88.26%   | 149       | 701   |
+| ✅     | github.com/titpetric/phpscript/annotations           | 88.82%   | 149       | 701   |
 | ❌     | github.com/titpetric/phpscript/cmd/phpscript/ast     | 0.00%    | 5         | 31    |
 | ❌     | github.com/titpetric/phpscript/cmd/phpscript/fmt     | 0.00%    | 5         | 42    |
 | ❌     | github.com/titpetric/phpscript/cmd/phpscript/info    | 78.96%   | 52        | 177   |
@@ -36,17 +36,17 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ❌     | github.com/titpetric/phpscript/list                  | 72.31%   | 115       | 335   |
 | ❌     | github.com/titpetric/phpscript/model                 | 36.82%   | 325       | 1130  |
 | ✅     | github.com/titpetric/phpscript/parser                | 91.34%   | 1039      | 3399  |
-| ✅     | github.com/titpetric/phpscript/runner                | 86.62%   | 1648      | 7002  |
+| ✅     | github.com/titpetric/phpscript/runner                | 86.93%   | 1649      | 7023  |
 | ✅     | github.com/titpetric/phpscript/runner/coverage       | 92.37%   | 45        | 187   |
 | ❌     | github.com/titpetric/phpscript/scripts/list-apis     | 0.00%    | 1         | 13    |
 | ✅     | github.com/titpetric/phpscript/stdlib                | 96.30%   | 4         | 88    |
 | ✅     | github.com/titpetric/phpscript/stdlib/compat         | 86.92%   | 184       | 901   |
-| ✅     | github.com/titpetric/phpscript/stdlib/core           | 85.86%   | 862       | 3861  |
+| ✅     | github.com/titpetric/phpscript/stdlib/core           | 86.14%   | 862       | 3861  |
 | ✅     | github.com/titpetric/phpscript/stdlib/crypto         | 85.97%   | 56        | 312   |
 | ✅     | github.com/titpetric/phpscript/stdlib/database       | 84.59%   | 105       | 791   |
 | ✅     | github.com/titpetric/phpscript/stdlib/files          | 87.99%   | 165       | 644   |
 | ❌     | github.com/titpetric/phpscript/stdlib/gd             | 76.99%   | 154       | 577   |
-| ❌     | github.com/titpetric/phpscript/stdlib/http           | 72.75%   | 61        | 417   |
+| ❌     | github.com/titpetric/phpscript/stdlib/http           | 73.26%   | 63        | 448   |
 | ✅     | github.com/titpetric/phpscript/stdlib/info           | 75.00%   | 0         | 10    |
 | ✅     | github.com/titpetric/phpscript/stdlib/internals      | 100.00%  | 0         | 18    |
 | ✅     | github.com/titpetric/phpscript/stdlib/logger         | 100.00%  | 9         | 73    |
@@ -107,7 +107,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/annotations          | scanner.walk                          | 82.40%   | 15        |
 | ✅     | github.com/titpetric/phpscript/annotations          | serveMuxRegistrar.Handle              | 100.00%  | 1         |
 | ✅     | github.com/titpetric/phpscript/annotations          | splitScheduleArgs                     | 100.00%  | 3         |
-| ✅     | github.com/titpetric/phpscript/annotations          | tag                                   | 75.00%   | 1         |
+| ✅     | github.com/titpetric/phpscript/annotations          | tag                                   | 100.00%  | 1         |
 | ✅     | github.com/titpetric/phpscript/annotations          | weekdayName                           | 22.20%   | 1         |
 | ✅     | github.com/titpetric/phpscript/cmd/phpscript/info   | Run                                   | 92.30%   | 3         |
 | ✅     | github.com/titpetric/phpscript/cmd/phpscript/info   | ctorParams                            | 100.00%  | 4         |
@@ -730,6 +730,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/runner               | Context.IsUpload                      | 100.00%  | 7         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.RawBody                       | 66.70%   | 1         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.Register                      | 100.00%  | 2         |
+| ✅     | github.com/titpetric/phpscript/runner               | Context.Request                       | 100.00%  | 0         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.ResponseHeaders               | 100.00%  | 0         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.ResponseStatus                | 66.70%   | 1         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.SetDefaultHeader              | 100.00%  | 1         |
@@ -740,7 +741,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/runner               | Context.decodeBody                    | 100.00%  | 7         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.filesArray                    | 94.70%   | 7         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.memoryFootprint               | 100.00%  | 4         |
-| ✅     | github.com/titpetric/phpscript/runner               | Context.parseBody                     | 85.20%   | 14        |
+| ✅     | github.com/titpetric/phpscript/runner               | Context.parseBody                     | 87.10%   | 15        |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.pathValues                    | 88.90%   | 7         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.recordError                   | 66.70%   | 2         |
 | ✅     | github.com/titpetric/phpscript/runner               | Context.requestArray                  | 100.00%  | 1         |
@@ -1018,13 +1019,14 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/runner               | flatHost.pullScope                    | 66.70%   | 5         |
 | ✅     | github.com/titpetric/phpscript/runner               | flattenConcat                         | 100.00%  | 4         |
 | ✅     | github.com/titpetric/phpscript/runner               | funcGetArgs                           | 75.00%   | 3         |
+| ✅     | github.com/titpetric/phpscript/runner               | goTypeName                            | 83.30%   | 3         |
 | ✅     | github.com/titpetric/phpscript/runner               | helperArray                           | 100.00%  | 4         |
 | ✅     | github.com/titpetric/phpscript/runner               | helperCast                            | 95.00%   | 7         |
 | ✅     | github.com/titpetric/phpscript/runner               | helperConcat                          | 100.00%  | 0         |
 | ✅     | github.com/titpetric/phpscript/runner               | helperIndex                           | 85.70%   | 12        |
 | ✅     | github.com/titpetric/phpscript/runner               | helperPair                            | 100.00%  | 0         |
 | ✅     | github.com/titpetric/phpscript/runner               | helperToObject                        | 100.00%  | 1         |
-| ❌     | github.com/titpetric/phpscript/runner               | instanceOfClass                       | 44.40%   | 6         |
+| ❌     | github.com/titpetric/phpscript/runner               | instanceOfClass                       | 66.70%   | 6         |
 | ✅     | github.com/titpetric/phpscript/runner               | instanceOfName                        | 75.00%   | 1         |
 | ✅     | github.com/titpetric/phpscript/runner               | invokeAny                             | 94.10%   | 8         |
 | ✅     | github.com/titpetric/phpscript/runner               | invokeFast                            | 100.00%  | 1         |
@@ -1177,7 +1179,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | asciiLower                            | 100.00%  | 12        |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | buildQuery                            | 100.00%  | 8         |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | callbackLess                          | 75.00%   | 1         |
-| ❌     | github.com/titpetric/phpscript/stdlib/core          | classNameOf                           | 45.50%   | 8         |
+| ✅     | github.com/titpetric/phpscript/stdlib/core          | classNameOf                           | 90.90%   | 8         |
 | ❌     | github.com/titpetric/phpscript/stdlib/core          | classOf                               | 20.00%   | 6         |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | dumpKey                               | 75.00%   | 1         |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | edgeValue                             | 100.00%  | 1         |
@@ -1193,7 +1195,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | isObject                              | 91.70%   | 6         |
 | ❌     | github.com/titpetric/phpscript/stdlib/core          | isObjectLike                          | 64.30%   | 7         |
 | ❌     | github.com/titpetric/phpscript/stdlib/core          | jsonDecodeStream                      | 76.70%   | 22        |
-| ❌     | github.com/titpetric/phpscript/stdlib/core          | jsonDecodeValue                       | 30.00%   | 8         |
+| ❌     | github.com/titpetric/phpscript/stdlib/core          | jsonDecodeValue                       | 40.00%   | 8         |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | jsonEncodeValue                       | 90.30%   | 16        |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | jsonObject.MarshalJSON                | 87.50%   | 7         |
 | ✅     | github.com/titpetric/phpscript/stdlib/core          | jsonObject.add                        | 100.00%  | 0         |
@@ -1447,6 +1449,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | Client.Send                           | 83.30%   | 2         |
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | Client.prepare                        | 93.30%   | 8         |
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | Client.send                           | 93.50%   | 3         |
+| ✅     | github.com/titpetric/phpscript/stdlib/http          | CurrentRequest                        | 85.70%   | 2         |
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | NewClient                             | 87.10%   | 12        |
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | NewRequest                            | 92.90%   | 7         |
 | ✅     | github.com/titpetric/phpscript/stdlib/http          | Register                              | 100.00%  | 0         |

--- a/docs/guides/50-a-json-api.md
+++ b/docs/guides/50-a-json-api.md
@@ -227,7 +227,7 @@ A malformed selection raises a plain `\Exception` out of the parser, and a plain
 {"error":{"message":"fields: unbalanced braces in selection","code":422}}
 ```
 
-Writes take a form body, not JSON. There is no `php://input` and no raw body binding in this runtime, so only an urlencoded or multipart body reaches `$_POST`; a request sent as `application/json` arrives with `$_POST` empty and every field looking absent. `POST /api/user` reads `$_POST["username"]` and answers 201 with the created record.
+Writes here take a form body, not JSON. Only an urlencoded or multipart body reaches `$_POST`, as in PHP, so a request sent as `application/json` arrives with `$_POST` empty and every field looking absent. `POST /api/user` reads `$_POST["username"]` and answers 201 with the created record. A route that wants to accept JSON reads the bytes itself, the way PHP does — `json_decode(file_get_contents("php://input"), true)` — which [api-echo.php](../../demos/example/api-echo.php) does next to the form case.
 
 ## Errors
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -273,6 +273,7 @@ Runtime-specific syntax and APIs that are not part of the PHP language reference
       - [draw](extensions/implemented-apis.md#draw)
       - [info](extensions/implemented-apis.md#info)
       - [write](extensions/implemented-apis.md#write)
+    - [stdlib/http](extensions/implemented-apis.md#stdlibhttp)
     - [stdlib/info](extensions/implemented-apis.md#stdlibinfo)
     - [stdlib/internals](extensions/implemented-apis.md#stdlibinternals)
     - [stdlib/pexec](extensions/implemented-apis.md#stdlibpexec)

--- a/docs/reference/extensions/implemented-apis.md
+++ b/docs/reference/extensions/implemented-apis.md
@@ -1379,6 +1379,19 @@ function imagejpeg(mixed $im, mixed ...$args): mixed
 function imagepng(mixed $im, mixed ...$args): mixed
 ```
 
+### stdlib/http
+
+```php
+/**
+ * HTTP\Request::current returns the request being served, as the same
+ * HTTP\Request an outbound one is, and null off a request: a command line
+ * run, a @startup or @schedule job. The superglobals carry the same
+ * request decoded, and $_GET, getallheaders() and php://input are the
+ * ordered, PHP-shaped readings of what this value holds raw.
+ */
+HTTP\Request::current(): mixed
+```
+
 ### stdlib/info
 
 ```php

--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -85,6 +85,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | database_test.phpt                    | PASS       | PASS    | SKIP |
 | http_request.phpt                     | PASS       | PASS    | SKIP |
 | http_response_code.phpt               | PASS       | PASS    | PASS |
+| http_server_request.phpt              | PASS       | PASS    | SKIP |
 | platform_database.phpt                | PASS       | PASS    | SKIP |
 | request_and_response_handling.phpt    | PASS       | PASS    | SKIP |
 | session_manager.phpt                  | PASS       | PASS    | SKIP |
@@ -321,7 +322,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/arithmetic  | 21       | 21     | 0      |
 | tests/fixtures/arrays      | 19       | 19     | 0      |
 | tests/fixtures/autoloading | 8        | 8      | 0      |
-| tests/fixtures/bindings    | 23       | 23     | 0      |
+| tests/fixtures/bindings    | 24       | 24     | 0      |
 | tests/fixtures/errors      | 2        | 2      | 0      |
 | tests/fixtures/exceptions  | 9        | 9      | 0      |
 | tests/fixtures/flatstack   | 7        | 7      | 0      |
@@ -338,4 +339,4 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/stdlib      | 19       | 19     | 0      |
 | tests/fixtures/strings     | 16       | 16     | 0      |
 | tests/fixtures/syntax      | 8        | 8      | 0      |
-| **Total**                  | 207      | 207    | 0      |
+| **Total**                  | 208      | 208    | 0      |

--- a/docs/use-cases/http-client.md
+++ b/docs/use-cases/http-client.md
@@ -103,6 +103,53 @@ echo $request->header->get("accept");
 Everything `net/http` exports on a request is reachable, so there is one
 vocabulary for a request rather than a PHP-side name for each part of it.
 
+## Read the request being served
+
+`HTTP\Request::current()` returns the inbound request, as the same
+`HTTP\Request` an outbound one is, and `null` off a request: a command line
+run, a `@startup` or a `@schedule` job.
+
+```php
+$request = HTTP\Request::current();
+
+echo $request->method;                     // POST
+echo $request->url->path;                  // /api/echo/a/b
+echo $request->header->get("content-type");
+echo $request->useragent();
+echo $request->referer();
+
+list($user, $password, $sent) = $request->basicauth();
+```
+
+It is not a replacement for the superglobals, and the two are not
+interchangeable. Read the request itself for what `net/http` answers and PHP
+has no name for — `useragent()`, `referer()`, `basicauth()`, `cookie($name)`,
+`formvalue($name)`, and `pattern`, the route the request matched. Read the
+superglobals for anything with more than one value in it:
+
+| For                   | Read                | Not                                    |
+|-----------------------|---------------------|----------------------------------------|
+| Query fields          | `$_GET`             | `$request->url->query()`               |
+| Every request header  | `getallheaders()`   | `$request->header`                     |
+| Form fields           | `$_POST`            | `$request->form`, `$request->postform` |
+| The raw body          | `php://input`       | `$request->body`                       |
+| Route path parameters | `$_REQUEST`         | `$request->pathvalue($name)`           |
+| Whether this is TLS   | `$_SERVER["HTTPS"]` | `$request->tls`                        |
+
+The left column is an ordered PHP array and the right one is a Go map, whose
+key order is re-randomised on every pass and whose values are lists rather than
+strings. `$request->body` is an `io.ReadCloser`, a stream a script has no way
+to hold or close. `$request->pathvalue()` takes the name the *router* captured,
+which is not always the name the annotation wrote: chi publishes a
+`{rest...}` parameter under `*`, where `$_REQUEST` carries it under `rest`.
+`$request->tls` is a pointer, and a nil pointer is neither `null` nor false, so
+`if ($request->tls)` is true on a plain HTTP request; `isset($_SERVER["HTTPS"])`
+is the question that answers itself.
+
+[api-echo.php](../../demos/example/api-echo.php) is the worked example: an
+httpbin-style endpoint that encodes the request it was given, reading each part
+from whichever of the two answers it well.
+
 ## Read a response
 
 | Method          | Returns                                                              |

--- a/runner/request.go
+++ b/runner/request.go
@@ -98,6 +98,12 @@ type Context struct {
 	// pointer for the same reason status is, so a copy of a Context reads
 	// what another copy buffered.
 	rawBody *[]byte
+
+	// request is the *http.Request this Context was built from, kept so a
+	// binding can hand the request itself to a script. It is nil for a Context
+	// assembled by hand: a CLI run, a @startup or @schedule job, the fixture
+	// harness, or an embedder filling c.Get itself. There was no request.
+	request *http.Request
 }
 
 type requestContextKey struct{}
@@ -169,6 +175,7 @@ func FromRequest(r *http.Request) Context {
 // max_input_vars and max_input_nesting_level bound what is built from it.
 func FromRequestOptions(r *http.Request, opts Options) Context {
 	c := NewContext()
+	c.request = r
 
 	// Query string ($_GET). Decoded from RawQuery, not r.URL.Query(): a
 	// url.Values is a map, so field order is already gone, and the decoder
@@ -404,6 +411,15 @@ func (c *Context) parseBody(r *http.Request, opts Options) {
 		}
 	}
 	c.PostVars = c.decodeBody(r, opts)
+
+	// ParseForm consumed the reader the buffered bytes were handed to, so a
+	// script reaching the request itself would find an exhausted body. Wrap the
+	// bytes again: php://input and $request->body then answer the same payload,
+	// rather than one of them silently reading empty. A multipart body was
+	// never buffered and stays as net/http left it.
+	if len(*c.rawBody) > 0 {
+		r.Body = io.NopCloser(bytes.NewReader(*c.rawBody))
+	}
 }
 
 // decodeBody builds $_POST, reading the brackets in the field names. Only the
@@ -777,6 +793,18 @@ func (c Context) RawBody() []byte {
 		return nil
 	}
 	return *c.rawBody
+}
+
+// Request returns the request this Context was built from, or nil when it was
+// built by hand and there was none. It is what lets a binding hand the request
+// itself to a script; the superglobals above are the same data decoded, and a
+// script reading either sees one request.
+//
+// The value is the host's, not a copy. It is request-lived and reached by one
+// script, so nothing guards it, and a write to it is visible only to the code
+// that runs after the write.
+func (c Context) Request() *http.Request {
+	return c.request
 }
 
 // SetRawBody stores the bytes php://input answers with, for a host that

--- a/stdlib/http/register.go
+++ b/stdlib/http/register.go
@@ -12,6 +12,13 @@ func Register(rt *runner.Runtime) {
 	// sends nothing; a client does that with $client->send($request).
 	rt.RegisterConstructor("HTTP\\Request", NewRequest)
 
+	// HTTP\Request::current returns the request being served, as the same
+	// HTTP\Request an outbound one is, and null off a request: a command line
+	// run, a @startup or @schedule job. The superglobals carry the same
+	// request decoded, and $_GET, getallheaders() and php://input are the
+	// ordered, PHP-shaped readings of what this value holds raw.
+	rt.RegisterFunc("HTTP\\Request::current", CurrentRequest)
+
 	// HTTP\Client sends requests, one at a time with send() or all at once with
 	// parallel(). It takes its settings as an associative array, and with no
 	// argument gives a client with a 30 second timeout that follows redirects.

--- a/stdlib/http/request.go
+++ b/stdlib/http/request.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	nethttp "net/http"
 	"strings"
+
+	"github.com/titpetric/phpscript/runner"
 )
 
 // NewRequest builds a request from $method and $url, with an optional $body.
@@ -45,6 +47,31 @@ func NewRequest(ctx context.Context, method, url string, body ...string) (*netht
 		return nil, fmt.Errorf("HTTP\\Request: %w", err)
 	}
 	return request, nil
+}
+
+// CurrentRequest returns the request being served, or null when nothing is
+// being served. It is the same net/http request an outbound one is, so the
+// inbound and the outbound side of HTTP read alike.
+//
+// The request is the host's own value rather than a copy of it. It is
+// request-lived and reached by one script, so no lock guards it, and a write
+// reaches only the code that runs after the write: net/http has already read
+// what it needed by the time a script can see it.
+//
+// The return type is any rather than *http.Request so that "no request" is
+// PHP's null. A nil pointer in a typed return slot is not a nil interface: it
+// arrives as a value that is_null() answers false for and that a plain if()
+// takes as true, which is the opposite of what the caller asked.
+func CurrentRequest(ctx context.Context) any {
+	c, ok := runner.RequestContext(ctx)
+	if !ok {
+		return nil
+	}
+	request := c.Request()
+	if request == nil {
+		return nil
+	}
+	return request
 }
 
 // flattenHeader renders a header set as the array shape a script reads. A

--- a/tests/fixtures/bindings/http_server_request.phpt
+++ b/tests/fixtures/bindings/http_server_request.phpt
@@ -1,0 +1,44 @@
+name: inbound http request binding
+description: >
+  HTTP\Request::current() is a host binding with no PHP counterpart, so the
+  expected output is the runtime's contract rather than PHP's. A fixture runs
+  off a request, which is the case this covers: the binding answers null, and a
+  script reads the superglobals instead. The value it hands back while a request
+  is being served is covered by TestRouteAPIEcho in tests/route_test.go, which
+  drives a real handler.
+
+  It also pins two things a script sees about a host-backed object, because both
+  read as bugs when met for the first time: the class name is the Go type's,
+  without the namespace the class was registered under, and a nil pointer field
+  is neither null nor false.
+runner:
+  php: false
+---
+<?php
+
+// Off a request there is nothing to hand back.
+$current = HTTP\Request::current();
+var_dump($current);
+
+$request = new HTTP\Request("GET", "https://example.invalid/users");
+
+// The class name a script sees is the name of the Go type, not the name the
+// class was registered under, so an outbound and an inbound request are the
+// same class and neither is HTTP\Request by that name.
+echo get_class($request), "\n";
+var_dump($request instanceof HTTP\Request);
+var_dump($request instanceof Request);
+
+// A pointer field that is nil arrives as a value that is not null and is not
+// false. $request->tls is the one a script reaches for to ask about TLS; the
+// answer is $_SERVER, where PHP puts it and where an unset key means no.
+var_dump(is_null($request->tls));
+var_dump((bool) $request->tls);
+?>
+---
+NULL
+Request
+bool(false)
+bool(true)
+bool(false)
+bool(true)

--- a/tests/fixtures/routing/api-echo.php
+++ b/tests/fixtures/routing/api-echo.php
@@ -1,0 +1,55 @@
+<?php
+
+// @route: /api/echo
+// @route: /api/echo/{rest...}
+//
+// An httpbin-style echo of the request being served. Every value in the answer
+// is read off the request and encoded here, in PHP: HTTP\Request::current()
+// hands the request over, it does not render one.
+//
+// Two annotations because a trailing-segment route only matches once there is
+// something to trail: /api/echo/{rest...} does not answer for /api/echo. Each
+// is written without a method, which registers it for GET and for POST.
+
+$request = HTTP\Request::current();
+
+// The body is read the PHP way. $request->body is an io.ReadCloser, which is
+// a stream a script has no way to hold, and only the two form content types
+// reach $_POST; php://input is what a JSON API or a webhook reads.
+$body = file_get_contents("php://input");
+
+// The decoded body is present only when the client said it sent JSON, and is
+// null otherwise, the way httpbin answers. header->get() is net/http's own
+// case-insensitive lookup.
+$json = null;
+$type = $request->header->get("content-type");
+if ($body !== "" && str_contains($type, "application/json")) {
+	$json = json_decode($body, true);
+}
+
+// The trailing segments come from $_REQUEST rather than $request->pathvalue():
+// each router publishes them under its own name, chi under "*", and $_REQUEST
+// carries them under the name the annotation wrote.
+$rest = isset($_REQUEST["rest"]) ? $_REQUEST["rest"] : "";
+
+// $_GET, getallheaders() and $_POST are ordered arrays. The same three read off
+// the request are Go maps -- $request->url->query() and $request->header --
+// which re-randomise their order on every pass, so an answer built from them
+// would differ between two identical requests. The cast to an object is what
+// writes an empty one as {} rather than [].
+$answer = array(
+	"method" => $request->method,
+	"proto" => $request->proto,
+	"host" => $request->host,
+	"path" => $request->url->path,
+	"rest" => $rest,
+	"url" => $_SERVER["REQUEST_SCHEME"] . "://" . $request->host . $request->requesturi,
+	"args" => (object)$_GET,
+	"headers" => (object)getallheaders(),
+	"form" => (object)$_POST,
+	"body" => $body,
+	"json" => $json,
+);
+
+header("Content-Type: application/json");
+echo json_encode($answer);

--- a/tests/route_test.go
+++ b/tests/route_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"mime/multipart"
@@ -101,6 +102,140 @@ func TestRouteFileUpload(t *testing.T) {
 	if _, err := os.Stat(fields[4]); !os.IsNotExist(err) {
 		t.Fatalf("tmp_name %q after response: err = %v, want not-exist", fields[4], err)
 	}
+}
+
+// TestRouteAPIEcho drives the /api/echo endpoint, which reads the request
+// through HTTP\Request::current() and encodes the answer in PHP. It covers the
+// three things the binding exists for: a request with no body, a trailing
+// {rest...} path, and a JSON body that no superglobal carries.
+func TestRouteAPIEcho(t *testing.T) {
+	root, err := fs.Sub(fixturesFS, "fixtures/routing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	if err := annotations.NewRoute(root).RegisterMux(mux); err != nil {
+		t.Fatal(err)
+	}
+
+	echo := func(t *testing.T, req *http.Request) map[string]any {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %q", rr.Code, rr.Body.String())
+		}
+		if got := rr.Header().Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q", got)
+		}
+		var answer map[string]any
+		if err := json.Unmarshal(rr.Body.Bytes(), &answer); err != nil {
+			t.Fatalf("decode %q: %v", rr.Body.String(), err)
+		}
+		return answer
+	}
+
+	// An empty object rather than an empty list: json_encode writes array() as
+	// [], and the endpoint casts each collection to an object so a client
+	// reading args.x finds an object to read it from.
+	assertEmptyObject := func(t *testing.T, answer map[string]any, key string) {
+		t.Helper()
+		value, ok := answer[key].(map[string]any)
+		if !ok || len(value) != 0 {
+			t.Fatalf("%s = %#v, want an empty object", key, answer[key])
+		}
+	}
+
+	t.Run("get with query", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/echo?x=1&y=2", nil)
+		req.Header.Set("X-Trace", "abc")
+		answer := echo(t, req)
+
+		if answer["method"] != http.MethodGet {
+			t.Errorf("method = %v", answer["method"])
+		}
+		if answer["path"] != "/api/echo" {
+			t.Errorf("path = %v", answer["path"])
+		}
+		if answer["rest"] != "" {
+			t.Errorf("rest = %v, want empty", answer["rest"])
+		}
+		if answer["url"] != "http://example.com/api/echo?x=1&y=2" {
+			t.Errorf("url = %v", answer["url"])
+		}
+		if answer["body"] != "" {
+			t.Errorf("body = %v, want empty", answer["body"])
+		}
+		if answer["json"] != nil {
+			t.Errorf("json = %v, want null", answer["json"])
+		}
+		args, _ := answer["args"].(map[string]any)
+		if args["x"] != "1" || args["y"] != "2" {
+			t.Errorf("args = %#v", answer["args"])
+		}
+		headers, _ := answer["headers"].(map[string]any)
+		if headers["X-Trace"] != "abc" {
+			t.Errorf("headers = %#v", answer["headers"])
+		}
+		assertEmptyObject(t, answer, "form")
+	})
+
+	// The trailing segments arrive joined, under the name the annotation wrote
+	// rather than the one the router captured them as.
+	t.Run("trailing path", func(t *testing.T) {
+		answer := echo(t, httptest.NewRequest(http.MethodGet, "/api/echo/a/b/c", nil))
+
+		if answer["rest"] != "a/b/c" {
+			t.Errorf("rest = %v", answer["rest"])
+		}
+		if answer["path"] != "/api/echo/a/b/c" {
+			t.Errorf("path = %v", answer["path"])
+		}
+		assertEmptyObject(t, answer, "args")
+	})
+
+	// A JSON body reaches the script through php://input, and leaves $_POST
+	// empty: only the two form content types populate it, here as in PHP.
+	t.Run("post json", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/echo", strings.NewReader(`{"name":"ada","n":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		answer := echo(t, req)
+
+		if answer["method"] != http.MethodPost {
+			t.Errorf("method = %v", answer["method"])
+		}
+		if answer["body"] != `{"name":"ada","n":2}` {
+			t.Errorf("body = %v", answer["body"])
+		}
+		decoded, _ := answer["json"].(map[string]any)
+		if decoded["name"] != "ada" || decoded["n"] != float64(2) {
+			t.Errorf("json = %#v", answer["json"])
+		}
+		assertEmptyObject(t, answer, "form")
+	})
+
+	// A form body is the case the superglobals already answer: $_POST carries
+	// it, and the raw bytes are still readable next to it.
+	t.Run("post form", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/echo/x", strings.NewReader("title=q3"))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		answer := echo(t, req)
+
+		form, _ := answer["form"].(map[string]any)
+		if form["title"] != "q3" {
+			t.Errorf("form = %#v", answer["form"])
+		}
+		if answer["body"] != "title=q3" {
+			t.Errorf("body = %v", answer["body"])
+		}
+		if answer["json"] != nil {
+			t.Errorf("json = %v, want null", answer["json"])
+		}
+		if answer["rest"] != "x" {
+			t.Errorf("rest = %v", answer["rest"])
+		}
+	})
 }
 
 func Example_routeSharedMemory() {


### PR DESCRIPTION
POC for #77. Hands the request being served to a script, and uses `/api/echo` to find out where the pass-through shape holds up and where it does not.

## What changed

- **`runner/request.go`** — `Context` keeps the `*http.Request` it was built from, behind a `Context.Request()` accessor. `NewContext()` leaves it nil, so a Context assembled by hand (CLI, `@startup`, `@schedule`, the fixture harness) has no request.
- **`runner/request.go`** — `parseBody` wraps the buffered `php://input` bytes back onto `r.Body` after `ParseForm`/`ParseMultipartForm` have run. Before this, `$request->body` was an exhausted reader: `php://input` answered the payload and the request itself answered nothing.
- **`stdlib/http/request.go`** — `CurrentRequest(ctx) any`, returning `c.Request()` or nil.
- **`stdlib/http/register.go`** — registers it as `HTTP\Request::current`, a native static on the class it returns.
- **`tests/fixtures/routing/api-echo.php`** — an httpbin-style echo endpoint. Two annotations, both method-less, so four registrations: `GET`/`POST` on `/api/echo` and on `/api/echo/{rest...}`. First `.php` file in the tree to use a `{rest...}` route.
- **`tests/route_test.go`** — `TestRouteAPIEcho`, four subtests through `httptest`: GET with query, trailing path, POST JSON, POST form.
- **`demos/example/api-echo.php`** — the same endpoint in the demo, plus a README row and three venom cases.
- **`tests/fixtures/bindings/http_server_request.phpt`** — pins `HTTP\Request::current()` answering null off a request, and the two host-object surprises below.
- **`docs/use-cases/http-client.md`** — a "Read the request being served" section with the read-this-not-that table.
- **`docs/guides/50-a-json-api.md`** — corrects "There is no `php://input` and no raw body binding in this runtime". There is; `runner/request.go:368` buffers it and `stdlib/files/stream.go:96` serves it.

`/api/echo` answers `method`, `proto`, `host`, `path`, `rest`, `url`, `args`, `headers`, `form`, `body`, `json`. The `json` key is present only when the content type is JSON, `null` otherwise. Every value is read off the request and encoded in `api-echo.php`; the binding hands the request over, it does not render one.

## Why `HTTP\Request::current()` and not `request()`

The issue floats `rt.BindObject("Request", r)` with `Request::Path`, and `request()` as the alternative.

- `Request::Path` as a static property read is not implementable: `helperStaticProp` reads `model.Class.Statics`, and a host-backed value has none. `helperClassConst` likewise reads `model.Class.Consts` only — there is no native-static-constant mechanism.
- `request()` would be a bare global for a subject that already has a class. `docs/naming-conventions.md:171-174` reserves the function spelling for bindings that are one call with no object to hold, and this one hands back an object.
- A `RegisterFunc` also documents only its own signature. `internal/apidoc/apidoc.go:172` reflects a type's methods off a **registered constructor**, so the returned surface reaches `implemented-apis.md` only because `HTTP\Request` is already a registered class.
- `HTTP\Request::current()` is the shape already in the tree: `DateTime::now()`, `Database::connections()`, `Closure::fromCallable()`.

## Observations: does the pass-through shape survive?

Measured against a probe endpoint, not assumed.

**It holds for scalars and for the methods PHP has no name for.** These have no superglobal equivalent and are the reason the binding is worth having:

| Reads | Answers |
|---|---|
| `$r->method`, `$r->proto`, `$r->host`, `$r->requesturi` | as expected |
| `$r->url->path`, `$r->url->string()` | as expected; `string()` is relative on a server request |
| `$r->useragent()`, `$r->referer()` | `probe/1`, `http://ref/` |
| `$r->formvalue("x")` | `1` — the merged query+form lookup |
| `$r->cookie("sid")` | an `*http.Cookie`; `$c->value` is `xyz` |
| `$r->basicauth()` | `["ada", "pw", 1]` — Go's three returns as a PHP list |
| `$r->pattern` | `POST /zz-probe/{rest...}` — the route that matched |

**It does not hold for anything with more than one value in it.** `$r->header`, `$r->url->query()`, `$r->form`, `$r->postform` and `$r->trailer` are Go maps: `foreach` order is re-randomised on every pass (`model/collection.go:24-28`) and each value is a `[]string`, not a string. An answer built from them differs between two identical requests, which is why `api-echo.php` reads `getallheaders()`, `$_GET` and `$_POST` instead.

**Three things read as bugs.** Each is pinned by a fixture:

1. **A nil pointer field is truthy.** `$r->tls` on a plain HTTP request: `gettype()` says `unknown type`, `is_null()` says false, `(bool)` says **true**. `if ($r->tls)` reports HTTPS on a cleartext request. `isset($_SERVER["HTTPS"])` is correct. The same shape bit this PR: `CurrentRequest` first returned `*http.Request`, and "no request" arrived as a truthy `"<nil>"` rather than null — hence the `any` return.
2. **The class name is the Go type's, not the registered name.** `get_class($r)` is `Request`. `$r instanceof HTTP\Request` is **false**; `$r instanceof Request` is true. `instanceOfClass` falls through to `goTypeName` (`runner/instanceof.go:94`), which drops the namespace.
3. **A write is accepted and inert.** `$r->method = "PATCH"` succeeds; `$_SERVER["REQUEST_METHOD"]` still says `POST`. The two now disagree about the same request.

**Reach.** `$r->clone()`, `$r->withcontext()` and `$r->parsemultipartform()` are all callable. The first two take a `context.Context` as their first parameter, so `wantsContext` (`runner/helpers.go:35`) **auto-injects the runtime lifecycle context** and a script calling `$r->withcontext()` silently rebinds the request to it. `docs/reference/extensions/bindings.md:23` already names the remedy — "return a dedicated facade type when the underlying implementation has exports that scripts must not see" — and this is the case for it.

## The interface question: for and against

The user's framing was that `HTTP\Request` and `HTTP\Response` should either implement `HTTP\RequestInterface` / `HTTP\ResponseInterface`, or be plain pass-through types. This PR ships them as pass-through, because the first option is not currently expressible.

**Against, and decisively so today:** an interface cannot be attached to a Go binding.

- `phpInstanceOf` reads an `Implements` list only off `*model.Object` (`runner/instanceof.go:38`). A host-backed value is not one and records no such list, so `$r instanceof HTTP\RequestInterface` is false and no stdlib change can make it true.
- `model.CheckInterfaces` skips any name no `interface` declaration in the same parsed program defines (`model/interfaces.go:60`), and `docs/design.md:63` states the rule as "a file is registered as a unit". An interface shipped from Go is invisible to the contract check.
- `docs/design.md:45-52`: "a class that says `implements` must declare every one of them itself, and that is the whole of what an interface does." A Go type declares nothing in PHP source, so there is nothing for the check to read.

An `HTTP\RequestInterface` added to `stdlib` today would therefore be a comment: not checked, not dispatched, and false under `instanceof`. Making it mean anything needs a **runtime** change — a per-constructor interface-name registry plus a branch in `phpInstanceOf` — which is a decision about the object model, not a stdlib addition.

**For, and worth weighing separately:** the three surprises above are all "the script sees the Go type". A named PHP-side contract is one way to stop that, but a facade is the other, is already the documented remedy, and needs no runtime change. `HTTP\Response` is already a facade for exactly this reason (`stdlib/http/response.go:11-15`) — note that it is a facade over the client result, not a binding for `*http.Response`, so the symmetry the issue assumes does not exist yet either.

The narrower question worth answering first: should `get_class()` on a host object report the registered name (`HTTP\Request`) rather than the Go type name (`Request`)? That is a small, self-contained fix, it makes `instanceof HTTP\Request` true, and it removes the collision where every Go type named `Request` is the same PHP class. It does not need interfaces.

## PSR-7, if the interfaces are wanted anyway

What phpscript already answers for each PSR-7 read method. The `with*` mutators are **not** proposed: each returns a new instance per call, which `docs/allocation-performance.md` argues against, and an inbound request here is request-lived and reached by one script, so there is nothing to protect by copying.

| PSR-7 | phpscript answers it with |
|---|---|
| `MessageInterface::getProtocolVersion()` | `$r->proto` / `$_SERVER["SERVER_PROTOCOL"]` |
| `getHeaders()` | `getallheaders()` |
| `hasHeader($n)` / `getHeaderLine($n)` | `$r->header->get($n)` |
| `getHeader($n)` | nothing ordered — `$r->header[$n]` is a Go `[]string` |
| `getBody()` | `file_get_contents("php://input")` |
| `RequestInterface::getRequestTarget()` | `$r->requesturi` / `$_SERVER["REQUEST_URI"]` |
| `getMethod()` | `$r->method` / `$_SERVER["REQUEST_METHOD"]` |
| `getUri()` | `$r->url` (a `*url.URL`, relative on a server request) |
| `ServerRequestInterface::getServerParams()` | `$_SERVER` |
| `getCookieParams()` | `$_COOKIE` |
| `getQueryParams()` | `$_GET` |
| `getUploadedFiles()` | `$_FILES` |
| `getParsedBody()` | `$_POST` |
| `getAttributes()` / `getAttribute($n)` | `$_REQUEST`, which carries the route path values |
| `UriInterface` | `$r->url->{scheme,host,path,rawquery,fragment}` |
| `StreamInterface` | nothing; there is no stream a script can hold |
| `UploadedFileInterface` | `$_FILES` entries plus `move_uploaded_file()` |

Two of the three interfaces are already answered end to end by names PHP defines. `StreamInterface` has no counterpart and would need one invented. That is the argument for leaving the PSR-7 vocabulary out and keeping the PHP one.

## Verification

```
go test ./...                                       # green
phpscript test --matrix ./tests/...                 # 208/208, php column included
atkins --final default                              # green
go test ./tests/ -run TestRouteAPIEcho -v           # 4/4 subtests
```

Against a running demo server, through the chi router (so `{rest...}` resolves under chi's `*`):

```
$ curl -s 'localhost:8080/api/echo/a/b?x=1&y=2' -H 'X-Trace: abc'
{"method":"GET","proto":"HTTP/1.1","host":"127.0.0.1:8080","path":"/api/echo/a/b",
 "rest":"a/b","url":"http://127.0.0.1:8080/api/echo/a/b?x=1&y=2",
 "args":{"x":"1","y":"2"},"headers":{"Accept":"*/*","User-Agent":"curl/8.18.0","X-Trace":"abc"},
 "form":{},"body":"","json":null}

$ curl -s -XPOST -H 'content-type: application/json' -d '{"a":1,"b":[2,3]}' localhost:8080/api/echo
{... "body":"{\"a\":1,\"b\":[2,3]}","json":{"a":1,"b":[2,3]}}

$ curl -s -XPOST -d 'title=q3' localhost:8080/api/echo/z
{... "rest":"z","form":{"title":"q3"},"body":"title=q3","json":null}
```

## API change report

`worktree verdict --from=main`:

# github.com/titpetric/phpscript @ v0.4.2

Patch release: v0.4.2, no exported symbols were removed since main.

## Commits since main

| Commit | API | Subject |
| --- | --- | --- |
| [`2357ed3`](https://github.com/titpetric/phpscript/commit/2357ed3) | +2/~0/-0 | feat(stdlib/http): hand the request being served to a script |

## API since main

| Change | Package | Symbol | Commits |
| --- | --- | --- | --- |
| Added | /runner | func (Context) Request () *http.Request | [`2357ed3`](https://github.com/titpetric/phpscript/commit/2357ed3) |
|  | /stdlib/http | func CurrentRequest (context.Context) any | [`2357ed3`](https://github.com/titpetric/phpscript/commit/2357ed3) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
