### PR TITLE
test(github): fixture for #84, instanceof does not resolve its right operand

### DIFF
--- a/tests/fixtures/github/84.yml
+++ b/tests/fixtures/github/84.yml
@@ -1,0 +1,47 @@
+name: instanceof does not resolve its right operand
+description: >
+  Every other place a class name is written goes through parser.qualify: new,
+  a static call, an implements list, ::class. parseInstanceOf does not, so the
+  raw source spelling reaches phpInstanceOf and is compared against the name
+  the class declared. An alias and an unqualified name inside a namespace are
+  both false; only the fully qualified spelling answers.
+
+  Here `use Bar as Baz` aliases a class in the same file. get_class and
+  Baz::class both report Bar, and `$b instanceof Bar` is true, so the alias
+  table exists and is applied - but `$b instanceof Baz` is false where php
+  prints bool(true). The namespaced form fails identically and is the one
+  mobius hits, but a namespaced file may hold only declarations here, so it
+  needs two files and is written out in the issue instead.
+
+  Reported: https://github.com/titpetric/phpscript/issues/84
+---
+<?php
+
+class Bar
+{
+    public $x = 1;
+}
+
+use Bar as Baz;
+
+$b = new Baz();
+
+// Works today: the alias resolves everywhere a class name is qualified at
+// parse time. `new` reaches the class, and `::class` reports its real name.
+var_dump(get_class($b));
+var_dump(Baz::class);
+var_dump(get_class($b) === Baz::class);
+
+// Works today: instanceof against the name the class declared.
+var_dump($b instanceof Bar);
+
+// What this issue asks for, and what fails: the same name resolution on the
+// right operand of instanceof.
+var_dump($b instanceof Baz);
+?>
+---
+string(3) "Bar"
+string(3) "Bar"
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
## Why this is necessary

`instanceof` is the only place a class name is written in PHP source and *not*
put through the parser's name resolution. `new`, a static call, a type name, an
`implements` list and `::class` all go through `parser.qualify()`, so `use
Foo\Bar;` and an unqualified name inside `namespace Foo` reach the runtime as
`Foo\Bar`. `parseInstanceOf` (`parser/expr.go:215`) deliberately does not, and
the raw source spelling reaches `phpInstanceOf` as the string to compare. The
comparison is then `"Bar" == "Foo\Bar"`, which is false.

`docs/reference/namespaces/README.md` documents both spellings as working:
aliasing and importing is listed as **Compatibility**, and "Class names are
relative to the current namespace unless they begin with `\`". `instanceof` is
the exception to a rule the reference states without one.

This is not the no-inheritance decision. `docs/design.md` settles *what*
`instanceof` compares - a declared class name, plus the interface names the
declaration listed, and nothing through `extends`. It says nothing about how
the name on the right is resolved, and the fix does not make any member arrive
through anything.

The caller: every class in mobius is under a `Mobius\...` namespace, so an
`instanceof` in that tree only answers when it is written fully qualified, even
in a file whose `use` line already aliased the name. Capability checks were
routed to `method_exists` instead - `mobius/common/code/Common/Dependency.php:89`
is one, and its comment names the substitution. The workaround is a runtime
string check standing in for a compile-time one.

## What the test asserts

`tests/fixtures/github/84.yml` declares one class and aliases it, all in one
file so no include root is involved:

```php
class Bar { public $x = 1; }

use Bar as Baz;

$b = new Baz();
```

It then asserts five values. Three pass today and are there to show that the
alias table exists and is applied: `get_class($b)` and `Baz::class` both report
`Bar`, and `$b instanceof Bar` is true. The fifth, `$b instanceof Baz`, is
`bool(true)` under `php` and `bool(false)` here.

The namespaced spelling fails the same way and is the form mobius hits, but a
namespaced file may hold only declarations in this runtime, so it takes two
files and cannot be a single fixture:

```php
// lib.php
namespace Foo;
class Bar {}
function check() {
    $b = new Bar();
    var_dump($b instanceof \Foo\Bar);   // php: true   phpscript: true
    var_dump($b instanceof Bar);        // php: true   phpscript: false
}
```

`use Foo\Bar;` from the global namespace and `use Foo\Bar;` from a second
namespace both behave the same as the alias case above: false. Only the
leading-backslash spelling answers.

## The proposed solution

Fix the behaviour. In `parseInstanceOf`, qualify a bare-name right operand the
way `parseNew` already does at `parser/expr.go:657`:

```go
right = p.qualify(name, absolute)   // when the operand is a bare class name
```

An operand that is an expression - a variable holding a name, or an object -
keeps reaching the runtime unresolved, because there is nothing to resolve at
parse time. `runner.instanceOfName` already strips a leading `\`, so a
fully-qualified spelling is unaffected. The interface branch needs no change:
`model.ClassDecl.Implements` is stored qualified (`parser/parser.go:1195`), so
it starts agreeing with the operand once the operand is qualified too.

The flatstack path reads the same model node (`flatstack/engine/compiler.go:1068`),
so both engines get the fix from one change. When it lands the fixture becomes
`tests/fixtures/namespaces/instanceof_alias.phpt`.

Closes nothing; the fixture is the reproduction for #84.
