### PR TITLE
test(github): fixture for #85, a top-level const declaration is misparsed

### DIFF
--- a/tests/fixtures/github/85.yml
+++ b/tests/fixtures/github/85.yml
@@ -1,0 +1,43 @@
+name: a top-level const declaration is misparsed as a bare identifier
+description: >
+  `const` is lexed as a T_STRING at the top level of a file, so the parser
+  reads it as a constant reference, ends the statement there, and the file
+  runs as `const;` followed by an assignment to an undefined name. At run
+  time that is: Undefined constant "const".
+
+  The misparse is silent in two more places. phpscript lint reports no
+  finding, and phpscript fmt rewrites `const X = 1;` into the two lines
+  `const;` and `X = 1;`, so formatting a ported tree changes the program.
+  The list form `const A = 1, B = 2;` fails differently again, at parse
+  time, with: unexpected token 8(",")@2.
+
+  This fixture bounds the report with the two spellings that do work:
+  define() for a global constant, and const inside a class. Only the
+  file-level declaration is missing.
+
+  Reported: https://github.com/titpetric/phpscript/issues/85
+---
+<?php
+
+// Works today: define() declares a global constant at run time.
+define("LAYOUT_DATE", "2006-01-02");
+echo LAYOUT_DATE, "\n";
+
+// Works today: const inside a class declaration.
+class Layout
+{
+    const DATETIME = "2006-01-02 15:04:05";
+}
+
+echo Layout::DATETIME, "\n";
+
+// What this issue asks for, and what fails: the same declaration at the top
+// level of a file.
+const LAYOUT_DATETIME = "2006-01-02 15:04:05";
+
+echo LAYOUT_DATETIME, "\n";
+?>
+---
+2006-01-02
+2006-01-02 15:04:05
+2006-01-02 15:04:05


### PR DESCRIPTION
## Why this is necessary

`const NAME = value;` at the top level of a file does not parse. The word
`const` is lexed as a `T_STRING` (`phpscript ast` shows it), the parser reads it
as a bare identifier, ends the statement there, and the file runs as two
statements: a constant reference `const`, then an assignment to an undefined
`X`. At run time that is:

```
Undefined constant "const"
```

`docs/reference/constants/README.md` already records the gap - "Global constant
declarations | Partial compatibility | `define()` declares a runtime constant;
the `const` statement does not" - and it is not in the "Won't implement" table
in `docs/design.md`. Class constants work; only the file-level form is missing.

Three things follow from it being a silent misparse rather than a parse error:

- `phpscript lint` reports no finding on the file.
- `phpscript fmt` **rewrites the source into something that is not the program
  that was read**. `const X = 1;` comes back as two lines, `const;` and
  `X = 1;`, so running the formatter over a ported tree corrupts it.
- `const A = 1, B = 2;` does fail at parse time, with
  `unexpected token 8(",")@2`, so the two spellings of the same declaration
  fail in two different ways at two different times.

The caller: `mobius/common/autoload/dates.php` declares its two layout
constants with `define("LAYOUT_DATETIME", ...)` and `define("LAYOUT_DATE", ...)`
where the file would otherwise write `const`. `define()` is a full workaround
for the value, but it is a function call rather than a declaration - it is not
visible to a static reader, it cannot appear before the runtime is up, and it is
what every ported library has to be edited into.

## What the test asserts

`tests/fixtures/github/85.yml` is one file, three declarations, no includes:

```php
define("LAYOUT_DATE", "2006-01-02");
echo LAYOUT_DATE, "\n";

class Layout { const DATETIME = "2006-01-02 15:04:05"; }
echo Layout::DATETIME, "\n";

const LAYOUT_DATETIME = "2006-01-02 15:04:05";
echo LAYOUT_DATETIME, "\n";
```

The first two are the spellings that work today and are there to bound the
report: this is not about constants in general, and not about `const` in a
class. Expected output is the three lines `php` prints. phpscript prints the
first two and then throws `Undefined constant "const"` on the third.

## The proposed solution

Implement it. `const` becomes a statement keyword in the parser, parsed as a
comma-separated list of `NAME = <constant expression>`, and each entry declares
into the same constant table `define()` and `Runtime.SetConst` write to - the
lookup side already exists and needs nothing. The class-constant parser already
reads the identical `NAME = value, NAME = value` list, so the grammar is not
new.

Two details worth stating up front:

- The value is a constant expression, evaluated once at declaration. Matching
  `define()`'s behaviour of taking whatever the expression evaluates to is
  enough; PHP's compile-time constant-expression restriction is not.
- Redeclaration follows `define()`: PHP warns and keeps the first value.

The formatter and linter come along for free once the keyword is real, which
removes the source-corrupting `fmt` behaviour above. When it lands the fixture
becomes `tests/fixtures/syntax/const_declaration.phpt`, and the "Partial
compatibility" row in `docs/reference/constants/README.md` becomes
"Compatibility".

Closes nothing; the fixture is the reproduction for #85.
