### PR TITLE
docs(fixtures): basename takes the suffix argument, for issue #99

### DIFF
--- a/tests/fixtures/github/99.yml
+++ b/tests/fixtures/github/99.yml
@@ -1,0 +1,42 @@
+name: basename takes the suffix argument and answers the empty and root paths like PHP
+description: >
+  basename() should accept PHP's optional second argument, a suffix to strip
+  when the name ends with it, keeping a name that is only the suffix and
+  matching case-sensitively. Without a suffix it should answer "" for ""
+  and for "/". Reported transcript on d4fc71f, both engines: any call with
+  a second argument stops with "basename() expects at most 1 argument, 2
+  given"; basename("") is "." and basename("/") is "/", which is Go
+  path.Base, not PHP.
+
+  Open: issue 99.
+---
+<?php
+
+// Works today: basename() and then substr() to drop the suffix.
+$base = basename("/srv/issues/088-wizard.yml");
+echo substr($base, 0, strlen($base) - 4), "\n";
+
+// What fails: the second argument, the suffix to strip.
+echo basename("/srv/issues/088-wizard.yml", ".yml"), "\n";
+echo basename("report.csv", ".csv"), "\n";
+echo basename(".yml", ".yml"), "\n";
+echo basename("a/b.YML", ".yml"), "\n";
+echo basename("a/b.yml/", ".yml"), "\n";
+
+// Without a suffix, PHP and Go path.Base differ on the first two.
+var_dump(basename(""));
+var_dump(basename("/"));
+var_dump(basename("a/b/"));
+var_dump(basename("."));
+?>
+---
+088-wizard
+088-wizard
+report
+.yml
+b.YML
+b
+string(0) ""
+string(0) ""
+string(1) "b"
+string(1) "."


### PR DESCRIPTION
Refs #99. This adds the reproduction only, no fix.

### Why this is necessary

Turning a file name into its name without the extension is everyday PHP: `basename($file, ".yml")`. On phpscript it stops the script, so every caller writes `substr($base, 0, strlen($base) - 4)` instead and hopes the extension length never changes. I hit it in a small checker that reads mobius's `issues/088-wizard.yml` files and wants `088-wizard`. The empty and root paths also answer differently from PHP, which matters to any code that treats an empty result as "no name".

### What the test asserts

`tests/fixtures/github/99.yml` expects php's own output:

- the suffix is stripped when the name ends with it: `088-wizard`, `report`
- a name that is only the suffix is kept: `basename(".yml", ".yml")` is `.yml`
- the match is case-sensitive: `basename("a/b.YML", ".yml")` is `b.YML`
- a trailing slash is ignored before the suffix: `basename("a/b.yml/", ".yml")` is `b`
- without a suffix, `basename("")` and `basename("/")` are both `""`

On `d4fc71f` the runtime and flatstack both stop at the first two-argument call with `basename() expects at most 1 argument, 2 given`, and answer `"."` and `"/"` for the empty and root paths (that part is Go's `path.Base`). Under php it passes.

### The proposed solution

Implement the argument. In `stdlib/files/path.go`, register `basename` as `func(path string, suffix ...string) string`, the way other bindings take optional arguments. Answer `""` when the path is empty or all slashes, and strip the suffix only when the base ends with it and is not equal to it. The issue has the ten-line version I tried: on a local build the fixture passes on both engines, `go test ./stdlib/files/...` passes, and the full fixture matrix is unchanged. Once it lands, this file can become `tests/fixtures/paths/basename.phpt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
