### PR TITLE
docs(fixtures): a string offset returns one byte, for issue #98

### DIFF
--- a/tests/fixtures/github/98.yml
+++ b/tests/fixtures/github/98.yml
@@ -1,0 +1,41 @@
+name: a string offset returns one byte, including bytes above 0x7f
+description: >
+  $s[$i] should return the single byte at position $i. For ASCII it does; for
+  any byte of 0x80 or more it returns two different bytes, so a UTF-8 letter
+  such as Č (C4 8C) comes apart when a string is walked byte by byte.
+  Reported transcript on d4fc71f, both engines: bin2hex($s[0]) of "Čedo" is
+  c384 instead of c4, strlen($s[0]) is 2, ord($s[0]) is 195, and the string
+  rebuilt from $s[$i] is not equal to the original. Cause: helperIndex
+  returns string(b[i]), which Go reads as a code point and UTF-8 encodes.
+
+  Open: issue 98.
+---
+<?php
+
+// Works today: substr() hands back the byte itself.
+$s = "Čedo";
+echo bin2hex(substr($s, 0, 1)), " ", bin2hex(substr($s, 1, 1)), "\n";
+
+// What fails: $s[$i] should hand back the same single byte.
+echo bin2hex($s[0]), " ", bin2hex($s[1]), "\n";
+echo strlen($s[0]), "\n";
+echo ord($s[0]), "\n";
+$ff = chr(255);
+echo bin2hex($ff[0]), "\n";
+echo bin2hex($s[-1]), "\n";
+
+// Walking a UTF-8 string byte by byte and gluing it back gives the same string.
+$copy = "";
+for ($i = 0; $i < strlen($s); $i++) {
+	$copy .= $s[$i];
+}
+var_dump($copy === $s);
+?>
+---
+c4 8c
+c4 8c
+1
+196
+ff
+6f
+bool(true)


### PR DESCRIPTION
Refs #98. This adds the reproduction only, no fix.

### Why this is necessary

mobius, a time-tracking app on phpscript, is full of Slovene names: Kovač, Žiga, Špela. Any code that walks a string with `$s[$i]` breaks on them, because every letter outside ASCII is two bytes in UTF-8 and each of those bytes comes back doubled. Its date comparator (`later()` in `src/Company/CompanyRates.php`) carries a comment saying its byte walk is exact for ASCII only because of this, and its CSV writer checks every byte of every cell the same way (`src/Report/Csv.php`). Today the only safe spelling is `substr($s, $i, 1)`.

### What the test asserts

`tests/fixtures/github/98.yml` reads "Čedo" and `chr(255)` byte by byte and expects php's own output:

- `$s[0]` and `$s[1]` are the same single bytes `substr()` returns: `c4`, then `8c`
- `strlen($s[0])` is `1` and `ord($s[0])` is `196`
- `chr(255)[0]` is `ff`, and a negative offset still works
- the string rebuilt from `$s[$i]` in a loop equals the original

On `d4fc71f` the runtime and flatstack both print `c384 c28c`, `2`, `195`, `c3bf` and `bool(false)`. Under php it passes.

### The proposed solution

Fix the behaviour. In `helperIndex` (`runner/helpers.go:110`), return `b[i : i+1]` instead of `string(b[i])`. Go's `string(byte)` treats the byte as a Unicode code point and encodes it, and that encoding is where the second byte comes from. On a local build with that one change the fixture passes on both engines, `go test ./runner/...` passes, and the full fixture matrix is unchanged. Once it lands, this file can become `tests/fixtures/strings/string_offset_bytes.phpt` beside `chr_ord.phpt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
