### PR TITLE
perf(test): --cache=worker|off, and the allocations behind a 3.3GB suite

### DIFF
--- a/cmd/phpscript/lint/run.go
+++ b/cmd/phpscript/lint/run.go
@@ -182,7 +182,7 @@ func collect(args []string, checkFlatstack bool) ([]result, error) {
 		}
 		for _, d := range diags {
 			status := statusWarn
-			if isParseError(d.Message) {
+			if d.Fatal || isParseError(d.Message) {
 				status = statusFail
 			}
 			results = append(results, result{status: status, file: d.File, line: d.Line, message: d.Message})

--- a/cmd/phpscript/test/group.go
+++ b/cmd/phpscript/test/group.go
@@ -30,18 +30,18 @@ type groupTotals struct {
 
 // mapFixtures runs fn over a group with bounded concurrency and returns values
 // in fixture discovery order, keeping terminal, Markdown, and JSON output stable.
-func mapFixtures[T any](fixtures []*tests.Fixture, parallel int, fn func(int, *tests.Fixture) T) []T {
+func mapFixtures[T any](fixtures []*tests.Fixture, parallel int, fn func(worker, i int, fx *tests.Fixture) T) []T {
 	results := make([]T, len(fixtures))
 	if parallel <= 1 || len(fixtures) <= 1 {
 		for i, fx := range fixtures {
-			results[i] = fn(i, fx)
+			results[i] = fn(0, i, fx)
 		}
 		return results
 	}
 
 	for start := 0; start < len(fixtures); {
 		if fixtures[start].Serial {
-			results[start] = fn(start, fixtures[start])
+			results[start] = fn(0, start, fixtures[start])
 			start++
 			continue
 		}
@@ -55,17 +55,24 @@ func mapFixtures[T any](fixtures []*tests.Fixture, parallel int, fn func(int, *t
 	return results
 }
 
-func mapFixtureBatch[T any](fixtures []*tests.Fixture, results []T, start, end, parallel int, fn func(int, *tests.Fixture) T) {
-	jobs := make(chan int)
+func mapFixtureBatch[T any](fixtures []*tests.Fixture, results []T, start, end, parallel int, fn func(worker, i int, fx *tests.Fixture) T) {
+	// Buffered to the whole batch, so the fixtures are queued in one go and
+	// the workers draw from it. An unbuffered channel makes the sender wait
+	// for a worker to take each one, which serialises the hand-off against
+	// the slowest fixture in flight.
+	jobs := make(chan int, end-start)
 	var workers sync.WaitGroup
 	workers.Add(min(parallel, end-start))
-	for range min(parallel, end-start) {
-		go func() {
+	for id := range min(parallel, end-start) {
+		// Each goroutine is one worker with a number, and the number is what
+		// --cache=worker scopes a cache to. The loop inside it is serial, so a
+		// worker's cache is never touched by two fixtures at once.
+		go func(id int) {
 			defer workers.Done()
 			for i := range jobs {
-				results[i] = fn(i, fixtures[i])
+				results[i] = fn(id, i, fixtures[i])
 			}
-		}()
+		}(id)
 	}
 	for i := start; i < end; i++ {
 		jobs <- i

--- a/cmd/phpscript/test/loop_test.go
+++ b/cmd/phpscript/test/loop_test.go
@@ -84,7 +84,7 @@ func TestMapFixturesRunsConcurrentlyWithSerialBarrier(t *testing.T) {
 	fixtures := []*tests.Fixture{{Name: "a"}, {Name: "b"}, {Name: "serial", Serial: true}, {Name: "c"}, {Name: "d"}}
 	var active, peak, serialActive atomic.Int64
 
-	results := mapFixtures(fixtures, 4, func(i int, fx *tests.Fixture) string {
+	results := mapFixtures(fixtures, 4, func(_, i int, fx *tests.Fixture) string {
 		current := active.Add(1)
 		defer active.Add(-1)
 		for current > peak.Load() && !peak.CompareAndSwap(peak.Load(), current) {

--- a/cmd/phpscript/test/matrix.go
+++ b/cmd/phpscript/test/matrix.go
@@ -87,7 +87,7 @@ func runMatrix(ctx context.Context, groups []fixtureGroup, opts Options, report 
 		groupPassed, groupFailed := 0, 0
 		groupStart := time.Now()
 
-		results := mapFixtures(group.Fixtures, opts.Parallel, func(i int, fx *tests.Fixture) matrixFixtureResult {
+		results := mapFixtures(group.Fixtures, opts.Parallel, func(worker, i int, fx *tests.Fixture) matrixFixtureResult {
 			row := matrixRow{DisplayPath: group.Paths[i], Label: group.Labels[i]}
 			var fixtureJSONRows []jsonFixture
 			for _, name := range opts.runners() {
@@ -106,7 +106,7 @@ func runMatrix(ctx context.Context, groups []fixtureGroup, opts Options, report 
 					continue
 				}
 
-				for _, fr := range runFixtureSamples(ctx, fx, name, opts) {
+				for _, fr := range runFixtureSamples(tests.WithWorker(ctx, worker), fx, name, opts) {
 					fr.DisplayPath = row.DisplayPath
 					fr.Label = row.Label
 					if name == tests.RunnerRuntime {

--- a/cmd/phpscript/test/run.go
+++ b/cmd/phpscript/test/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"runtime/metrics"
 	"runtime/pprof"
 	"sort"
 	"strings"
@@ -38,6 +39,7 @@ type Options struct {
 	CoverFile  string
 	Split      bool
 	SkipPHP    bool
+	Cache      string
 }
 
 // coverReport reports whether the cover mode owns stdout with a per-symbol
@@ -110,6 +112,7 @@ func NewCommand() *cli.Command {
 			fs.Lookup("cover").NoOptDefVal = CoverLine
 			fs.StringVar(&opts.CoverFile, "coverfile", "", "Write the coverage profile to this file (implies --cover; default "+DefaultCoverFile+")")
 			fs.BoolVar(&opts.Split, "split", false, "With --cover, also write each fixture's own coverage next to it as <fixture>.cov")
+			fs.StringVar(&opts.Cache, "cache", CacheWorker, "Scope of the parse caches: worker (one per worker loop, the default) or off (a new one per fixture run)")
 		},
 		Run: func(ctx context.Context, args []string) error {
 			return Run(ctx, args, opts)
@@ -160,8 +163,16 @@ func runFixtureLoop(ctx context.Context, fx *tests.Fixture, r tests.Runner, opts
 	}
 	samples := make([]int64, 0, hint)
 
+	// MemStats only when something reports it. ReadMemStats stops the world,
+	// and this runs once per fixture per runner - 1368 pauses over a 342-file
+	// matrix - for two numbers nothing prints unless --profile asked for them.
+	// The GC count comes from runtime/metrics either way, which does not stop
+	// anything, so the column stays.
 	var before, after runtime.MemStats
-	runtime.ReadMemStats(&before)
+	if opts.Profile {
+		runtime.ReadMemStats(&before)
+	}
+	gcBefore := gcCycles()
 	start := time.Now()
 	for {
 		opStart := time.Now()
@@ -183,9 +194,12 @@ func runFixtureLoop(ctx context.Context, fx *tests.Fixture, r tests.Runner, opts
 		}
 	}
 	out.Total = time.Since(start)
-	runtime.ReadMemStats(&after)
-	out.GCRuns = after.NumGC - before.NumGC
+	out.GCRuns = uint32(gcCycles() - gcBefore)
 	if opts.Profile {
+		runtime.ReadMemStats(&after)
+		// Per op, not per fixture: --count and --time run the fixture N times
+		// inside the one pair of readings, so the totals are divided by the
+		// runs rather than sampled per iteration.
 		n := uint64(out.Runs)
 		out.AllocsPerOp = (after.Mallocs - before.Mallocs) / n
 		out.BytesPerOp = (after.TotalAlloc - before.TotalAlloc) / n
@@ -292,6 +306,14 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		return fmt.Errorf("discover fixtures: %w", err)
 	}
 
+	mode, err := cacheMode(opts.Cache)
+	if err != nil {
+		return err
+	}
+	for _, fx := range fixtures {
+		fx.SetCacheScope(mode)
+	}
+
 	if opts.Autoload != "" || opts.Include != "" {
 		// The flags speak from the invocation root: that is where the autoload
 		// folder and the include file live, below no fixture directory.
@@ -378,8 +400,8 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		groupPassed, groupFailed := 0, 0
 		groupStart := time.Now()
 
-		fixtureRuns := mapFixtures(group.Fixtures, opts.Parallel, func(_ int, fx *tests.Fixture) []*fixtureRun {
-			return runFixtureSamples(ctx, fx, tests.RunnerRuntime, opts)
+		fixtureRuns := mapFixtures(group.Fixtures, opts.Parallel, func(worker, _ int, fx *tests.Fixture) []*fixtureRun {
+			return runFixtureSamples(tests.WithWorker(ctx, worker), fx, tests.RunnerRuntime, opts)
 		})
 		for i, fx := range group.Fixtures {
 			var fixtureResult *tests.TestResult
@@ -523,4 +545,48 @@ func writeMemProfile(opts Options) error {
 		return fmt.Errorf("write memprofile: %w", err)
 	}
 	return nil
+}
+
+// gcCycles returns the number of completed GC cycles.
+//
+// runtime/metrics rather than runtime.MemStats: NumGC is only reachable through
+// ReadMemStats, which stops the world, and this is read twice per fixture per
+// runner. The metrics reader takes a lock and copies a counter.
+func gcCycles() uint64 {
+	sample := [1]metrics.Sample{{Name: "/gc/cycles/total:gc-cycles"}}
+	metrics.Read(sample[:])
+	if sample[0].Value.Kind() != metrics.KindUint64 {
+		return 0
+	}
+	return sample[0].Value.Uint64()
+}
+
+// The --cache modes, which say how far a parsed include and a compiled
+// expression travel.
+//
+// There is no "shared" mode because a worker loop already is one: run without
+// --parallel there is a single worker, so a single set of caches serves the
+// whole run. Sharing them across workers on top of that only adds contention
+// for a hit the worker's own cache already has.
+const (
+	// CacheOff gives every fixture run its own caches and drops the runtime
+	// after it. Nothing one run parsed is visible to the next, so a run is
+	// charged the parsing its own includes cost - and what it held is returned
+	// when it ends rather than kept for the length of the suite.
+	CacheOff = "off"
+	// CacheWorker gives each worker one set, reused by the fixtures that
+	// worker runs serially. What is held scales with --parallel rather than
+	// with the number of fixtures.
+	CacheWorker = "worker"
+)
+
+// cacheMode reads the --cache flag.
+func cacheMode(value string) (string, error) {
+	switch value {
+	case "", CacheWorker:
+		return CacheWorker, nil
+	case CacheOff:
+		return value, nil
+	}
+	return "", fmt.Errorf("--cache must be %s or %s, not %q", CacheWorker, CacheOff, value)
 }

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -18,11 +18,11 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ❌     | cmd/phpscript/ast     | 0.00%    | 5         | 31    |
 | ❌     | cmd/phpscript/fmt     | 0.00%    | 5         | 42    |
 | ❌     | cmd/phpscript/info    | 79.20%   | 52        | 183   |
-| ❌     | cmd/phpscript/lint    | 73.07%   | 56        | 218   |
+| ❌     | cmd/phpscript/lint    | 73.07%   | 57        | 218   |
 | ✅     | cmd/phpscript/list    | 30.00%   | 4         | 38    |
 | ❌     | cmd/phpscript/run     | 26.67%   | 11        | 86    |
 | ✅     | cmd/phpscript/server  | 80.88%   | 121       | 881   |
-| ✅     | cmd/phpscript/test    | 81.28%   | 485       | 1841  |
+| ✅     | cmd/phpscript/test    | 80.94%   | 490       | 1891  |
 | ❌     | cmd/phpscript/version | 0.00%    | 31        | 81    |
 | ✅     | config                | 94.49%   | 55        | 256   |
 | ✅     | flatstack             | 50.00%   | 0         | 18    |
@@ -32,17 +32,17 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | internal/arrayi64     | 100.00%  | 6         | 18    |
 | ✅     | internal/phpval       | 90.60%   | 142       | 575   |
 | ✅     | internal/table        | 100.00%  | 24        | 135   |
-| ✅     | lint                  | 87.32%   | 238       | 844   |
+| ✅     | lint                  | 87.32%   | 238       | 846   |
 | ❌     | list                  | 76.85%   | 136       | 472   |
 | ❌     | model                 | 36.84%   | 325       | 1130  |
-| ✅     | parser                | 91.34%   | 1039      | 3399  |
-| ✅     | runner                | 86.62%   | 1656      | 7163  |
+| ✅     | parser                | 91.37%   | 1041      | 3434  |
+| ✅     | runner                | 86.48%   | 1662      | 7205  |
 | ✅     | runner/bindings       | 86.72%   | 95        | 538   |
 | ✅     | runner/coverage       | 92.37%   | 45        | 187   |
 | ❌     | scripts/list-apis     | 0.00%    | 1         | 13    |
 | ✅     | stdlib                | 96.30%   | 4         | 94    |
 | ✅     | stdlib/compat         | 86.92%   | 184       | 901   |
-| ✅     | stdlib/core           | 85.53%   | 958       | 4262  |
+| ✅     | stdlib/core           | 85.48%   | 959       | 4275  |
 | ✅     | stdlib/crypto         | 85.97%   | 56        | 312   |
 | ✅     | stdlib/database       | 84.59%   | 105       | 791   |
 | ✅     | stdlib/files          | 87.78%   | 272       | 1041  |
@@ -58,7 +58,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     | stdlib/span           | 100.00%  | 0         | 11    |
 | ✅     | stdlib/time           | 42.78%   | 5         | 137   |
 | ❌     | telemetry             | 73.04%   | 10        | 209   |
-| ✅     | tests                 | 82.90%   | 215       | 1140  |
+| ✅     | tests                 | 84.80%   | 224       | 1262  |
 
 ## Functions
 
@@ -121,7 +121,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | printHostClass                        | 73.30%   | 5         |
 | ✅     |                      | printSourceTree                       | 85.20%   | 21        |
 | ✅     |                      | shortType                             | 75.00%   | 1         |
-| ✅     | cmd/phpscript/lint   | collect                               | 81.50%   | 22        |
+| ✅     | cmd/phpscript/lint   | collect                               | 81.50%   | 23        |
 | ✅     |                      | hasFailure                            | 75.00%   | 3         |
 | ✅     |                      | isParseError                          | 100.00%  | 1         |
 | ✅     |                      | line                                  | 100.00%  | 1         |
@@ -169,7 +169,8 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | writeAutoindexRow                     | 92.30%   | 5         |
 | ✅     | cmd/phpscript/test   | Options.coverReport                   | 100.00%  | 1         |
 | ✅     |                      | Options.runners                       | 100.00%  | 4         |
-| ✅     |                      | Run                                   | 81.00%   | 97        |
+| ✅     |                      | Run                                   | 81.00%   | 99        |
+| ✅     |                      | cacheMode                             | 50.00%   | 1         |
 | ✅     |                      | coverFilePath                         | 83.30%   | 2         |
 | ✅     |                      | coverFiles                            | 92.90%   | 9         |
 | ✅     |                      | coverFixtures                         | 100.00%  | 1         |
@@ -187,6 +188,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | formatGCRuns                          | 100.00%  | 1         |
 | ✅     |                      | formatMicros                          | 100.00%  | 0         |
 | ✅     |                      | funcRows                              | 100.00%  | 24        |
+| ✅     |                      | gcCycles                              | 80.00%   | 1         |
 | ✅     |                      | groupFixtures                         | 100.00%  | 3         |
 | ✅     |                      | mapFixtureBatch                       | 100.00%  | 5         |
 | ✅     |                      | mapFixtures                           | 100.00%  | 10        |
@@ -214,7 +216,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | ratio                                 | 100.00%  | 0         |
 | ❌     |                      | reportArgs                            | 66.70%   | 8         |
 | ✅     |                      | reportBlocks                          | 100.00%  | 3         |
-| ✅     |                      | runFixtureLoop                        | 100.00%  | 18        |
+| ✅     |                      | runFixtureLoop                        | 100.00%  | 19        |
 | ✅     |                      | runFixtureSamples                     | 90.00%   | 5         |
 | ✅     |                      | sortProfile                           | 83.30%   | 4         |
 | ✅     |                      | sortRows                              | 83.30%   | 4         |
@@ -698,7 +700,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | parser.parseStmt                      | 100.00%  | 4         |
 | ✅     |                      | parser.parseStmtNode                  | 94.00%   | 25        |
 | ✅     |                      | parser.parseStmts                     | 100.00%  | 20        |
-| ✅     |                      | parser.parseSubExpr                   | 75.00%   | 3         |
+| ✅     |                      | parser.parseSubExpr                   | 82.40%   | 3         |
 | ❌     |                      | parser.parseSwitch                    | 67.60%   | 25        |
 | ✅     |                      | parser.parseTernary                   | 82.40%   | 11        |
 | ✅     |                      | parser.parseThrow                     | 83.30%   | 1         |
@@ -730,6 +732,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | phpTokenizer.scanString               | 100.00%  | 10        |
 | ✅     |                      | phpTokenizer.scanVariable             | 100.00%  | 2         |
 | ✅     |                      | phpTokenizer.scanWhitespace           | 100.00%  | 4         |
+| ✅     |                      | releaseTokens                         | 80.00%   | 1         |
 | ❌     |                      | repeatableExpr                        | 47.60%   | 25        |
 | ✅     |                      | scanCurly                             | 91.70%   | 9         |
 | ✅     |                      | scanInterp                            | 100.00%  | 16        |
@@ -740,6 +743,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | scratch[T].push                       | 100.00%  | 0         |
 | ✅     |                      | scratch[T].take                       | 100.00%  | 1         |
 | ❌     |                      | skipQuoted                            | 75.00%   | 6         |
+| ✅     |                      | takeTokens                            | 100.00%  | 1         |
 | ✅     |                      | token.String                          | 100.00%  | 0         |
 | ✅     |                      | tokenizeFrom                          | 100.00%  | 0         |
 | ✅     | runner               | AcceptsHTML                           | 100.00%  | 12        |
@@ -823,7 +827,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | Runtime.DeclaredClasses               | 100.00%  | 3         |
 | ✅     |                      | Runtime.DefinedConstants              | 100.00%  | 0         |
 | ✅     |                      | Runtime.DefinedFunctions              | 100.00%  | 4         |
-| ✅     |                      | Runtime.Eval                          | 97.60%   | 18        |
+| ✅     |                      | Runtime.Eval                          | 95.60%   | 21        |
 | ✅     |                      | Runtime.Exit                          | 100.00%  | 0         |
 | ✅     |                      | Runtime.FS                            | 100.00%  | 0         |
 | ✅     |                      | Runtime.FreezeStdlib                  | 100.00%  | 0         |
@@ -966,7 +970,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | ScriptEnvironment                     | 100.00%  | 5         |
 | ✅     |                      | Size.Bytes                            | 100.00%  | 0         |
 | ✅     |                      | Size.Exceeds                          | 100.00%  | 1         |
-| ✅     |                      | Size.String                           | 66.70%   | 2         |
+| ✅     |                      | Size.String                           | 100.00%  | 2         |
 | ✅     |                      | Size.UnmarshalYAML                    | 100.00%  | 1         |
 | ✅     |                      | Transpiler.Calls                      | 100.00%  | 0         |
 | ✅     |                      | Transpiler.Closures                   | 100.00%  | 0         |
@@ -978,7 +982,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | Transpiler.addCall                    | 100.00%  | 3         |
 | ✅     |                      | Transpiler.addConst                   | 100.00%  | 0         |
 | ✅     |                      | Transpiler.addVar                     | 100.00%  | 0         |
-| ❌     |                      | Transpiler.emit                       | 78.10%   | 66        |
+| ❌     |                      | Transpiler.emit                       | 78.50%   | 69        |
 | ✅     |                      | Transpiler.emitArgs                   | 85.70%   | 3         |
 | ✅     |                      | Transpiler.emitArray                  | 84.60%   | 8         |
 | ✅     |                      | Transpiler.emitBinary                 | 90.00%   | 7         |
@@ -1368,7 +1372,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | registerEncoding                      | 100.00%  | 0         |
 | ✅     |                      | registerEnvironment                   | 100.00%  | 7         |
 | ✅     |                      | registerJSON                          | 100.00%  | 0         |
-| ✅     |                      | registerLang                          | 93.20%   | 47        |
+| ✅     |                      | registerLang                          | 93.40%   | 47        |
 | ✅     |                      | registerMath                          | 100.00%  | 4         |
 | ✅     |                      | registerMbstring                      | 100.00%  | 0         |
 | ✅     |                      | registerOutput                        | 95.20%   | 10        |
@@ -1387,6 +1391,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | sortInt64Array                        | 100.00%  | 6         |
 | ✅     |                      | sortLess                              | 100.00%  | 0         |
 | ✅     |                      | sortValues                            | 85.00%   | 6         |
+| ✅     |                      | stdinStream.Read                      | 75.00%   | 1         |
 | ✅     |                      | strtolInt                             | 97.60%   | 37        |
 | ❌     |                      | substrWindow                          | 63.60%   | 12        |
 | ✅     |                      | urlEncode                             | 100.00%  | 9         |
@@ -1671,14 +1676,19 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | Fixture.RootDir                       | 100.00%  | 1         |
 | ✅     |                      | Fixture.Runs                          | 100.00%  | 3         |
 | ✅     |                      | Fixture.SetAppRoot                    | 100.00%  | 1         |
+| ✅     |                      | Fixture.SetCacheScope                 | 100.00%  | 0         |
 | ✅     |                      | Fixture.SetCoverage                   | 100.00%  | 0         |
 | ✅     |                      | Fixture.SetRootFS                     | 100.00%  | 0         |
-| ✅     |                      | Fixture.flatIncludeCache              | 100.00%  | 3         |
-| ✅     |                      | Fixture.includeCache                  | 100.00%  | 3         |
+| ✅     |                      | Fixture.acquireRuntime                | 83.30%   | 8         |
+| ✅     |                      | Fixture.cacheRoot                     | 100.00%  | 1         |
+| ✅     |                      | Fixture.caches                        | 75.00%   | 1         |
+| ✅     |                      | Fixture.cleanState                    | 100.00%  | 0         |
+| ✅     |                      | Fixture.flatCaches                    | 75.00%   | 1         |
 | ✅     |                      | Fixture.includePrelude                | 85.70%   | 5         |
 | ✅     |                      | Fixture.program                       | 100.00%  | 2         |
 | ✅     |                      | Fixture.realRoot                      | 100.00%  | 1         |
 | ✅     |                      | Fixture.runnerOptions                 | 100.00%  | 3         |
+| ✅     |                      | Fixture.runtimeKey                    | 100.00%  | 0         |
 | ✅     |                      | Fixture.stdin                         | 100.00%  | 2         |
 | ✅     |                      | NewFailStorage                        | 100.00%  | 0         |
 | ✅     |                      | NewStorage                            | 75.00%   | 1         |
@@ -1687,18 +1697,19 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | RunFixture                            | 100.00%  | 0         |
 | ❌     |                      | RunFixtureOn                          | 74.20%   | 20        |
 | ✅     |                      | TestMain                              | 100.00%  | 0         |
+| ✅     |                      | WithWorker                            | 100.00%  | 0         |
+| ✅     |                      | absPath                               | 66.70%   | 1         |
 | ✅     |                      | bindingError.Error                    | 100.00%  | 0         |
 | ✅     |                      | buildFixtureRequestContext            | 97.70%   | 9         |
 | ✅     |                      | collector.RegisterFunc                | 100.00%  | 0         |
+| ✅     |                      | currentWorker                         | 100.00%  | 2         |
 | ✅     |                      | embeddedFixtures                      | 85.30%   | 14        |
 | ✅     |                      | errorChainContains                    | 60.00%   | 3         |
-| ✅     |                      | executeFixturePHP                     | 96.80%   | 7         |
-| ✅     |                      | executeFlatstack                      | 88.90%   | 7         |
+| ✅     |                      | executeFixturePHP                     | 92.30%   | 7         |
+| ✅     |                      | executeFlatstack                      | 83.90%   | 8         |
 | ✅     |                      | executePHP                            | 90.80%   | 7         |
-| ✅     |                      | flatIncludeCacheFor                   | 100.00%  | 1         |
 | ✅     |                      | hostPanicFast                         | 100.00%  | 0         |
 | ✅     |                      | hostPanicReflect                      | 100.00%  | 0         |
-| ✅     |                      | includeCacheFor                       | 100.00%  | 1         |
 | ✅     |                      | loadFixtureFile                       | 75.00%   | 2         |
 | ✅     |                      | memStorage.All                        | 100.00%  | 2         |
 | ✅     |                      | memStorage.Get                        | 100.00%  | 1         |
@@ -1706,6 +1717,7 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | memStorage.Set                        | 100.00%  | 0         |
 | ✅     |                      | memStorage.Tenant                     | 100.00%  | 0         |
 | ✅     |                      | newFlatstackTestRuntime               | 100.00%  | 0         |
+| ✅     |                      | newWorker                             | 100.00%  | 0         |
 | ❌     |                      | parseArgs                             | 76.20%   | 13        |
 | ✅     |                      | phpEnv                                | 33.30%   | 2         |
 | ✅     |                      | phpFatal                              | 100.00%  | 4         |
@@ -1717,4 +1729,6 @@ cover. Tests with cognitive complexity 0 would be covered by invocation.
 | ✅     |                      | testPHPFS                             | 83.30%   | 2         |
 | ✅     |                      | toString                              | 66.70%   | 1         |
 | ✅     |                      | unionFS.Open                          | 90.00%   | 6         |
+| ✅     |                      | worker.flatIncludeFor                 | 100.00%  | 1         |
+| ✅     |                      | worker.includeFor                     | 100.00%  | 1         |
 | ✅     |                      | writePHPScript                        | 58.80%   | 5         |

--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -90,6 +90,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | json_stream.phpt                      | PASS       | PASS    | SKIP |
 | platform_database.phpt                | PASS       | PASS    | SKIP |
 | request_and_response_handling.phpt    | PASS       | PASS    | SKIP |
+| request_body_stdin.phpt               | PASS       | PASS    | SKIP |
 | session_manager.phpt                  | PASS       | PASS    | SKIP |
 | setcookie.phpt                        | PASS       | PASS    | SKIP |
 | storage_constructor_error.phpt        | PASS       | PASS    | SKIP |
@@ -219,13 +220,14 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 
 ## tests/fixtures/paths
 
-| tests/fixtures/paths | Flat stack | Runtime | PHP  |
-|----------------------|------------|---------|------|
-| chdir.phpt           | PASS       | PASS    | PASS |
-| magic_constants.phpt | PASS       | PASS    | PASS |
-| root_filesystem.phpt | PASS       | PASS    | PASS |
-| stat.phpt            | PASS       | PASS    | PASS |
-| streamread.phpt      | PASS       | PASS    | PASS |
+| tests/fixtures/paths     | Flat stack | Runtime | PHP  |
+|--------------------------|------------|---------|------|
+| chdir.phpt               | PASS       | PASS    | PASS |
+| chdir_include_cache.phpt | PASS       | PASS    | PASS |
+| magic_constants.phpt     | PASS       | PASS    | PASS |
+| root_filesystem.phpt     | PASS       | PASS    | PASS |
+| stat.phpt                | PASS       | PASS    | PASS |
+| streamread.phpt          | PASS       | PASS    | PASS |
 
 ## tests/fixtures/pexec
 
@@ -299,6 +301,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | base64.phpt                   | PASS       | PASS    | PASS |
 | case_functions.phpt           | PASS       | PASS    | PASS |
 | chr_ord.phpt                  | PASS       | PASS    | PASS |
+| escapes_bytes.phpt            | PASS       | PASS    | PASS |
 | fnmatch.phpt                  | PASS       | PASS    | PASS |
 | http_build_query.phpt         | PASS       | PASS    | PASS |
 | interpolation.phpt            | PASS       | PASS    | PASS |
@@ -335,7 +338,7 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/arithmetic  | 21       | 21     | 0      |
 | tests/fixtures/arrays      | 20       | 20     | 0      |
 | tests/fixtures/autoloading | 8        | 8      | 0      |
-| tests/fixtures/bindings    | 26       | 26     | 0      |
+| tests/fixtures/bindings    | 27       | 27     | 0      |
 | tests/fixtures/errors      | 3        | 3      | 0      |
 | tests/fixtures/exceptions  | 9        | 9      | 0      |
 | tests/fixtures/flatstack   | 7        | 7      | 0      |
@@ -345,11 +348,11 @@ last. See [testing.md](./testing.md) for the fixture format and how to add one.
 | tests/fixtures/namespaces  | 3        | 3      | 0      |
 | tests/fixtures/oop         | 24       | 24     | 0      |
 | tests/fixtures/output      | 4        | 4      | 0      |
-| tests/fixtures/paths       | 5        | 5      | 0      |
+| tests/fixtures/paths       | 6        | 6      | 0      |
 | tests/fixtures/pexec       | 2        | 2      | 0      |
 | tests/fixtures/regex       | 7        | 7      | 0      |
 | tests/fixtures/runtime     | 14       | 14     | 0      |
 | tests/fixtures/stdlib      | 22       | 22     | 0      |
-| tests/fixtures/strings     | 18       | 18     | 0      |
+| tests/fixtures/strings     | 19       | 19     | 0      |
 | tests/fixtures/syntax      | 8        | 8      | 0      |
-| **Total**                  | 221      | 221    | 0      |
+| **Total**                  | 224      | 224    | 0      |

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -18,6 +18,12 @@ type Diagnostic struct {
 	File    string
 	Line    int
 	Message string
+
+	// Fatal marks a finding the program cannot survive, as against one it
+	// might: a call to a function some host registers is a warning because the
+	// linter cannot see every binding, but a redeclaration is refused by the
+	// runtime whatever is registered. A fatal finding fails the lint run.
+	Fatal bool
 }
 
 func (d Diagnostic) String() string {

--- a/lint/redeclare.go
+++ b/lint/redeclare.go
@@ -54,12 +54,14 @@ func lintRedeclared(file string, prog *model.Program, out *[]Diagnostic) {
 				File:    file,
 				Line:    line,
 				Message: fmt.Sprintf("Cannot redeclare function %s() (previously declared on line %d)", decl.Name, previous),
+				Fatal:   true,
 			})
 		case rt.FunctionExists(decl.Name):
 			*out = append(*out, Diagnostic{
 				File:    file,
 				Line:    line,
 				Message: fmt.Sprintf("Cannot redeclare function %s()", decl.Name),
+				Fatal:   true,
 			})
 		default:
 			seen[key] = line

--- a/parser/interp.go
+++ b/parser/interp.go
@@ -279,6 +279,7 @@ func (p *parser) parseSubExpr(src string, line int) (model.Expr, error) {
 	if err != nil {
 		return nil, fmt.Errorf("line %d: string interpolation: %w", line, err)
 	}
+	defer releaseTokens(toks)
 
 	sub := &parser{toks: toks, namespace: p.namespace, imports: p.imports}
 	e, err := sub.parseExpr()

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -103,8 +104,46 @@ var multiOpsByFirst = func() [utf8.RuneSelf][]string {
 // the whole slice, on dense ones.
 const bytesPerToken = 4
 
+// tokenPool recycles the token slice a parse walks.
+//
+// The slice is the largest single allocation the parser makes - a token is five
+// fields and a source file yields one per four bytes - and it is garbage the
+// moment the AST is built: model cannot hold a token, the type is unexported to
+// it, and every read through p.toks[i] copies the struct rather than aliasing
+// the array. So the same backing array serves every parse in the process.
+//
+// It holds *[]token rather than []token because putting a slice in an
+// interface allocates the header; a pointer to one does not.
+var tokenPool sync.Pool
+
+// takeTokens returns an empty token slice, recycled when one is free.
+//
+// A recycled slice keeps whatever capacity it grew to, so the pool converges on
+// the largest file the process has parsed and later parses stop growing
+// altogether. The hint is only used when the pool is empty.
+func takeTokens(hint int) []token {
+	if v := tokenPool.Get(); v != nil {
+		return (*v.(*[]token))[:0]
+	}
+	return make([]token, 0, hint)
+}
+
+// releaseTokens returns a slice to the pool.
+//
+// It clears first. A token holds two strings, and those keep whole source files
+// alive: a pooled slice that kept them would trade an allocation saving for a
+// retention leak, which is the more expensive of the two.
+func releaseTokens(toks []token) {
+	if cap(toks) == 0 {
+		return
+	}
+	clear(toks)
+	toks = toks[:0]
+	tokenPool.Put(&toks)
+}
+
 func (l *lexer) run() ([]token, error) {
-	l.tokens = make([]token, 0, len(l.src)/bytesPerToken+8)
+	l.tokens = takeTokens(len(l.src)/bytesPerToken + 8)
 	l.skipShebang()
 	for l.pos < len(l.src) {
 		if !l.inPHP {
@@ -112,6 +151,10 @@ func (l *lexer) run() ([]token, error) {
 			continue
 		}
 		if err := l.lexPHP(); err != nil {
+			// The caller gets no slice to hand back, so the failed lex
+			// returns its own.
+			releaseTokens(l.tokens)
+			l.tokens = nil
 			return nil, err
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -28,6 +28,12 @@ func Parse(src string) (*model.Program, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The AST outlives the tokens but never points into them: model cannot
+	// hold a token, the type is unexported to it, and every read through
+	// p.toks[i] copies the struct. So the slice goes back to the pool here,
+	// however the parse ends.
+	defer releaseTokens(toks)
+
 	// One span per statement; statements run around one per sixteen tokens, so
 	// the hint saves the map's rehash-and-copy cycle (rule 6).
 	p := &parser{toks: toks, spans: make(map[model.Stmt]model.SourceSpan, len(toks)/16+8)}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -690,3 +690,56 @@ class Store implements Reader {
 		t.Errorf("AnonClasses = %v, want none", prog.AnonClasses)
 	}
 }
+
+// benchSource is a file of the shape the parser meets in an application: a
+// class with methods, a function, control flow and interpolation, repeated
+// until it is the size of a real source file rather than a snippet.
+var benchSource = func() string {
+	const unit = `
+class Row%[1]d {
+	private $id;
+	private $name;
+
+	public function __construct($id, $name) {
+		$this->id = $id;
+		$this->name = $name;
+	}
+
+	public function label($prefix = "row") {
+		if ($this->id > 0 && $this->name !== "") {
+			return "{$prefix}-{$this->id}: {$this->name}";
+		}
+		return $prefix;
+	}
+}
+
+function collect%[1]d(array $rows) {
+	$out = array();
+	foreach ($rows as $key => $row) {
+		if (!isset($row["id"])) {
+			continue;
+		}
+		$out[$key] = new Row%[1]d($row["id"], isset($row["name"]) ? $row["name"] : "");
+	}
+	return $out;
+}
+`
+	var b strings.Builder
+	b.WriteString("<?php\nnamespace Acme\\Bench;\n")
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&b, unit, i)
+	}
+	return b.String()
+}()
+
+// BenchmarkParse measures the whole parse, which is where the token slice is
+// allocated and discarded. B/op is the number the token pool moves.
+func BenchmarkParse(b *testing.B) {
+	b.SetBytes(int64(len(benchSource)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Parse(benchSource); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -428,6 +428,26 @@ func (rt *Runtime) ResetSession(out io.Writer, stdin io.Reader) {
 	}
 }
 
+// Reset returns the runtime to the state a new one is in, so a pool can hand
+// the same value to the next program instead of building another.
+//
+// It is ResetSession plus everything that outlives a session: the parse caches,
+// and the two maps keyed by AST node - compiled expressions and source spans.
+// Those are what ResetSession deliberately keeps, because a --count loop runs
+// one program repeatedly and the keys are the same nodes each time. Across two
+// different programs they are keys nothing will look up again, holding the
+// previous program's tree alive behind them.
+//
+// The caches are cleared rather than replaced: a cleared map keeps the buckets
+// it grew, so the next program allocates nothing to start.
+func (rt *Runtime) Reset(out io.Writer, stdin io.Reader) {
+	rt.ResetSession(out, stdin)
+	clear(rt.compiled)
+	clear(rt.sourceSpans)
+	rt.includeCache.Clear()
+	rt.exprCache.Clear()
+}
+
 // SetContext installs the lifecycle context auto-injected into registered Go
 // callables whose first parameter is a context.Context (constructors, methods,
 // functions). Defaults to context.Background().

--- a/runner/runtime.go
+++ b/runner/runtime.go
@@ -992,6 +992,20 @@ func (rt *Runtime) OnError(fn func(error)) {
 // Eval transpiles e, binds the referenced variables from scope, and runs the
 // resulting program through the expr-lang VM.
 func (rt *Runtime) Eval(e model.Expr, scope *Scope) (any, error) {
+	// A literal is its own value. Everything below this transpiles to expr
+	// source and runs it on the VM, which for a constant is the whole machine
+	// to answer what the parser already knew - and, for a string holding a
+	// byte that is not valid UTF-8, cannot answer correctly: the value would
+	// travel as \xff in source text and come back as the two bytes UTF-8
+	// spells U+00FF with.
+	if l, ok := e.(*model.Lit); ok {
+		if n, ok := l.Value.(int); ok {
+			// PHP integers are int64 everywhere else in the runtime, and the
+			// VM would have widened this one on the way out.
+			return int64(n), nil
+		}
+		return l.Value, nil
+	}
 	if b, ok := e.(*model.Binary); ok && b.Op == "." {
 		return rt.evalConcat(b, scope)
 	}

--- a/runner/transpile.go
+++ b/runner/transpile.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/titpetric/phpscript/model"
 )
@@ -172,6 +173,15 @@ func constIdent(name string) string { return constIdentPrefix + name }
 func (t *Transpiler) emit(e model.Expr) (string, error) {
 	switch n := e.(type) {
 	case *model.Lit:
+		if text, ok := n.Value.(string); ok && !utf8.ValidString(text) {
+			// A string carrying a byte that is not valid UTF-8 cannot travel
+			// as source text: strconv.Quote writes it as \xff, and expr-lang
+			// reads that back as the codepoint U+00FF and encodes it as the
+			// two bytes UTF-8 spells it with. "a\xffb" would arrive four bytes
+			// long. The literal is handed to the runtime instead, which reads
+			// the value itself and never spells it.
+			return "__eval(" + strconv.Quote(t.mark(n)) + ")", nil
+		}
 		return litSource(n.Value), nil
 
 	case *model.Var:

--- a/stdlib/core/lang.go
+++ b/stdlib/core/lang.go
@@ -85,7 +85,13 @@ func phpGetType(value any) string {
 func registerLang(rt *runner.Runtime) {
 	rt.SetConst("DIRECTORY_SEPARATOR", string(os.PathSeparator))
 	rt.SetConst("PATH_SEPARATOR", string(os.PathListSeparator))
-	rt.SetConst("STDIN", rt.Stdin())
+	// STDIN holds the runtime, not the reader of the moment. The constant is
+	// frozen once and a runtime can serve more than one program - a --count
+	// loop, a worker reusing its runtime - and each of those brings its own
+	// stdin. Reading through the runtime means STDIN is whatever the current
+	// session's is, the way php://output writes wherever output currently
+	// goes rather than where it went when the handle was made.
+	rt.SetConst("STDIN", stdinStream{rt: rt})
 	// spl_autoload_register registers $callback as an autoloader, or the default spl_autoload when $callback is null or omitted; $prepend puts it first and $throw is ignored.
 	rt.RegisterFunc("spl_autoload_register", func(args ...any) (bool, error) {
 		var callback any = rt.SPLAutoload
@@ -375,4 +381,18 @@ func strtolInt(s string, base int64) int64 {
 		return math.MaxInt64
 	}
 	return int64(mag)
+}
+
+// stdinStream is the reader STDIN answers with. It resolves the runtime's
+// current stdin per read, so a session that replaced it is read from.
+type stdinStream struct {
+	rt *runner.Runtime
+}
+
+func (s stdinStream) Read(p []byte) (int, error) {
+	in := s.rt.Stdin()
+	if in == nil {
+		return 0, io.EOF
+	}
+	return in.Read(p)
 }

--- a/tests/fixture.go
+++ b/tests/fixture.go
@@ -36,51 +36,6 @@ var phpFS fs.FS
 
 var phpFSOnce sync.Once
 
-var exprCache = runner.NewExprCache()
-
-var flatExprCache = flatstack.NewExprCache()
-
-// An include cache is keyed by the path as the script wrote it, so one cache
-// shared across fixture areas would serve syntax/code/functions.php to a
-// fixture in another area that includes its own code/functions.php. The caches
-// are therefore per include root, which is the directory holding the fixture.
-var (
-	includeCaches     sync.Map // string -> *runner.IncludeCache
-	flatIncludeCaches sync.Map // string -> *flatstack.IncludeCache
-)
-
-func includeCacheFor(dir string) *runner.IncludeCache {
-	if cache, ok := includeCaches.Load(dir); ok {
-		return cache.(*runner.IncludeCache)
-	}
-	cache, _ := includeCaches.LoadOrStore(dir, runner.NewIncludeCache())
-	return cache.(*runner.IncludeCache)
-}
-
-func flatIncludeCacheFor(dir string) *flatstack.IncludeCache {
-	if cache, ok := flatIncludeCaches.Load(dir); ok {
-		return cache.(*flatstack.IncludeCache)
-	}
-	cache, _ := flatIncludeCaches.LoadOrStore(dir, flatstack.NewIncludeCache())
-	return cache.(*flatstack.IncludeCache)
-}
-
-// ResetCaches clears all global shared caches between test suites.
-func ResetCaches() {
-	exprCache.Clear()
-	flatExprCache.Clear()
-	includeCaches.Range(func(key, value any) bool {
-		value.(*runner.IncludeCache).Clear()
-		includeCaches.Delete(key)
-		return true
-	})
-	flatIncludeCaches.Range(func(key, value any) bool {
-		value.(*flatstack.IncludeCache).Clear()
-		flatIncludeCaches.Delete(key)
-		return true
-	})
-}
-
 func testPHPFS() fs.FS {
 	phpFSOnce.Do(func() {
 		var err error
@@ -189,17 +144,16 @@ type Fixture struct {
 	Expected string `yaml:"-"`
 	Path     string `yaml:"-"`
 
-	appRoot            string
-	includes           []string
-	coverage           *coverage.Collector
-	rootFS             fs.FS
-	privateInclude     *runner.IncludeCache
-	privateFlatInclude *flatstack.IncludeCache
-	mu                 sync.Mutex
-	parsed             *model.Program
-	parsedErr          error
-	interp             *runner.Runtime
-	flatRT             *flatstack.Runtime
+	appRoot    string
+	cacheScope string
+	includes   []string
+	coverage   *coverage.Collector
+	rootFS     fs.FS
+	mu         sync.Mutex
+	parsed     *model.Program
+	parsedErr  error
+	interp     *runner.Runtime
+	flatRT     *flatstack.Runtime
 }
 
 // TestResult carries execution outcome for a single fixture.
@@ -233,6 +187,227 @@ func (f *Fixture) SetRootFS(root fs.FS) {
 // An include that is not there is not an error; the flag says what to load
 // when the application provides it, and a tree without an autoload.php simply
 // runs without one.
+// Cache scopes, naming how far a parsed include and a compiled expression
+// travel. The CLI spells them as --cache=off|worker|shared.
+const (
+	CacheOff    = "off"
+	CacheWorker = "worker"
+)
+
+// SetCacheScope says how far this fixture's parse caches reach.
+//
+// The caches are what a suite trades memory for speed with. Worker, the
+// default, gives each worker loop one set, reused by the fixtures that worker
+// runs serially, so what is held scales with --parallel rather than with the
+// number of fixtures. Off gives a run its own and drops them - and its runtime
+// - when it ends, so a run is charged its own parsing and holds nothing
+// afterwards.
+func (f *Fixture) SetCacheScope(scope string) {
+	f.cacheScope = scope
+}
+
+// caches answers the include and expression caches this run installs.
+//
+// Off builds a pair for this run alone. Worker takes the pair belonging to the
+// goroutine running it, so the fixtures one worker walks share what they parse
+// and two workers share nothing. Shared is the process-wide pair, keyed by
+// include root because a cache is keyed by the path a script wrote and two
+// folders can both hold a code/functions.php.
+func (f *Fixture) caches(ctx context.Context) (*runner.IncludeCache, *runner.ExprCache) {
+	switch f.cacheScope {
+	case CacheOff:
+		return runner.NewIncludeCache(), runner.NewExprCache()
+	}
+	w := currentWorker(ctx)
+	return w.includeFor(f.cacheRoot()), w.expr
+}
+
+// flatCaches is caches for the bytecode runtime.
+func (f *Fixture) flatCaches(ctx context.Context) (*flatstack.IncludeCache, *flatstack.ExprCache) {
+	switch f.cacheScope {
+	case CacheOff:
+		return flatstack.NewIncludeCache(), flatstack.NewExprCache()
+	}
+	w := currentWorker(ctx)
+	return w.flatIncludeFor(f.cacheRoot()), w.flatExpr
+}
+
+// acquireRuntime answers the runtime this run executes on, and whether it was
+// just built and still needs its bindings.
+//
+// Worker scope hands back the worker's own runtime, Reset for this run rather
+// than rebuilt: a reset runtime keeps the maps and buckets it grew, so the next
+// fixture allocates nothing to start, and what a run holds is bounded by
+// --parallel instead of by the number of fixtures. It is rebuilt only when the
+// fixture answers a different runtimeKey, which is once per folder rather than
+// once per fixture.
+//
+// Off scope builds one per run and lets it go when the run ends, which is the
+// clean state that mode is for.
+func (f *Fixture) acquireRuntime(ctx context.Context, out io.Writer) (*runner.Runtime, bool) {
+	include, expr := f.caches(ctx)
+
+	build := func() *runner.Runtime {
+		rt := runner.New(out, f.runnerOptions())
+		rt.SetIncludeCache(include)
+		rt.SetExprCache(expr)
+		return rt
+	}
+
+	if f.cacheScope != CacheWorker {
+		if f.interp != nil {
+			// The same fixture again, under --count: the program and its AST
+			// are the ones already compiled, so the session resets and the
+			// caches stay.
+			f.interp.ResetSession(out, f.stdin())
+			return f.interp, false
+		}
+		return build(), true
+	}
+
+	w := currentWorker(ctx)
+	key := f.runtimeKey()
+	if w.interp != nil && w.interpKey == key {
+		// Reset, not ResetSession: the last fixture's compiled expressions and
+		// source spans are keyed by AST nodes this one will never look up, and
+		// they would hold that fixture's tree alive behind them.
+		if f.interp == w.interp {
+			w.interp.ResetSession(out, f.stdin())
+		} else {
+			w.interp.Reset(out, f.stdin())
+		}
+		return w.interp, false
+	}
+
+	rt := build()
+	w.interp = rt
+	w.interpKey = key
+	return rt, true
+}
+
+// runtimeKey names what a runtime was built for. A worker reuses its runtime
+// when the next fixture answers the same key and builds another when it does
+// not: RootFS is fixed at construction and stdlib.RegisterFS binds the file
+// bindings to a directory, so neither survives a move. Fixtures arrive grouped
+// by folder, so the key changes once per group rather than once per fixture.
+func (f *Fixture) runtimeKey() string {
+	return fmt.Sprintf("%s\x00%v", f.cacheRoot(), f.Options)
+}
+
+// worker holds what one serial worker loop reuses across the fixtures it runs.
+//
+// The include caches are keyed by include root, not pooled into one. A cache is
+// keyed by the path a script wrote, so one cache spanning two roots would serve
+// a fixture in one folder the code/functions.php belonging to another - and
+// with --autoload, autoload.php names a different file under every invocation
+// root. The expression caches are keyed by source text, which carries no root,
+// so one of each per worker is right.
+type worker struct {
+	include     map[string]*runner.IncludeCache
+	flatInclude map[string]*flatstack.IncludeCache
+	expr        *runner.ExprCache
+	flatExpr    *flatstack.ExprCache
+
+	// The runtime this worker reuses, and the key it was built for. One
+	// runtime per worker rather than one per fixture is what bounds what a
+	// run holds by --parallel instead of by the number of fixtures.
+	interp    *runner.Runtime
+	interpKey string
+	flatRT    *flatstack.Runtime
+	flatKey   string
+}
+
+func newWorker() *worker {
+	return &worker{
+		include:     map[string]*runner.IncludeCache{},
+		flatInclude: map[string]*flatstack.IncludeCache{},
+		expr:        runner.NewExprCache(),
+		flatExpr:    flatstack.NewExprCache(),
+	}
+}
+
+// includeFor answers this worker's cache for one include root, building it on
+// first use. A worker runs its fixtures serially, so no lock is needed here.
+func (w *worker) includeFor(root string) *runner.IncludeCache {
+	if c, ok := w.include[root]; ok {
+		return c
+	}
+	c := runner.NewIncludeCache()
+	w.include[root] = c
+	return c
+}
+
+// flatIncludeFor is includeFor for the bytecode runtime.
+func (w *worker) flatIncludeFor(root string) *flatstack.IncludeCache {
+	if c, ok := w.flatInclude[root]; ok {
+		return c
+	}
+	c := flatstack.NewIncludeCache()
+	w.flatInclude[root] = c
+	return c
+}
+
+// workers is the pool a worker-scoped run draws from, indexed by the id
+// WithWorker assigned. A run outside a worker loop - a single-threaded run, a
+// Go test calling RunFixture directly - gets index zero, which is a worker like
+// any other.
+var (
+	workersMu sync.Mutex
+	workers   = map[int]*worker{}
+	workerKey = new(int)
+)
+
+// WithWorker marks ctx as belonging to worker id, so a fixture run under it
+// takes that worker's caches. The command's worker loop calls this once per
+// goroutine; everything else inherits worker zero.
+func WithWorker(ctx context.Context, id int) context.Context {
+	return context.WithValue(ctx, workerKey, id)
+}
+
+// currentWorker answers the caches for the worker ctx names. Go has no
+// goroutine-local storage, so the id rides the context the run was started
+// with - which is already threaded from the command down to here.
+func currentWorker(ctx context.Context) *worker {
+	id := 0
+	if got, ok := ctx.Value(workerKey).(int); ok {
+		id = got
+	}
+	workersMu.Lock()
+	defer workersMu.Unlock()
+	if w, ok := workers[id]; ok {
+		return w
+	}
+	w := newWorker()
+	workers[id] = w
+	return w
+}
+
+// cacheRoot names the tree a cached include path is relative to.
+//
+// Absolute, because the relative spelling is ambiguous: a cached path is
+// relative to a root, and two roots reached from different working directories
+// can both be called "suite". A fixture given an app root resolves against that
+// too, so the key names both trees.
+func (f *Fixture) cacheRoot() string {
+	root := absPath(f.RootDir())
+	if f.appRoot != "" {
+		return root + "\x00" + absPath(f.appRoot)
+	}
+	return root
+}
+
+// absPath answers the absolute spelling, or the given one when the working
+// directory cannot be read - a key that is merely ambiguous beats no key.
+func absPath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
+}
+
+// cleanState reports whether the run drops what it built when it ends.
+func (f *Fixture) cleanState() bool { return f.cacheScope == CacheOff }
+
 func (f *Fixture) SetAppRoot(root, autoload string, includes ...string) {
 	f.appRoot = root
 	f.includes = includes
@@ -270,29 +445,6 @@ func (f *Fixture) RootDir() string {
 // tree must not be served a program cached for the embedded one.
 func (f *Fixture) realRoot() bool {
 	return f.Root != "" || f.appRoot != ""
-}
-
-// includeCache is the include cache for the fixture's root. A fixture reaching
-// a real tree gets a private one rather than sharing by directory name.
-func (f *Fixture) includeCache() *runner.IncludeCache {
-	if f.realRoot() {
-		if f.privateInclude == nil {
-			f.privateInclude = runner.NewIncludeCache()
-		}
-		return f.privateInclude
-	}
-	return includeCacheFor(f.RootDir())
-}
-
-// flatIncludeCache is includeCache for the bytecode runtime.
-func (f *Fixture) flatIncludeCache() *flatstack.IncludeCache {
-	if f.realRoot() {
-		if f.privateFlatInclude == nil {
-			f.privateFlatInclude = flatstack.NewIncludeCache()
-		}
-		return f.privateFlatInclude
-	}
-	return flatIncludeCacheFor(f.RootDir())
 }
 
 // unionFS resolves a path against each layer in order, first hit wins. It is
@@ -605,13 +757,19 @@ func executeFixturePHP(ctx context.Context, f *Fixture) (string, runner.Context,
 		return "Internal Server Error", runner.Context{}, err
 	}
 
+	if f.cleanState() {
+		// A clean state is a new runtime, not only an empty cache. A runtime
+		// keeps every declaration it hoisted out of an include, and this
+		// fixture holds the runtime for the whole run, so reusing one carries
+		// the last fixture's functions and classes into the next and keeps
+		// their ASTs alive besides.
+		defer func() { f.interp = nil }()
+	}
+
 	var out strings.Builder
 	reqCtx := buildFixtureRequestContext(f)
-	if f.interp == nil {
-		options := f.runnerOptions()
-		rt := runner.New(&out, options)
-		rt.SetIncludeCache(f.includeCache())
-		rt.SetExprCache(exprCache)
+	rt, built := f.acquireRuntime(ctx, &out)
+	if built {
 		rt.RegisterConstructor("Storage", NewStorage)
 		rt.RegisterConstructor("FailStorage", NewFailStorage)
 		registerPanicBindings(rt)
@@ -619,17 +777,16 @@ func executeFixturePHP(ctx context.Context, f *Fixture) (string, runner.Context,
 		// RegisterFS rebinds them to the fixture, so it has to run after it.
 		stdlib.Register(rt)
 		stdlib.RegisterFS(rt, f.RootDir())
-		// The harness parses and runs the fixture directly rather than going
-		// through LoadFile, so nothing else sets the entrypoint and __FILE__
-		// and __DIR__ would both be empty. An empty __DIR__ silently turns
-		// __DIR__ . "/x" into "/x", which is then rejected as escaping the
-		// root: a confusing two-step failure a long way from its cause.
-		rt.UpdateFilename(f.Path)
 		rt.FreezeStdlib()
-		f.interp = rt
-	} else {
-		f.interp.ResetSession(&out, f.stdin())
 	}
+	// The harness parses and runs the fixture directly rather than going
+	// through LoadFile, so nothing else sets the entrypoint and __FILE__ and
+	// __DIR__ would both be empty. An empty __DIR__ silently turns
+	// __DIR__ . "/x" into "/x", which is then rejected as escaping the root: a
+	// confusing two-step failure a long way from its cause.
+	rt.UpdateFilename(f.Path)
+	f.interp = rt
+
 	f.interp.SetCoverage(f.coverage)
 	f.interp.SetContext(ctx)
 	reqCtx.Register(f.interp)
@@ -662,7 +819,10 @@ func executeFlatstack(ctx context.Context, f *Fixture) (string, runner.Context, 
 	var out strings.Builder
 	reqCtx := buildFixtureRequestContext(f)
 	if f.flatRT == nil {
-		f.flatRT = newFlatstackTestRuntime(&out, f.runnerOptions(), f.RootDir(), f.Path, f.flatIncludeCache())
+		// A nil cache is caching off, which is what SetNoCache asks for; both
+		// cache types answer a miss for nil rather than needing a branch here.
+		flatCache, flatExpr := f.flatCaches(ctx)
+		f.flatRT = newFlatstackTestRuntime(&out, f.runnerOptions(), f.RootDir(), f.Path, flatCache, flatExpr)
 		f.flatRT.FreezeStdlib()
 	} else {
 		f.flatRT.ResetSession(&out, f.stdin())
@@ -674,6 +834,10 @@ func executeFlatstack(ctx context.Context, f *Fixture) (string, runner.Context, 
 		return "Internal Server Error", reqCtx, err
 	}
 
+	if f.cleanState() {
+		defer func() { f.flatRT = nil }()
+	}
+
 	if err := f.flatRT.Run(prog); err != nil {
 		if _, ok := flatstack.IsExit(err); ok {
 			return out.String(), reqCtx, nil
@@ -683,10 +847,10 @@ func executeFlatstack(ctx context.Context, f *Fixture) (string, runner.Context, 
 	return out.String(), reqCtx, nil
 }
 
-func newFlatstackTestRuntime(out *strings.Builder, options flatstack.Options, rootDir, entrypoint string, flatIncludeCache *flatstack.IncludeCache) *flatstack.Runtime {
+func newFlatstackTestRuntime(out *strings.Builder, options flatstack.Options, rootDir, entrypoint string, flatIncludeCache *flatstack.IncludeCache, flatExpr *flatstack.ExprCache) *flatstack.Runtime {
 	runtime := flatstack.New(out, options)
 	runtime.SetIncludeCache(flatIncludeCache)
-	runtime.SetExprCache(flatExprCache)
+	runtime.SetExprCache(flatExpr)
 	runtime.RegisterConstructor("Storage", NewStorage)
 	runtime.RegisterConstructor("FailStorage", NewFailStorage)
 	registerPanicBindings(runtime)

--- a/tests/fixture_test.go
+++ b/tests/fixture_test.go
@@ -96,8 +96,8 @@ func newTestRuntime(out *strings.Builder, ctx context.Context, input ...*strings
 		options.Stdin = input[0]
 	}
 	rt := runner.New(out, options)
-	rt.SetIncludeCache(includeCacheFor("fixtures"))
-	rt.SetExprCache(exprCache)
+	rt.SetIncludeCache(runner.NewIncludeCache())
+	rt.SetExprCache(runner.NewExprCache())
 	rt.SetContext(context.WithValue(ctx, tenantKey, "acme"))
 	rt.RegisterConstructor("Storage", NewStorage)
 	rt.RegisterConstructor("FailStorage", NewFailStorage)

--- a/tests/fixtures/bindings/request_body_stdin.phpt
+++ b/tests/fixtures/bindings/request_body_stdin.phpt
@@ -1,0 +1,41 @@
+name: a request body reaches php://input, and STDIN stays empty
+description: >
+  request.body is the raw body a fixture states, and php://input is what reads
+  it - which is how a JSON endpoint is tested without the body existing as a
+  string first. STDIN is a separate stream and stays empty unless request.stdin
+  fills it, so a fixture that states a body does not find it on stdin as well.
+  The php column sits this one out: the cli SAPI maps php://input onto the
+  process stdin, so the body would have to arrive there and the two streams
+  could not be told apart.
+runner:
+  php: false
+
+request:
+  headers:
+    Content-Type: application/json
+  body: '{"id":7}'
+---
+<?php
+
+// php://input is the body, and it rewinds: opening it twice reads it twice,
+// the way php has since 5.6.
+echo file_get_contents("php://input"), "\n";
+echo file_get_contents("php://input"), "\n";
+
+$handle = fopen("php://input", "r");
+echo stream_get_contents($handle), "\n";
+fclose($handle);
+
+// STDIN is empty, not the body. An empty stream reads as "" and reports the
+// end immediately rather than blocking.
+var_dump(stream_get_contents(STDIN));
+
+$in = fopen("php://stdin", "r");
+var_dump($in);
+?>
+---
+{"id":7}
+{"id":7}
+{"id":7}
+string(0) ""
+bool(false)

--- a/tests/fixtures/paths/chdir_include_cache.phpt
+++ b/tests/fixtures/paths/chdir_include_cache.phpt
@@ -1,0 +1,29 @@
+name: an include is cached under the path it resolved to, not the path it was written as
+description: >
+  "samename.php" names two different files depending on where the working
+  directory is, so including it from both places has to produce both. The parsed
+  include is cached, and a cache keyed by the path as the script wrote it would
+  answer the second include with the first file - the same spelling, the wrong
+  contents. This fixture is that case: it fails if the key ever stops carrying
+  the working directory.
+---
+<?php
+
+$root = include "samename.php";
+var_dump(chdir("workdir"));
+$moved = include "samename.php";
+var_dump(chdir(".."));
+$back = include "samename.php";
+
+echo $root, "|", $moved, "|", $back, "\n";
+
+// The second include of a path already resolved is the cached one, and it is
+// still the right file: caching is what this asserts, not that it was skipped.
+$again = include "workdir/samename.php";
+echo $again, "\n";
+?>
+---
+bool(true)
+bool(true)
+root|workdir|root
+workdir

--- a/tests/fixtures/paths/samename.php
+++ b/tests/fixtures/paths/samename.php
@@ -1,0 +1,5 @@
+<?php
+
+// Same spelling as workdir/samename.php, different file: what tells them
+// apart is the working directory the include resolved against.
+return "root";

--- a/tests/fixtures/paths/workdir/samename.php
+++ b/tests/fixtures/paths/workdir/samename.php
@@ -1,0 +1,3 @@
+<?php
+
+return "workdir";

--- a/tests/fixtures/strings/escapes_bytes.phpt
+++ b/tests/fixtures/strings/escapes_bytes.phpt
@@ -1,0 +1,30 @@
+name: a hex escape names one byte, whatever its value
+description: >
+  "\xff" is one byte, not the codepoint U+00FF. The distinction only shows above
+  7f, where UTF-8 spells a codepoint with two bytes: a string that travelled
+  through source text as an escape would come back a byte longer. Covers the
+  boundary either side of 7f and a byte written into the middle of a string.
+---
+<?php
+
+echo strlen("a\xffb"), " ", bin2hex("a\xffb"), "\n";
+echo strlen("\x7f"), " ", bin2hex("\x7f"), "\n";
+echo strlen("\x80"), " ", bin2hex("\x80"), "\n";
+echo strlen("\x00"), " ", bin2hex("\x00"), "\n";
+
+// The same bytes built with chr(), which never travels as an escape, so the
+// two spellings have to agree.
+echo bin2hex("a" . chr(255) . "b"), "\n";
+var_dump("a\xffb" === "a" . chr(255) . "b");
+
+// An octal escape is a byte too.
+echo strlen("\377"), " ", bin2hex("\377"), "\n";
+?>
+---
+3 61ff62
+1 7f
+1 80
+1 00
+61ff62
+bool(true)
+1 ff


### PR DESCRIPTION
`phpscript test` held 2 GB of live heap and peaked at 3.3 GB over an application
suite, because every fixture kept the runtime it built. This adds
`--cache=worker|off` to say how far a parsed include travels, fixes the two
allocation costs the profiles pointed at, and fixes three bugs the work
uncovered.

Closes: no issue, this came out of profiling the suite.

Checklist (tick what applies):

- [x] I added or updated tests covering the changed behaviour
- [x] I added a .phpt fixture under tests/fixtures/ for changed language or runtime behaviour
- [ ] I updated the documentation under docs/ for this change
- [x] I ran the default atkins pipeline and it passes end to end
- [x] I committed every generated file, docs/test-fixtures.md and docs/code-coverage.md included
- [ ] I changed go.mod/sum (third party PRs get auto-rejected on this)

`--cache` is not written up under `docs/` yet, which is the one box left open.

## Goal

`phpscript test` held 2 GB of live heap and peaked at 3.3 GB running an
application suite, because every fixture kept the runtime it built and every
runtime keeps the declarations it hoisted out of an include. This adds
`--cache=worker|off` to say how far a parsed include travels, and fixes the two
allocation costs the profiles pointed at.

Workload for the whole-suite numbers: mobius, 342 fixtures across two runtimes,
`--matrix --skip-php --include vendor/autoload.php`. Peak RSS is
`/usr/bin/time -v`; heap totals are `--memprofile` read with `go tool pprof`.

## `--cache`

| mode | what it scopes | when |
|---|---|---|
| `worker` (default) | one set of caches per worker loop, reused by the fixtures that worker runs serially | normal runs: what is held scales with `--parallel`, not with the fixture count |
| `off` | a new set per fixture run, and the runtime dropped with it | a clean state per fixture, and the smallest footprint |

There is no `shared` mode: a worker loop already is one. Without `--parallel`
there is a single worker, so a single set serves the run; sharing across workers
on top of that only adds contention for a hit the worker's own cache has.

## Before and after

| run | peak RSS | wall | alloc_space | inuse_space |
|---|---|---|---|---|
| whole suite, before | 3.26 GB | 45.1 s | 9910 MB | 2020 MB |
| whole suite, `--cache=worker` | **769 MB** | **40.9 s** | | |
| whole suite, `--cache=off` | **78 MB** | 48.9 s | 7940 MB | **12.7 MB** |
| `--cover=func`, before | 4.44 GB | 63.6 s | 11282 MB | 2091 MB |
| `--cover=func`, after | 4.37 GB | 52.4 s | | |
| `--cover=func --cache=off` | **1.71 GB** | 64.7 s | | |
| `./src/...` (160), worker | 299 MB | 5.9 s | | |
| `./src/...` (160), off | **53 MB** | 7.1 s | | |
| `./src/Time/...` (12) `-c 4`, worker | 63 MB | 3.67 s | | |
| `./src/Time/...` (12) `-c 4`, off | **35 MB** | 3.68 s | | |

Every column passes 342/342 (or 160/160, 12/12), and `--cover` reports the same
80.8% whichever way the caches are scoped.
